### PR TITLE
Unit tests for discord nickname, and add DRY transform

### DIFF
--- a/backend/discord/core.py
+++ b/backend/discord/core.py
@@ -1,0 +1,17 @@
+import upsidedown
+
+def make_nickname(character, discord_user):
+    corporation = character.corporation
+
+    nickname = f"[{corporation.ticker}] {character.character_name}"
+
+    if discord_user.is_down_under:
+        nickname = upsidedown.transform(nickname)
+
+    if discord_user.dress_wearer:
+        nickname = f"[👗] {character.character_name}"
+
+    if corporation.ticker == "-DRY-":
+        nickname = f"[ω] {character.character_name}"
+
+    return nickname

--- a/backend/discord/helpers.py
+++ b/backend/discord/helpers.py
@@ -8,6 +8,8 @@ from discord.client import DiscordClient
 from eveonline.models import EveCharacter, EvePrimaryCharacter
 from users.helpers import offboard_user
 
+import core
+
 from .models import DiscordRole, DiscordUser
 
 discord = DiscordClient()
@@ -36,18 +38,7 @@ def get_expected_nickname(user: User):
     if not eve_primary_character or not is_valid_for_nickname:
         return None
 
-    character = eve_primary_character.character
-    corporation = character.corporation
-    nickname = f"[{corporation.ticker}] {character.character_name}"
-
-    if discord_user.is_down_under:
-        nickname = upsidedown.transform(nickname)
-
-    if discord_user.dress_wearer:
-        nickname = f"[👗] {character.character_name}"
-
-    return nickname
-
+    return make_nickname(eve_primary_character.character, discord_user)
 
 def get_discord_user(user: User, notify=False):
     """

--- a/backend/discord/tests.py
+++ b/backend/discord/tests.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest.mock import Mock
+
+from core import make_nickname
+
+class TestCategorizeByAge(unittest.TestCase):
+    def test_basic_nickname(self):
+        character = Mock(character_name="Bob", corporation=Mock(ticker="ABC"))
+        discord = Mock(is_down_under=False, dress_wearer=False)
+        self.assertEqual(f"[ABC] Bob", make_nickname(character, discord))
+
+    def test_down_under_nickname(self):
+        character = Mock(character_name="Bob", corporation=Mock(ticker="ABC"))
+        discord = Mock(is_down_under=True, dress_wearer=False)
+        self.assertEqual(f"qoᗺ [ƆᗺⱯ]", make_nickname(character, discord))
+
+    def test_dress_wearer(self):
+        character = Mock(character_name="Bob", corporation=Mock(ticker="ABC"))
+        discord = Mock(is_down_under=False, dress_wearer=True)
+        self.assertEqual(f"[👗] Bob", make_nickname(character, discord))
+
+    def test_dry_corp(self):
+        character = Mock(character_name="Scott", corporation=Mock(ticker="-DRY-"))
+        discord = Mock(is_down_under=False, dress_wearer=True)
+        self.assertEqual(f"[ω] Scott", make_nickname(character, discord))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Initial implementation that doesn't support down-under or dress-wearing DRY members. 

There may also be better ways to unit test isolated functions from files with lots of dependencies.