### PR TITLE
Add support for anchoring structure timers

### DIFF
--- a/backend/structures/helpers.py
+++ b/backend/structures/helpers.py
@@ -33,7 +33,7 @@ def get_skyhook_details(selected_item_window: str):
     # regex pattern for structure name, location, and owner
     structure_pattern = re.compile(r"(.*) \((.*)\) \[(.*)\]")
     # get the entire timer out
-    timer_pattern = re.compile(r"Reinforced until (.*)")
+    timer_pattern = re.compile(r" until (.*)")
 
     # parse the structure name, location, and owner
     structure_match = structure_pattern.match(selected_item_window)
@@ -64,7 +64,7 @@ def get_structure_details(selected_item_window: str):
     # regex pattern for system name and structure name
     structure_pattern = re.compile(r"(.*) - (.*)")
     # get the entire timer out
-    timer_pattern = re.compile(r"Reinforced until (.*)")
+    timer_pattern = re.compile(r" until (.*)")
 
     # parse the structure name, location, and owner
     structure_match = structure_pattern.match(selected_item_window)

--- a/backend/structures/tests/test_helpers.py
+++ b/backend/structures/tests/test_helpers.py
@@ -1,26 +1,49 @@
+import unittest
 from datetime import datetime
 
-from structures.helpers import get_skyhook_details, get_structure_details
+from structures.helpers import (
+    get_skyhook_details,
+    get_structure_details,
+    StructureResponse,
+)
 
 
-def test_get_skyhook_details():
-    selected_item_window = "Orbital Skyhook (KBP7-G III) [Sukanan Inititive]\n0.5 AU\nReinforced until 2024.07.17 11:10:47"
-    expected = {
-        "structure_name": "Orbital Skyhook",
-        "location": "KBP7-G III",
-        "owner": "Sukanan Inititive",
-        "timer": datetime.strptime("2024.07.17 11:10:47", "%Y.%m.%d %H:%M:%S"),
-    }
-    assert get_skyhook_details(selected_item_window) == expected
+class StructureHelperTest(unittest.TestCase):
 
+    def test_get_skyhook_details(self):
+        selected_item_window = "Orbital Skyhook (KBP7-G III) [Sukanan Inititive]\n0.5 AU\nReinforced until 2024.07.17 11:10:47"
+        expected = StructureResponse(
+            structure_name="Orbital Skyhook",
+            location="KBP7-G III",
+            # "owner": "Sukanan Inititive",
+            timer=datetime.strptime(
+                "2024.07.17 11:10:47", "%Y.%m.%d %H:%M:%S"
+            ),
+        )
+        self.assertEqual(get_skyhook_details(selected_item_window), expected)
 
-def test_get_structure_details():
-    selected_item_window = (
-        "Sosala - WATERMELLON\n0 m\nReinforced until 2024.06.23 23:20:58"
-    )
-    expected = {
-        "system_name": "Sosala",
-        "structure_name": "WATERMELLON",
-        "timer": datetime.strptime("2024.06.23 23:20:58", "%Y.%m.%d %H:%M:%S"),
-    }
-    assert get_structure_details(selected_item_window) == expected
+    def test_get_structure_details(self):
+        selected_item_window = (
+            "Sosala - WATERMELLON\n0 m\nReinforced until 2024.06.23 23:20:58"
+        )
+        expected = StructureResponse(
+            location="Sosala",
+            structure_name="WATERMELLON",
+            timer=datetime.strptime(
+                "2024.06.23 23:20:58", "%Y.%m.%d %H:%M:%S"
+            ),
+        )
+        self.assertEqual(get_structure_details(selected_item_window), expected)
+
+    def test_anchoring_structure(self):
+        selected_item_window = (
+            "Sosala - WATERMELLON\n0 m\nAnchoring until 2024.06.23 23:20:58"
+        )
+        expected = StructureResponse(
+            location="Sosala",
+            structure_name="WATERMELLON",
+            timer=datetime.strptime(
+                "2024.06.23 23:20:58", "%Y.%m.%d %H:%M:%S"
+            ),
+        )
+        self.assertEqual(get_structure_details(selected_item_window), expected)


### PR DESCRIPTION
Fixed selected item window parser to support timers for states other than reinforced, such as anchoring. Also fixed the unit tests for the parser.