### PR TITLE
Add standard claims to user JWT tokens

### DIFF
--- a/backend/users/router.py
+++ b/backend/users/router.py
@@ -1,5 +1,6 @@
 import logging
 
+import datetime
 import jwt
 from typing import List
 from django.conf import settings
@@ -76,6 +77,9 @@ def callback(request, code: str):
         "username": user["username"],
         "avatar": f"https://cdn.discordapp.com/avatars/{django_user.discord_user.id}/{django_user.discord_user.avatar}.png",
         "is_superuser": django_user.is_superuser,
+        "sub": user["username"],
+        "iss": request.get_host(),
+        "iat": datetime.datetime.now(),
     }
     encoded_jwt_token = jwt.encode(
         payload, settings.SECRET_KEY, algorithm="HS256"


### PR DESCRIPTION
Adds some standard claims to the user JWT tokens: subject, issuer and issue-at. This will allow better token validation if needed in future, including revoking old tokens while still accepting recently generated ones.

While this should have zero impact, any failure could impact site login for all users and so the merge should only happen when in a position to rapidly roll back the change.