### PR TITLE
fix: missing period in ip

### DIFF
--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -76,7 +76,7 @@ else:
             "NAME": os.environ.get("DB_NAME", "minmatar"),
             "USER": os.environ.get("DB_USER", "root"),
             "PASSWORD": os.environ.get("DB_PASSWORD", "example"),
-            "HOST": os.environ.get("DB_HOST", "127.0.01"),
+            "HOST": os.environ.get("DB_HOST", "127.0.0.1"),
             "PORT": os.environ.get("DB_PORT", "3306"),
             "OPTIONS": {"charset": "utf8mb4"},
         },


### PR DESCRIPTION
IP was set to 127.0.01 instead of 127.0.0.1 for the default/fallback ip