### PR TITLE
Prepare to redirect tools to my.minmatar.org

### DIFF
--- a/proxy/reverse_proxy.conf
+++ b/proxy/reverse_proxy.conf
@@ -49,3 +49,9 @@ server {
       proxy_pass          http://app:8000/;
     }
 }
+
+server {
+    server_name tools.minmatar.org;
+
+    return 302 https://my.minmatar.org/;
+}


### PR DESCRIPTION
Proxy update to redirect from `tools.minmatar.org` to `my.minmatar.org`.

This shouldn't have any effect until DNS is updated to send `tools` traffic to the proxy.