### PR TITLE
Background task logging cleanup

### DIFF
--- a/backend/app/settings_celery.py
+++ b/backend/app/settings_celery.py
@@ -1,4 +1,7 @@
 from celery.schedules import crontab
+from celery.worker import strategy
+
+strategy.logger.setLevel("WARNING")
 
 CELERYBEAT_SCHEDULE = {
     "esi_cleanup_callbackredirect": {

--- a/backend/eveonline/helpers/skills.py
+++ b/backend/eveonline/helpers/skills.py
@@ -30,7 +30,7 @@ def upsert_character_skills(character_id: int):
     populate skills from eve and save them to the character
 
     """
-    logger.info("Upserting skills for character %s", character_id)
+    logger.debug("Upserting skills for character %s", character_id)
     character = EveCharacter.objects.get(character_id=character_id)
 
     response = EsiClient(character).get_character_skills()
@@ -55,7 +55,7 @@ def upsert_character_skill(character: EveCharacter, esi_skill):
         character=character, skill_id=esi_skill["skill_id"]
     ).order_by("-skill_points")
 
-    logger.info("Query count %d", qry.count())
+    logger.debug("Query count %d", qry.count())
 
     if qry.count() == 0:
         skill = EveCharacterSkill(
@@ -145,7 +145,7 @@ def compare_skills_to_skillset(character_id: int, skillset: EveSkillset):
 def create_eve_character_skillset(character_id: int, skillset: EveSkillset):
     """Create a skillset for a character"""
     # delete existing
-    logger.info(
+    logger.debug(
         "Creating skillset for character %s and skillset %s",
         character_id,
         skillset.name,

--- a/backend/fleets/tasks.py
+++ b/backend/fleets/tasks.py
@@ -19,14 +19,16 @@ def update_fleet_instances():
     Update fleet instances
     """
     active_fleet_instances = EveFleetInstance.objects.filter(end_time=None)
-    logger.info("Updating status of %s fleets", active_fleet_instances.count())
+    logger.debug(
+        "Updating status of %s fleets", active_fleet_instances.count()
+    )
     for fleet_instance in active_fleet_instances:
         logger.info("Updating fleet instance %s", fleet_instance.id)
         try:
             fleet_instance.update_is_registered_status()
             fleet_instance.update_fleet_members()
         except Exception as e:
-            logger.info(
+            logger.warning(
                 "An error occurred while updating fleet instance %s: %s",
                 fleet_instance.id,
                 e,
@@ -61,12 +63,12 @@ def update_standing_fleet_instances():
         try:
             standing_fleet.update_fleet_members()
         except Exception as e:
-            logger.info(
+            logger.error(
                 "An error occurred while updating standing fleet instance %s: %s",
                 standing_fleet.id,
                 e,
             )
-            logger.info("Assuming fleet is closed")
+            logger.debug("Assuming fleet is closed")
             standing_fleet.end_time = timezone.now()
             standing_fleet.save()
 
@@ -122,7 +124,7 @@ def update_fleet_schedule():
         )["content"]
         == message
     ):
-        logger.info("Fleet schedule message is up to date, skipping update")
+        logger.debug("Fleet schedule message is up to date, skipping update")
         return
 
     discord_client.update_message(

--- a/backend/groups/tasks.py
+++ b/backend/groups/tasks.py
@@ -40,7 +40,7 @@ def update_affiliation(user_id: int):
         logger.warning("No primary character found for user %s", user)
         UserAffiliation.objects.filter(user=user).delete()
         return
-    if primaries.count() > 0:
+    if primaries.count() != 1:
         logger.warning(
             "%d primary characters found for user %s", primaries.count(), user
         )

--- a/backend/market/helpers.py
+++ b/backend/market/helpers.py
@@ -109,7 +109,7 @@ def create_market_contract(contract: dict, issuer_id: int) -> None:
         contract["status"],
     )
 
-    contract, _ = EveMarketContract.objects.update_or_create(
+    contract_instance, _ = EveMarketContract.objects.update_or_create(
         id=contract["contract_id"],
         defaults={
             "title": contract["title"],
@@ -124,7 +124,7 @@ def create_market_contract(contract: dict, issuer_id: int) -> None:
         },
     )
     logger.debug("Contract %d created", contract["contract_id"])
-    return contract
+    return contract_instance
 
 
 def create_character_market_contracts(character_id: int):

--- a/backend/market/helpers.py
+++ b/backend/market/helpers.py
@@ -40,7 +40,7 @@ def create_market_contract(contract: dict, issuer_id: int) -> None:
     # Need to add comma for ships that contain same name
     # e.g Exequror and Exequror Navy Issue
     alias_title_lookup = f"{contract['title']},"
-    logger.info(
+    logger.debug(
         f"Processing contract {contract['contract_id']}, {contract['title']}"
     )
     if contract["acceptor_id"] == issuer_id:

--- a/backend/market/tasks.py
+++ b/backend/market/tasks.py
@@ -41,7 +41,7 @@ def fetch_eve_market_contracts():
                 f"Not fetching character contracts for ESI suspended character {character.character_id}"
             )
             continue
-        logger.info(f"Fetching character contracts {character.character_id}")
+        logger.debug(f"Fetching character contracts {character.character_id}")
         try:
             create_character_market_contracts(character.character_id)
             known_entity_ids.append(character.character_id)

--- a/backend/structures/tasks.py
+++ b/backend/structures/tasks.py
@@ -33,7 +33,7 @@ def update_corporation_structures(corporation_id: int):
         and corporation.ceo.token
         and not corporation.ceo.esi_suspended
     ):
-        logger.info(
+        logger.debug(
             "Corporation %s has token for CEO: %s",
             corporation,
             corporation.ceo,
@@ -43,7 +43,7 @@ def update_corporation_structures(corporation_id: int):
 
         token = Token.get_token(corporation.ceo.character_id, required_scopes)
         if token:
-            logger.info("Fetching structures for corporation %s", corporation)
+            logger.debug("Fetching structures for corporation %s", corporation)
             response = esi.client.Corporation.get_corporations_corporation_id_structures(
                 corporation_id=corporation.corporation_id,
                 token=token.valid_access_token(),
@@ -51,7 +51,8 @@ def update_corporation_structures(corporation_id: int):
 
             known_structure_ids = []
             for structure in response:
-                logger.info("Processing structure %s", structure)
+                logger.info("Updating structure %s", structure["name"])
+                logger.debug("Structure details %s", structure)
                 system, _ = EveSolarSystem.objects.get_or_create_esi(
                     id=structure["system_id"]
                 )


### PR DESCRIPTION
Now that we have access to the server logs it is a good idea to cleanup the Celery task logging to make it easier to sort the signal from the noise.