### PR TITLE
Minor overhaul on Fix ESI token dialog and bugfix dialog visibility glitch

### DIFF
--- a/frontend/app/src/components/blocks/FixESITokenButton.astro
+++ b/frontend/app/src/components/blocks/FixESITokenButton.astro
@@ -29,6 +29,7 @@ import { renderer } from '@helpers/marked';
 
 import Flexblock from '@components/compositions/Flexblock.astro';
 import FlexInline from '@components/compositions/FlexInline.astro';
+import Grid from '@components/compositions/Grid.astro';
 
 import PilotBadge from '@components/blocks/PilotBadge.astro';
 import DialogButton from '@components/blocks/DialogButton.astro';
@@ -60,15 +61,18 @@ import TutorialBadge from '@components/blocks/TutorialBadge.astro';
 
             <Flexblock gap="var(--space-s)">
                 <p>{fix ? t('fix_esi_token_dialog_text') : t('update_esi_token_dialog_text')}</p>
-                <PilotBadge character_id={character.character_id} character_name={character.character_name}>
-                    <small>{`${character.esi_token ?? 'Basic'} ${t('token')}`}</small>
-                </PilotBadge>
 
-                <Select x-model="esi_token">
-                    {user_selectable_esi_tokens_roles.map(role =>
-                        <option value={role}>{t(role as any)}</option>
-                    )}
-                </Select>
+                <Grid min_item_width="250px">
+                    <PilotBadge character_id={character.character_id} character_name={character.character_name}>
+                        <small>{`${character.esi_token ?? 'Basic'} ${t('token')}`}</small>
+                    </PilotBadge>
+    
+                    <Select x-model="esi_token">
+                        {user_selectable_esi_tokens_roles.map(role =>
+                            <option value={role}>{t(role as any)}</option>
+                        )}
+                    </Select>
+                </Grid>
                 
                 <TutorialBadge>
                     <p set:html={marked.parseInline(t('esi_token_wiki'), { renderer })} />

--- a/frontend/app/src/components/blocks/PilotsList.astro
+++ b/frontend/app/src/components/blocks/PilotsList.astro
@@ -298,6 +298,10 @@ delete attributes.class
                     opacity: 0;
                 }
 
+                &:has(.open) .action-button {
+                    opacity: 1;
+                }
+
                 &:hover,
                 &:focus-within {
                     .action-button {


### PR DESCRIPTION
Visibility glitch happened when the focus was not anymore on the **Refresh ESI Token** button and the mouse pointer was moved away from the dialog. This cause the `.action-button` parent to hide and hiding the dialog as well