### PR TITLE
Remove special modifiers to discord nicknames

### DIFF
--- a/backend/discord/core.py
+++ b/backend/discord/core.py
@@ -1,6 +1,3 @@
-import upsidedown
-
-
 def make_nickname(character, discord_user):
     corporation = character.corporation
 

--- a/backend/discord/core.py
+++ b/backend/discord/core.py
@@ -6,13 +6,4 @@ def make_nickname(character, discord_user):
 
     nickname = f"[{corporation.ticker}] {character.character_name}"
 
-    if discord_user.is_down_under:
-        nickname = upsidedown.transform(nickname)
-
-    if discord_user.dress_wearer:
-        nickname = f"[👗] {character.character_name}"
-
-    if corporation.ticker == "-DRY-":
-        nickname = f"[ω] {character.character_name}"
-
     return nickname

--- a/backend/discord/tests.py
+++ b/backend/discord/tests.py
@@ -30,24 +30,6 @@ class DiscordSimpleTests(SimpleTestCase):
         discord = Mock(is_down_under=False, dress_wearer=False)
         self.assertEqual("[ABC] Bob", make_nickname(character, discord))
 
-    def test_down_under_nickname(self):
-        character = Mock(character_name="Bob", corporation=Mock(ticker="ABC"))
-        discord = Mock(is_down_under=True, dress_wearer=False)
-        self.assertEqual("qoᗺ [ƆᗺⱯ]", make_nickname(character, discord))
-
-    def test_dress_wearer(self):
-        character = Mock(character_name="Bob", corporation=Mock(ticker="ABC"))
-        discord = Mock(is_down_under=False, dress_wearer=True)
-        self.assertEqual("[👗] Bob", make_nickname(character, discord))
-
-    def test_dry_corp(self):
-        character = Mock(
-            character_name="Scott", corporation=Mock(ticker="-DRY-")
-        )
-        discord = Mock(is_down_under=False, dress_wearer=True)
-        self.assertEqual("[ω] Scott", make_nickname(character, discord))
-
-
 class DiscordSignalTests(TestCase):
     """
     Django tests for Discord signal functionality.

--- a/backend/discord/tests.py
+++ b/backend/discord/tests.py
@@ -30,6 +30,7 @@ class DiscordSimpleTests(SimpleTestCase):
         discord = Mock(is_down_under=False, dress_wearer=False)
         self.assertEqual("[ABC] Bob", make_nickname(character, discord))
 
+
 class DiscordSignalTests(TestCase):
     """
     Django tests for Discord signal functionality.


### PR DESCRIPTION
As we've grown in size, it's a bit harder to follow people with all the weird modifiers.