### PR TITLE
#1566 function, endpoint, signal to remove roles from discord server user

### DIFF
--- a/backend/discord/signals.py
+++ b/backend/discord/signals.py
@@ -112,12 +112,12 @@ def user_group_changed(
 
 
 @receiver(
-    signals.post_delete,
+    signals.pre_delete,
     sender=DiscordUser,
-    dispatch_uid="discord_user_deleted",
+    dispatch_uid="discord_user_deleting",
 )
-def discord_user_deleted(
+def discord_user_deleting(
     sender, instance, **kwargs
 ):  # pylint: disable=unused-argument
-    logger.info("Discord user deleted, removing roles")
+    logger.info("Discord user deleting, removing roles")
     remove_all_roles_from_guild_member(instance.id)

--- a/backend/tech/router.py
+++ b/backend/tech/router.py
@@ -18,10 +18,7 @@ from authentication import AuthBearer
 from discord.client import DiscordClient
 from discord.models import DiscordUser
 from discord.tasks import sync_discord_user, sync_discord_nickname
-from discord.helpers import (
-    remove_all_roles_from_guild_member,
-    DiscordUserNotFound,
-)
+from discord.helpers import remove_all_roles_from_guild_member
 from groups.helpers import TECH_TEAM, user_in_team
 from groups.tasks import update_affiliation
 from eveonline.client import esi_for
@@ -583,7 +580,6 @@ def force_refresh(request, username: str):
     response={
         200: None,
         403: ErrorResponse,
-        404: ErrorResponse,
         409: ErrorResponse,
     },
 )
@@ -593,8 +589,6 @@ def remove_discord_roles(request, user_id: int):
 
     try:
         remove_all_roles_from_guild_member(user_id)
-    except DiscordUserNotFound as e:
-        return 404, ErrorResponse(detail=str(e))
     except ValueError as e:
         return 409, ErrorResponse(detail=str(e))
     return 200, None


### PR DESCRIPTION
#1566

In the alliance role
<img width="373" height="205" alt="Screenshot 2025-08-14 203914" src="https://github.com/user-attachments/assets/b3b4396d-88cb-4744-9684-016a347f65e3" />

manually remove from database
test the api endpoint to remove discord user roles

Alliance role removed
<img width="266" height="160" alt="Screenshot 2025-08-14 204039" src="https://github.com/user-attachments/assets/b42b556b-8be8-4465-85b4-45e490a8eba0" />


The nickname is still set,  that might need to be a separate ticket,  one question is what to change it to... 

logs showing that when the "delete me" feature of the site is used by a player it removes their roles
```
2025-08-22 11:45:25,539 INFO     [discord.helpers] Removing 1 discord roles for discord user ***** with nickname ***1
2025-08-22 11:45:25,540 INFO     [groups.signals] User affiliation deleted, updating user groups
2025-08-22 11:45:25,549 INFO     [discord.signals] User removed from group, removing from discord role
[22/Aug/2025 11:45:25] "DELETE /api/users/delete HTTP/1.1" 200 30
```
