### PR TITLE
Use regex for killmail validation/parsing

### DIFF
--- a/backend/srp/tests.py
+++ b/backend/srp/tests.py
@@ -22,7 +22,7 @@ BASE_URL = "/api/srp"
 KM_CHAR = 634915984
 KM_ID = 126008813
 KM_HASH = "9c92aa157f138da9b5a64abbd8225893f1b8b5f0"
-KM_LINK = f"https://esi.evetech.net/latest/killmails/{KM_ID}/{KM_HASH}/"
+KM_LINK = f"https://esi.evetech.net/killmails/{KM_ID}/{KM_HASH}/"
 
 
 class SrpRouterTestCase(TestCase):


### PR DESCRIPTION
Should match the changes made in the frontend and astro.

ESI supports both with and without the v1, and looking at older api versions, there's no mention of the v1 in the url.

The versioning part of the ESI docs only mentions an API compatibility date header :shrug: 