### PR TITLE
Tribe activity: primary character and actor character

### DIFF
--- a/backend/tribes/endpoints/groups/get_tribe_group_activity.py
+++ b/backend/tribes/endpoints/groups/get_tribe_group_activity.py
@@ -49,6 +49,7 @@ def get_tribe_group_activity(
         .select_related(
             "character",
             "user",
+            "user__eveplayer__primary_character",
             "tribe_group_activity",
         )
         .order_by("-created_at")
@@ -60,6 +61,13 @@ def get_tribe_group_activity(
     items = []
     for r in records:
         activity_type = r.tribe_group_activity.activity_type
+        primary = None
+        if (
+            r.user
+            and getattr(r.user, "eveplayer", None)
+            and r.user.eveplayer.primary_character
+        ):
+            primary = r.user.eveplayer.primary_character
         items.append(
             TribeGroupActivityRecordSchema(
                 id=r.pk,
@@ -68,9 +76,13 @@ def get_tribe_group_activity(
                 activity_type_display=activity_type_labels.get(
                     activity_type, activity_type
                 ),
-                character_id=r.character_id,
+                character_id=r.character.character_id if r.character else None,
                 character_name=(
                     r.character.character_name if r.character else ""
+                ),
+                primary_character_id=primary.character_id if primary else None,
+                primary_character_name=(
+                    (primary.character_name or "") if primary else ""
                 ),
                 user_id=r.user_id,
                 username=r.user.username if r.user else "",

--- a/backend/tribes/endpoints/groups/schemas.py
+++ b/backend/tribes/endpoints/groups/schemas.py
@@ -11,6 +11,8 @@ class TribeGroupActivityRecordSchema(BaseModel):
     activity_type_display: str
     character_id: Optional[int] = None
     character_name: str = ""
+    primary_character_id: Optional[int] = None
+    primary_character_name: str = ""
     user_id: Optional[int] = None
     username: str = ""
     source_type_id: Optional[int] = None

--- a/frontend/app/src/components/blocks/GenericActivityItem.astro
+++ b/frontend/app/src/components/blocks/GenericActivityItem.astro
@@ -20,21 +20,30 @@ import { number_thousand_separator } from '@helpers/numbers'
 import FlexInline from '@components/compositions/FlexInline.astro'
 
 import PilotBadge from '@components/blocks/PilotBadge.astro';
+import CharacterPicture from '@components/blocks/CharacterPicture.astro';
 import ItemPicture from '@components/blocks/ItemPicture.astro';
 import Picture from '@components/blocks/Picture.astro';
+import FixedFluid from '@components/compositions/FixedFluid.astro';
 ---
 
 <FlexInline>
     <span class="[ basis-[200px] ]">
         {format_date_time(lang, activity.created_at)}
     </span>
-    <PilotBadge
-        class="[ basis-[250px] ]"
-        character_id={activity.character_id ?? 0}
-        character_name={activity.character_name}
-        size={32}
-        centered={true}
-    />
+    <FlexInline class="[ basis-[250px] ]" gap="var(--space-2xs)">
+        <PilotBadge
+            character_id={activity.primary_character_id ?? activity.character_id ?? 0}
+            character_name={activity.primary_character_name || activity.character_name}
+            size={32}
+            centered={true}
+        />
+        {activity.character_id != null && activity.primary_character_id != null && activity.character_id !== activity.primary_character_id &&
+            <FixedFluid width="16px" gap="var(--space-3xs)" class="[ items-center ]">
+                <CharacterPicture character_id={activity.character_id} character_name={activity.character_name} size={16} icon_quality={32} />
+                <small>{activity.character_name}</small>
+            </FixedFluid>
+        }
+    </FlexInline>
     <span class="[ basis-[220px] ]">{activity.activity_type_display}</span>
     <FlexInline gap='var(--space-2xs)'>
         {activity.source_type_id &&

--- a/frontend/app/src/types/api.minmatar.org.ts
+++ b/frontend/app/src/types/api.minmatar.org.ts
@@ -159,6 +159,8 @@ export interface TribeGroupActivityRecord {
     activity_type_display: string;
     character_id:         number | null;
     character_name:       string;
+    primary_character_id: number | null;
+    primary_character_name: string;
     user_id:               number | null;
     username:              string;
     source_type_id:       number | null;


### PR DESCRIPTION
- API: Add primary_character_id/primary_character_name to group activity records
- API: Use EVE external character_id (EveCharacter.character_id) for actor and primary so portrait URLs work (images.evetech.net/characters/{id}/portrait)
- Endpoint: select_related user__eveplayer__primary_character
- Frontend: Show primary character as main portrait; when actor differs (alt), show actor portrait and name beside it

Made-with: Cursor