### PR TITLE
Tribe activity metrics: point weights, per-activity metrics, leaderboards

### DIFF
--- a/backend/tribes/admin.py
+++ b/backend/tribes/admin.py
@@ -172,6 +172,8 @@ class TribeGroupActivityAdmin(admin.ModelAdmin):
         "target_eve_type_id",
         "description",
         "is_active",
+        "points_per_record",
+        "points_per_unit",
         "created_at",
     )
     list_filter = ("activity_type", "is_active", "tribe_group__tribe")

--- a/backend/tribes/endpoints/__init__.py
+++ b/backend/tribes/endpoints/__init__.py
@@ -2,13 +2,17 @@
 
 from ninja import Router
 
-from tribes.endpoints.tribes import router as tribes_router
+from tribes.endpoints.activity import router as activity_router
 from tribes.endpoints.groups import router as groups_router
+from tribes.endpoints.members import router as members_router
 from tribes.endpoints.memberships import router as memberships_router
+from tribes.endpoints.tribes import router as tribes_router
 
 router = Router(tags=["Tribes"])
 router.add_router("", tribes_router)
 router.add_router("", groups_router)
+router.add_router("", activity_router)
+router.add_router("", members_router)
 router.add_router("", memberships_router)
 
 __all__ = ["router"]

--- a/backend/tribes/endpoints/activity/__init__.py
+++ b/backend/tribes/endpoints/activity/__init__.py
@@ -1,0 +1,16 @@
+"""Tribe activity endpoints: per-activity metrics and leaderboard."""
+
+from ninja import Router
+
+from tribes.endpoints.activity.get_tribe_activity_leaderboard import (
+    router as get_tribe_activity_leaderboard_router,
+)
+from tribes.endpoints.activity.get_tribe_activity_metrics import (
+    router as get_tribe_activity_metrics_router,
+)
+
+router = Router(tags=["Tribes - Activity"])
+router.add_router("", get_tribe_activity_metrics_router)
+router.add_router("", get_tribe_activity_leaderboard_router)
+
+__all__ = ["router"]

--- a/backend/tribes/endpoints/activity/get_tribe_activity_leaderboard.py
+++ b/backend/tribes/endpoints/activity/get_tribe_activity_leaderboard.py
@@ -1,0 +1,169 @@
+"""GET /{tribe_id}/activity/leaderboard - paginated leaderboard (points only)."""
+
+from datetime import datetime, timedelta
+
+from django.contrib.auth import get_user_model
+from django.db.models import ExpressionWrapper, F, FloatField, Sum, Value
+from django.db.models.functions import Coalesce
+from django.utils import timezone
+from ninja import Router, Query
+
+from eveonline.helpers.characters import (
+    user_characters,
+    user_primary_character,
+)
+from eveonline.models import EvePlayer
+from tribes.models import Tribe
+
+from tribes.endpoints.groups.schemas import (
+    CharacterRefSchema,
+    TribeActivityLeaderboardEntrySchema,
+    TribeActivityLeaderboardListSchema,
+)
+from tribes.models import TribeGroupActivityRecord
+
+PATH = "/{tribe_id}/activity/leaderboard"
+METHOD = "get"
+ROUTE_SPEC = {
+    "summary": "Paginated leaderboard by total points; points only.",
+    "response": {200: TribeActivityLeaderboardListSchema, 404: dict},
+}
+
+router = Router(tags=["Tribes - Activity"])
+
+MAX_LIMIT = 100
+DEFAULT_LIMIT = 50
+
+
+def _parse_since_until(since: str | None, until: str | None):
+    start = end = None
+    if since:
+        try:
+            if since.endswith("d"):
+                start = timezone.now() - timedelta(days=int(since[:-1]))
+            else:
+                start = datetime.fromisoformat(since.replace("Z", "+00:00"))
+                if timezone.is_naive(start):
+                    start = timezone.make_aware(start)
+        except (ValueError, TypeError):
+            pass
+    if until:
+        try:
+            end = datetime.fromisoformat(until.replace("Z", "+00:00"))
+            if timezone.is_naive(end):
+                end = timezone.make_aware(end)
+        except (ValueError, TypeError):
+            pass
+    return start, end
+
+
+def get_tribe_activity_leaderboard(
+    request,
+    tribe_id: int,
+    group_id: int | None = Query(None),
+    activity_type: str | None = Query(None),
+    since: str | None = Query(None),
+    until: str | None = Query(None),
+    limit: int = Query(DEFAULT_LIMIT, ge=1, le=MAX_LIMIT),
+    offset: int = Query(0, ge=0),
+    order: str = Query("total_points"),
+):
+    if not Tribe.objects.filter(pk=tribe_id).exists():
+        return 404, {"detail": "Tribe not found."}
+
+    qs = TribeGroupActivityRecord.objects.filter(
+        tribe_group_activity__tribe_group__tribe_id=tribe_id
+    ).filter(user_id__isnull=False)
+
+    if group_id is not None:
+        qs = qs.filter(tribe_group_activity__tribe_group_id=group_id)
+    if activity_type:
+        qs = qs.filter(tribe_group_activity__activity_type=activity_type)
+    start, end = _parse_since_until(since, until)
+    if start:
+        qs = qs.filter(created_at__gte=start)
+    if end:
+        qs = qs.filter(created_at__lte=end)
+
+    points_expr = ExpressionWrapper(
+        Coalesce(F("tribe_group_activity__points_per_record"), Value(0.0))
+        + Coalesce(F("tribe_group_activity__points_per_unit"), Value(0.0))
+        * Coalesce(F("quantity"), Value(0.0)),
+        output_field=FloatField(),
+    )
+    qs = (
+        qs.values("user_id")
+        .annotate(total_points=Sum(points_expr))
+        .order_by("-total_points")
+    )
+    total = qs.count()
+    page = list(qs[offset : offset + limit])
+    if not page:
+        return 200, TribeActivityLeaderboardListSchema(
+            items=[], total=total, limit=limit, offset=offset
+        )
+
+    user_ids = [r["user_id"] for r in page]
+    points_by_user = {r["user_id"]: float(r["total_points"]) for r in page}
+
+    players = (
+        EvePlayer.objects.filter(user_id__in=user_ids)
+        .select_related("primary_character")
+        .only(
+            "user_id",
+            "primary_character_id",
+            "primary_character__character_id",
+            "primary_character__character_name",
+        )
+    )
+    primary_by_user = {}
+    for p in players:
+        if p.primary_character_id:
+            primary_by_user[p.user_id] = (
+                p.primary_character.character_id,
+                p.primary_character.character_name or "",
+            )
+
+    user_model = get_user_model()
+    users = {u.pk: u for u in user_model.objects.filter(pk__in=user_ids)}
+    alts_by_user = {}
+    for user_id in user_ids:
+        user = users.get(user_id)
+        if not user:
+            alts_by_user[user_id] = []
+            continue
+        primary = user_primary_character(user)
+        chars = user_characters(user)
+        alt_refs = [
+            CharacterRefSchema(
+                character_id=c.character_id,
+                character_name=c.character_name or "",
+            )
+            for c in chars
+            if not primary or c.pk != primary.pk
+        ]
+        alts_by_user[user_id] = alt_refs
+
+    items = []
+    for user_id in user_ids:
+        primary = primary_by_user.get(user_id)
+        if primary:
+            pc_id, pc_name = primary
+        else:
+            pc_id, pc_name = None, ""
+        items.append(
+            TribeActivityLeaderboardEntrySchema(
+                user_id=user_id,
+                primary_character_id=pc_id,
+                primary_character_name=pc_name,
+                alts=alts_by_user.get(user_id, []),
+                total_points=points_by_user.get(user_id, 0.0),
+            )
+        )
+
+    return 200, TribeActivityLeaderboardListSchema(
+        items=items, total=total, limit=limit, offset=offset
+    )
+
+
+router.get(PATH, **ROUTE_SPEC)(get_tribe_activity_leaderboard)

--- a/backend/tribes/endpoints/activity/get_tribe_activity_metrics.py
+++ b/backend/tribes/endpoints/activity/get_tribe_activity_metrics.py
@@ -1,0 +1,109 @@
+"""GET /{tribe_id}/activity/{activity_id}/metrics - per-activity metrics for one TribeGroupActivity."""
+
+from datetime import datetime, timedelta
+
+from django.db.models import (
+    Count,
+    ExpressionWrapper,
+    F,
+    FloatField,
+    Sum,
+    Value,
+)
+from django.db.models.functions import Coalesce
+from django.utils import timezone
+from ninja import Router, Query
+
+from tribes.endpoints.groups.schemas import TribeActivityMetricsSchema
+from tribes.models import TribeGroupActivity, TribeGroupActivityRecord
+
+PATH = "/{tribe_id}/activity/{activity_id}/metrics"
+METHOD = "get"
+ROUTE_SPEC = {
+    "summary": "Metrics for one tribe group activity (record count, total quantity, total points).",
+    "response": {200: TribeActivityMetricsSchema, 404: dict},
+}
+
+router = Router(tags=["Tribes - Activity"])
+
+
+def _parse_since_until(since: str | None, until: str | None):
+    """Parse since/until query params; return (start, end) datetimes or (None, None)."""
+    start = end = None
+    if since:
+        try:
+            if since.endswith("d"):
+                days = int(since[:-1])
+                start = timezone.now() - timedelta(days=days)
+            else:
+                start = datetime.fromisoformat(since.replace("Z", "+00:00"))
+                if timezone.is_naive(start):
+                    start = timezone.make_aware(start)
+        except (ValueError, TypeError):
+            pass
+    if until:
+        try:
+            end = datetime.fromisoformat(until.replace("Z", "+00:00"))
+            if timezone.is_naive(end):
+                end = timezone.make_aware(end)
+        except (ValueError, TypeError):
+            pass
+    return start, end
+
+
+def get_tribe_activity_metrics(
+    request,
+    tribe_id: int,
+    activity_id: int,
+    since: str | None = Query(None, description="ISO date or e.g. 7d, 30d"),
+    until: str | None = Query(None, description="ISO date"),
+):
+    activity = (
+        TribeGroupActivity.objects.filter(pk=activity_id)
+        .select_related("tribe_group", "tribe_group__tribe")
+        .first()
+    )
+    if not activity or activity.tribe_group.tribe_id != tribe_id:
+        return 404, {"detail": "Activity not found."}
+
+    qs = TribeGroupActivityRecord.objects.filter(
+        tribe_group_activity_id=activity_id
+    )
+    start, end = _parse_since_until(since, until)
+    if start:
+        qs = qs.filter(created_at__gte=start)
+    if end:
+        qs = qs.filter(created_at__lte=end)
+
+    points_expr = ExpressionWrapper(
+        Coalesce(F("tribe_group_activity__points_per_record"), Value(0.0))
+        + Coalesce(F("tribe_group_activity__points_per_unit"), Value(0.0))
+        * Coalesce(F("quantity"), Value(0.0)),
+        output_field=FloatField(),
+    )
+    agg = qs.aggregate(
+        record_count=Count("id"),
+        total_quantity=Sum("quantity"),
+        total_points=Sum(points_expr),
+    )
+    record_count = agg["record_count"] or 0
+    total_quantity = agg["total_quantity"]
+    total_points = float(agg["total_points"] or 0.0)
+
+    activity_type_labels = dict(TribeGroupActivity.ACTIVITY_TYPE_CHOICES)
+    return 200, TribeActivityMetricsSchema(
+        activity_id=activity.pk,
+        activity_type=activity.activity_type,
+        activity_type_display=activity_type_labels.get(
+            activity.activity_type, activity.activity_type
+        ),
+        group_id=activity.tribe_group_id,
+        group_name=activity.tribe_group.name or "",
+        unit="",  # Could be derived from records if needed
+        record_count=record_count,
+        total_quantity=total_quantity,
+        total_points=total_points,
+    )
+
+
+router.get(PATH, **ROUTE_SPEC)(get_tribe_activity_metrics)

--- a/backend/tribes/endpoints/groups/schemas.py
+++ b/backend/tribes/endpoints/groups/schemas.py
@@ -80,3 +80,59 @@ class TribeGroupSchema(BaseModel):
     is_active: bool
     member_count: int = 0
     requirements: List[RequirementSchema] = []
+
+
+# --- Activity metrics, member activity, leaderboard ---
+
+
+class TribeActivityMetricsSchema(BaseModel):
+    """Per-activity metrics for one TribeGroupActivity."""
+
+    activity_id: int
+    activity_type: str
+    activity_type_display: str
+    group_id: int
+    group_name: str = ""
+    unit: str = ""
+    record_count: int
+    total_quantity: Optional[float] = None
+    total_points: float = 0.0
+
+
+class TribeMemberActivityBreakdownItemSchema(BaseModel):
+    """Per-activity-type breakdown for member activity."""
+
+    activity_type: str
+    unit: str = ""
+    record_count: int = 0
+    total_quantity: Optional[float] = None
+
+
+class TribeMemberActivitySchema(BaseModel):
+    """Activity summary for one tribe member (primary + alts + metrics)."""
+
+    primary_character_id: Optional[int] = None
+    primary_character_name: str = ""
+    alts: List[CharacterRefSchema] = []
+    total_points: float = 0.0
+    record_count: int = 0
+    breakdown: List[TribeMemberActivityBreakdownItemSchema] = []
+
+
+class TribeActivityLeaderboardEntrySchema(BaseModel):
+    """One leaderboard row; points only."""
+
+    user_id: int
+    primary_character_id: Optional[int] = None
+    primary_character_name: str = ""
+    alts: List[CharacterRefSchema] = []
+    total_points: float = 0.0
+
+
+class TribeActivityLeaderboardListSchema(BaseModel):
+    """Paginated leaderboard."""
+
+    items: List[TribeActivityLeaderboardEntrySchema]
+    total: int
+    limit: int
+    offset: int

--- a/backend/tribes/endpoints/members/__init__.py
+++ b/backend/tribes/endpoints/members/__init__.py
@@ -1,0 +1,12 @@
+"""Tribe-level members endpoints (e.g. member activity)."""
+
+from ninja import Router
+
+from tribes.endpoints.members.get_tribe_member_activity import (
+    router as get_tribe_member_activity_router,
+)
+
+router = Router(tags=["Tribes - Members"])
+router.add_router("", get_tribe_member_activity_router)
+
+__all__ = ["router"]

--- a/backend/tribes/endpoints/members/get_tribe_member_activity.py
+++ b/backend/tribes/endpoints/members/get_tribe_member_activity.py
@@ -1,0 +1,157 @@
+"""GET /{tribe_id}/members/{member_id}/activity - activity summary for one tribe member."""
+
+from datetime import datetime, timedelta
+
+from django.contrib.auth import get_user_model
+from django.db.models import (
+    Count,
+    ExpressionWrapper,
+    F,
+    FloatField,
+    Sum,
+    Value,
+)
+from django.db.models.functions import Coalesce
+from django.utils import timezone
+from ninja import Router, Query
+
+from eveonline.helpers.characters import (
+    user_characters,
+    user_primary_character,
+)
+
+from tribes.endpoints.groups.schemas import (
+    CharacterRefSchema,
+    TribeMemberActivityBreakdownItemSchema,
+    TribeMemberActivitySchema,
+)
+from tribes.models import TribeGroupActivityRecord, TribeGroupMembership
+
+PATH = "/{tribe_id}/members/{member_id}/activity"
+METHOD = "get"
+ROUTE_SPEC = {
+    "summary": "Activity summary for one tribe member (primary + alts, total_points, record_count, breakdown).",
+    "response": {200: TribeMemberActivitySchema, 404: dict},
+}
+
+router = Router(tags=["Tribes - Members"])
+
+
+def _parse_since_until(since: str | None, until: str | None):
+    start = end = None
+    if since:
+        try:
+            if since.endswith("d"):
+                start = timezone.now() - timedelta(days=int(since[:-1]))
+            else:
+                start = datetime.fromisoformat(since.replace("Z", "+00:00"))
+                if timezone.is_naive(start):
+                    start = timezone.make_aware(start)
+        except (ValueError, TypeError):
+            pass
+    if until:
+        try:
+            end = datetime.fromisoformat(until.replace("Z", "+00:00"))
+            if timezone.is_naive(end):
+                end = timezone.make_aware(end)
+        except (ValueError, TypeError):
+            pass
+    return start, end
+
+
+def get_tribe_member_activity(
+    request,
+    tribe_id: int,
+    member_id: int,
+    since: str | None = Query(None),
+    until: str | None = Query(None),
+):
+    is_member = TribeGroupMembership.objects.filter(
+        tribe_group__tribe_id=tribe_id,
+        user_id=member_id,
+        status=TribeGroupMembership.STATUS_ACTIVE,
+    ).exists()
+    if not is_member:
+        return 404, {"detail": "Member not found."}
+
+    qs = TribeGroupActivityRecord.objects.filter(
+        tribe_group_activity__tribe_group__tribe_id=tribe_id,
+        user_id=member_id,
+    )
+    start, end = _parse_since_until(since, until)
+    if start:
+        qs = qs.filter(created_at__gte=start)
+    if end:
+        qs = qs.filter(created_at__lte=end)
+
+    points_expr = ExpressionWrapper(
+        Coalesce(F("tribe_group_activity__points_per_record"), Value(0.0))
+        + Coalesce(F("tribe_group_activity__points_per_unit"), Value(0.0))
+        * Coalesce(F("quantity"), Value(0.0)),
+        output_field=FloatField(),
+    )
+    agg = qs.aggregate(
+        record_count=Count("id"),
+        total_points=Sum(points_expr),
+    )
+    record_count = agg["record_count"] or 0
+    total_points = float(agg["total_points"] or 0.0)
+
+    breakdown_qs = qs.values(
+        "tribe_group_activity__activity_type",
+        "tribe_group_activity__tribe_group__name",
+    ).annotate(
+        record_count=Count("id"),
+        total_quantity=Sum("quantity"),
+    )
+    breakdown = [
+        TribeMemberActivityBreakdownItemSchema(
+            activity_type=row["tribe_group_activity__activity_type"],
+            unit="",
+            record_count=row["record_count"],
+            total_quantity=row["total_quantity"],
+        )
+        for row in breakdown_qs
+    ]
+
+    user_model = get_user_model()
+    try:
+        user = user_model.objects.get(pk=member_id)
+    except user_model.DoesNotExist:
+        return 200, TribeMemberActivitySchema(
+            primary_character_id=None,
+            primary_character_name="",
+            alts=[],
+            total_points=total_points,
+            record_count=record_count,
+            breakdown=breakdown,
+        )
+
+    primary = user_primary_character(user)
+    if primary:
+        primary_character_id = primary.character_id
+        primary_character_name = primary.character_name or ""
+    else:
+        primary_character_id = None
+        primary_character_name = ""
+
+    chars = user_characters(user)
+    alts = [
+        CharacterRefSchema(
+            character_id=c.character_id, character_name=c.character_name or ""
+        )
+        for c in chars
+        if not primary or c.pk != primary.pk
+    ]
+
+    return 200, TribeMemberActivitySchema(
+        primary_character_id=primary_character_id,
+        primary_character_name=primary_character_name,
+        alts=alts,
+        total_points=total_points,
+        record_count=record_count,
+        breakdown=breakdown,
+    )
+
+
+router.get(PATH, **ROUTE_SPEC)(get_tribe_member_activity)

--- a/backend/tribes/migrations/0020_add_tribegroupactivity_point_weights.py
+++ b/backend/tribes/migrations/0020_add_tribegroupactivity_point_weights.py
@@ -1,0 +1,31 @@
+# Generated manually for point weights on TribeGroupActivity
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("tribes", "0019_tribegroupactivity_tribegroupactivityrecord"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="tribegroupactivity",
+            name="points_per_record",
+            field=models.FloatField(
+                blank=True,
+                help_text="Points awarded per record (count-based: killmail, fleet).",
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="tribegroupactivity",
+            name="points_per_unit",
+            field=models.FloatField(
+                blank=True,
+                help_text="Points per unit of quantity (e.g. mining m³, industry ISK).",
+                null=True,
+            ),
+        ),
+    ]

--- a/backend/tribes/models/tribe_group_activity.py
+++ b/backend/tribes/models/tribe_group_activity.py
@@ -56,6 +56,16 @@ class TribeGroupActivity(models.Model):
     )
     description = models.CharField(max_length=255, blank=True)
     is_active = models.BooleanField(default=True)
+    points_per_record = models.FloatField(
+        null=True,
+        blank=True,
+        help_text="Points awarded per record (count-based: killmail, fleet).",
+    )
+    points_per_unit = models.FloatField(
+        null=True,
+        blank=True,
+        help_text="Points per unit of quantity (e.g. mining m³, industry ISK).",
+    )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/frontend/app/src/helpers/api.minmatar.org/tribes.ts
+++ b/frontend/app/src/helpers/api.minmatar.org/tribes.ts
@@ -7,6 +7,9 @@ import type {
     TribeLeaderboardEntry,
     TribeActivity,
     TribeGroupActivityList,
+    TribeActivityMetrics,
+    TribeMemberActivity,
+    TribeActivityLeaderboardList,
     ActivityType,
     LogActivityPayload,
 } from '@dtypes/api.minmatar.org'
@@ -472,4 +475,50 @@ export async function get_group_leaderboard(
     } catch (error) {
         throw new Error(`Error fetching group leaderboard: ${error.message}`)
     }
+}
+
+export async function get_tribe_activity_metrics(
+    tribe_id: number,
+    activity_id: number,
+    params?: { since?: string; until?: string }
+): Promise<TribeActivityMetrics> {
+    const query = query_string(params ?? {})
+    const ENDPOINT = `${API_ENDPOINT}/${tribe_id}/activity/${activity_id}/metrics${query ? `?${query}` : ''}`
+    const response = await fetch(ENDPOINT, { headers: { 'Content-Type': 'application/json' } })
+    if (!response.ok)
+        throw new Error(get_error_message(response.status, `GET ${ENDPOINT}`))
+    return await response.json() as TribeActivityMetrics
+}
+
+export async function get_tribe_member_activity(
+    tribe_id: number,
+    member_id: number,
+    params?: { since?: string; until?: string }
+): Promise<TribeMemberActivity> {
+    const query = query_string(params ?? {})
+    const ENDPOINT = `${API_ENDPOINT}/${tribe_id}/members/${member_id}/activity${query ? `?${query}` : ''}`
+    const response = await fetch(ENDPOINT, { headers: { 'Content-Type': 'application/json' } })
+    if (!response.ok)
+        throw new Error(get_error_message(response.status, `GET ${ENDPOINT}`))
+    return await response.json() as TribeMemberActivity
+}
+
+export async function get_tribe_activity_leaderboard(
+    tribe_id: number,
+    params?: {
+        group_id?: number;
+        activity_type?: string;
+        since?: string;
+        until?: string;
+        limit?: number;
+        offset?: number;
+        order?: string;
+    }
+): Promise<TribeActivityLeaderboardList> {
+    const query = query_string(params ?? {})
+    const ENDPOINT = `${API_ENDPOINT}/${tribe_id}/activity/leaderboard${query ? `?${query}` : ''}`
+    const response = await fetch(ENDPOINT, { headers: { 'Content-Type': 'application/json' } })
+    if (!response.ok)
+        throw new Error(get_error_message(response.status, `GET ${ENDPOINT}`))
+    return await response.json() as TribeActivityLeaderboardList
 }

--- a/frontend/app/src/types/api.minmatar.org.ts
+++ b/frontend/app/src/types/api.minmatar.org.ts
@@ -177,6 +177,54 @@ export interface TribeGroupActivityList {
     offset:  number;
 }
 
+/** Per-activity metrics for one TribeGroupActivity (GET tribe activity metrics). */
+export interface TribeActivityMetrics {
+    activity_id:            number;
+    activity_type:          string;
+    activity_type_display:  string;
+    group_id:               number;
+    group_name:             string;
+    unit:                   string;
+    record_count:           number;
+    total_quantity:         number | null;
+    total_points:           number;
+}
+
+/** Per-activity-type breakdown item for member activity. */
+export interface TribeMemberActivityBreakdownItem {
+    activity_type:  string;
+    unit:           string;
+    record_count:   number;
+    total_quantity: number | null;
+}
+
+/** Activity summary for one tribe member (GET member activity). */
+export interface TribeMemberActivity {
+    primary_character_id:   number | null;
+    primary_character_name:  string;
+    alts:                   TribeCharacterRef[];
+    total_points:           number;
+    record_count:           number;
+    breakdown:              TribeMemberActivityBreakdownItem[];
+}
+
+/** One leaderboard entry (points only). */
+export interface TribeActivityLeaderboardEntry {
+    user_id:                number;
+    primary_character_id:   number | null;
+    primary_character_name: string;
+    alts:                   TribeCharacterRef[];
+    total_points:           number;
+}
+
+/** Paginated tribe activity leaderboard. */
+export interface TribeActivityLeaderboardList {
+    items:   TribeActivityLeaderboardEntry[];
+    total:   number;
+    limit:   number;
+    offset:  number;
+}
+
 export const activity_types = [
     'fleet_participation',
     'kills',


### PR DESCRIPTION
…ctivity, leaderboard

- Add points_per_record and points_per_unit to TribeGroupActivity (migration 0020)
- GET /{tribe_id}/activity/{activity_id}/metrics - per-activity metrics
- GET /{tribe_id}/members/{member_id}/activity - member activity summary (primary + alts, points, breakdown)
- GET /{tribe_id}/activity/leaderboard - paginated leaderboard (points only)
- Frontend types and API helpers for new endpoints

Made-with: Cursor