### PR TITLE
Enhance Discord voice tracking with generic activity records

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -27,7 +27,7 @@ jobs:
           flake8 .
       - name: Lint with black
         run: |
-          pip install black
+          pip install black==26.5.1
           black --check .
       - name: Run tests
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 # Install hooks: pre-commit install
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 26.5.1
     hooks:
       - id: black
         name: black (backend)

--- a/backend/app/settings_celery.py
+++ b/backend/app/settings_celery.py
@@ -270,6 +270,13 @@ CELERYBEAT_OTHER = [
         },
     ),
     (
+        "[Misc] Sync Discord Guilds",
+        {
+            "task": "discord.tasks.sync_discord_guilds_task",
+            "schedule": crontab(minute=0, hour="*/6"),
+        },
+    ),
+    (
         "[Misc] Sync Discord User Nicknames",
         {
             "task": "discord.tasks.sync_discord_user_nicknames",

--- a/backend/app/urls.py
+++ b/backend/app/urls.py
@@ -28,6 +28,7 @@ from tech.router import router as tech_router
 
 from applications.router import router as applications_router
 from combatlog.router import router as combatlog_router
+from discord.router import router as discord_router
 from discord.views import discord_login
 from eveonline.routers import router
 from fittings.router import doctrines_router, fittings_router
@@ -70,6 +71,7 @@ api.add_router("srp", srp_router)
 api.add_router("onboarding", onboarding_router)
 api.add_router("tech", tech_router)
 api.add_router("subscriptions", subscription_router)
+api.add_router("discord", discord_router)
 
 
 @api.exception_handler(UnauthorizedError)

--- a/backend/discord/admin.py
+++ b/backend/discord/admin.py
@@ -1,8 +1,10 @@
-from django.contrib import admin
+from django.contrib import admin, messages
 
 from eveonline.helpers.characters import user_primary_character
 
-from .models import DiscordUser, DiscordRole
+from .forms import DiscordChannelAdminForm
+from .guilds import sync_discord_guilds
+from .models import DiscordChannel, DiscordGuild, DiscordUser, DiscordRole
 
 
 @admin.register(DiscordUser)
@@ -18,3 +20,94 @@ class DiscordUserAdmin(admin.ModelAdmin):
 class DiscordRoleAdmin(admin.ModelAdmin):
     list_display = ("role_id", "name")
     search_fields = ("role_id", "name")
+
+
+@admin.register(DiscordGuild)
+class DiscordGuildAdmin(admin.ModelAdmin):
+    list_display = (
+        "name",
+        "guild_id",
+        "is_primary",
+        "is_active",
+        "last_seen_at",
+        "updated_at",
+    )
+    list_filter = ("is_primary", "is_active")
+    search_fields = ("name", "guild_id")
+    readonly_fields = (
+        "guild_id",
+        "name",
+        "is_primary",
+        "is_active",
+        "last_seen_at",
+        "created_at",
+        "updated_at",
+    )
+    actions = ("sync_guilds",)
+
+    def has_add_permission(self, request):
+        return False
+
+    @admin.action(description="Sync guilds from Discord")
+    def sync_guilds(self, request, queryset):
+        del queryset
+        try:
+            count = sync_discord_guilds()
+        except Exception as error:
+            self.message_user(
+                request,
+                f"Failed to sync Discord guilds: {error}",
+                level=messages.ERROR,
+            )
+            return
+        self.message_user(
+            request,
+            f"Synced {count} guild(s) from Discord.",
+            level=messages.SUCCESS,
+        )
+
+
+@admin.register(DiscordChannel)
+class DiscordChannelAdmin(admin.ModelAdmin):
+    form = DiscordChannelAdminForm
+    list_display = (
+        "name",
+        "guild",
+        "channel_type",
+        "track_voice_activity",
+        "channel_id",
+        "updated_at",
+    )
+    list_filter = ("guild", "channel_type", "track_voice_activity")
+    search_fields = ("name", "channel_id", "guild__name")
+    readonly_fields = (
+        "channel_id",
+        "name",
+        "channel_type",
+        "created_at",
+        "updated_at",
+    )
+
+    def get_fields(self, request, obj=None):
+        if obj:
+            return (
+                "guild",
+                "channel_id",
+                "name",
+                "channel_type",
+                "track_voice_activity",
+                "created_at",
+                "updated_at",
+            )
+        return ("discord_channel_pick", "track_voice_activity")
+
+    def save_model(self, request, obj, form, change):
+        super().save_model(request, obj, form, change)
+        if (
+            not change
+            and not DiscordGuild.objects.filter(is_active=True).exists()
+        ):
+            messages.warning(
+                request,
+                "No active Discord guilds are synced yet. Run “Sync guilds from Discord”.",
+            )

--- a/backend/discord/channels.py
+++ b/backend/discord/channels.py
@@ -1,0 +1,42 @@
+import logging
+
+import requests
+
+from discord.client import DiscordClient
+from discord.models import DiscordGuild
+
+logger = logging.getLogger(__name__)
+discord = DiscordClient()
+
+ADMIN_PICKER_CHANNEL_TYPES = {"text", "voice", "stage", "forum"}
+VOICE_TRACKING_CHANNEL_TYPES = {"voice", "stage"}
+
+
+def fetch_guild_channels(guild_id=None):
+    """Return guild channels from the Discord API."""
+    try:
+        return discord.get_guild_channels(guild_id=guild_id)
+    except requests.RequestException:
+        logger.exception("Failed to fetch Discord guild channels")
+        return []
+
+
+def fetch_active_guild_channels():
+    """Return channels for all active tracked guilds."""
+    channels = []
+    for guild in DiscordGuild.objects.filter(is_active=True).order_by("name"):
+        channels.extend(fetch_guild_channels(guild_id=guild.guild_id))
+    return channels
+
+
+def get_guild_channel(channel_id: int, guild_id=None):
+    """Return a single guild channel by ID, or None if not found."""
+    channel_list = (
+        fetch_guild_channels(guild_id=guild_id)
+        if guild_id is not None
+        else fetch_active_guild_channels()
+    )
+    for channel in channel_list:
+        if channel["id"] == channel_id:
+            return channel
+    return None

--- a/backend/discord/client.py
+++ b/backend/discord/client.py
@@ -365,3 +365,35 @@ class DiscordClient(DiscordBaseClient):
                 "name": name,
             },
         ).json()
+
+    def get_guild_channels(self, guild_id=None):
+        """Get all channels from a guild."""
+        type_map = {
+            0: "text",
+            2: "voice",
+            4: "category",
+            13: "stage",
+            15: "forum",
+        }
+        target_guild_id = guild_id or self.guild_id
+        channels = self.get(f"{BASE_URL}/guilds/{target_guild_id}/channels")
+        return [
+            {
+                "id": int(channel["id"]),
+                "name": channel["name"],
+                "type": type_map.get(channel["type"], "unknown"),
+                "guild_id": int(target_guild_id),
+            }
+            for channel in channels
+        ]
+
+    def get_bot_guilds(self):
+        """Get all guilds the bot user is a member of."""
+        guilds = self.get(f"{BASE_URL}/users/@me/guilds")
+        return [
+            {
+                "id": int(guild["id"]),
+                "name": guild["name"],
+            }
+            for guild in guilds
+        ]

--- a/backend/discord/forms.py
+++ b/backend/discord/forms.py
@@ -1,0 +1,134 @@
+from django import forms
+from django.core.exceptions import ValidationError
+
+from discord.channels import (
+    ADMIN_PICKER_CHANNEL_TYPES,
+    VOICE_TRACKING_CHANNEL_TYPES,
+    fetch_active_guild_channels,
+    get_guild_channel,
+)
+from discord.models import DiscordChannel, DiscordGuild
+
+
+class DiscordChannelAdminForm(forms.ModelForm):
+    discord_channel_pick = forms.ChoiceField(
+        choices=[],
+        required=False,
+        label="Discord channel",
+        help_text="Select a channel from an active synced guild.",
+    )
+
+    class Meta:
+        model = DiscordChannel
+        fields = ("track_voice_activity",)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        channels = fetch_active_guild_channels()
+        channel_guild_names = {
+            guild.guild_id: guild.name
+            for guild in DiscordGuild.objects.filter(is_active=True)
+        }
+        choices = [("", "---------")]
+        for channel in channels:
+            if channel["type"] not in ADMIN_PICKER_CHANNEL_TYPES:
+                continue
+            guild_name = channel_guild_names.get(
+                channel["guild_id"], "Unknown guild"
+            )
+            label = f"{guild_name} / {channel['name']} ({channel['type']})"
+            choices.append((str(channel["id"]), label))
+
+        self.fields["discord_channel_pick"].choices = choices
+
+        if self.instance.pk:
+            del self.fields["discord_channel_pick"]
+            self.fields["guild"] = forms.ModelChoiceField(
+                queryset=DiscordGuild.objects.all(),
+                disabled=True,
+                required=False,
+                initial=self.instance.guild,
+            )
+            self.fields["name"] = forms.CharField(
+                disabled=True,
+                required=False,
+                initial=self.instance.name,
+            )
+            self.fields["channel_type"] = forms.CharField(
+                disabled=True,
+                required=False,
+                initial=self.instance.get_channel_type_display(),
+            )
+            self.fields["channel_id"] = forms.IntegerField(
+                disabled=True,
+                required=False,
+                initial=self.instance.channel_id,
+            )
+        elif not channels:
+            self.fields["discord_channel_pick"].help_text = (
+                "No channels found. Sync Discord guilds first, then try again."
+            )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        track_voice_activity = cleaned_data.get("track_voice_activity", False)
+
+        if self.instance.pk:
+            channel_type = self.instance.channel_type
+        else:
+            channel_id_raw = cleaned_data.get("discord_channel_pick")
+            if not channel_id_raw:
+                raise ValidationError(
+                    {"discord_channel_pick": "Select a Discord channel."}
+                )
+            channel = get_guild_channel(int(channel_id_raw))
+            if channel is None:
+                raise ValidationError(
+                    {
+                        "discord_channel_pick": "Selected channel was not found on Discord."
+                    }
+                )
+            cleaned_data["_selected_channel"] = channel
+            channel_type = channel["type"]
+            guild = DiscordGuild.objects.filter(
+                guild_id=channel["guild_id"], is_active=True
+            ).first()
+            if guild is None:
+                raise ValidationError(
+                    {
+                        "discord_channel_pick": (
+                            "Selected channel belongs to a guild that is not synced yet."
+                        )
+                    }
+                )
+            cleaned_data["_selected_guild"] = guild
+
+        if (
+            track_voice_activity
+            and channel_type not in VOICE_TRACKING_CHANNEL_TYPES
+        ):
+            raise ValidationError(
+                {
+                    "track_voice_activity": (
+                        "Voice activity tracking is only supported for voice and stage channels."
+                    )
+                }
+            )
+
+        return cleaned_data
+
+    def save(self, commit=True):
+        instance = super().save(commit=False)
+        selected_channel = self.cleaned_data.get("_selected_channel")
+        selected_guild = self.cleaned_data.get("_selected_guild")
+        if selected_channel:
+            instance.channel_id = selected_channel["id"]
+            instance.name = selected_channel["name"]
+            instance.channel_type = selected_channel["type"]
+        if selected_guild:
+            instance.guild = selected_guild
+
+        if commit:
+            instance.save()
+        return instance

--- a/backend/discord/guilds.py
+++ b/backend/discord/guilds.py
@@ -1,0 +1,43 @@
+import logging
+
+from django.conf import settings
+from django.utils import timezone
+
+from discord.client import DiscordClient
+from discord.models import DiscordGuild
+
+logger = logging.getLogger(__name__)
+discord = DiscordClient()
+
+
+def sync_discord_guilds(source_guilds=None):
+    """
+    Upsert DiscordGuild rows from the Discord API or an explicit guild list.
+
+    When source_guilds is omitted, fetches guild membership via the bot token.
+    Guilds missing from the latest sync are marked inactive rather than deleted.
+    """
+    if source_guilds is None:
+        source_guilds = discord.get_bot_guilds()
+
+    now = timezone.now()
+    seen_ids = []
+    for guild in source_guilds:
+        guild_id = int(guild["id"])
+        seen_ids.append(guild_id)
+        DiscordGuild.objects.update_or_create(
+            guild_id=guild_id,
+            defaults={
+                "name": guild["name"],
+                "last_seen_at": now,
+                "is_active": True,
+            },
+        )
+
+    DiscordGuild.objects.exclude(guild_id__in=seen_ids).update(is_active=False)
+
+    primary_id = settings.DISCORD_GUILD_ID
+    DiscordGuild.objects.filter(guild_id=primary_id).update(is_primary=True)
+    DiscordGuild.objects.exclude(guild_id=primary_id).update(is_primary=False)
+
+    return len(seen_ids)

--- a/backend/discord/migrations/0012_discordvoiceminuterecord.py
+++ b/backend/discord/migrations/0012_discordvoiceminuterecord.py
@@ -1,0 +1,113 @@
+from django.db import migrations, models
+
+
+def adopt_or_create_table(apps, schema_editor):
+    table_name = "standingfleet_standingfleetvoicerecord"
+    if table_name in schema_editor.connection.introspection.table_names():
+        return
+
+    if schema_editor.connection.vendor == "mysql":
+        schema_editor.execute(
+            """
+            CREATE TABLE standingfleet_standingfleetvoicerecord (
+                id BIGINT AUTO_INCREMENT NOT NULL PRIMARY KEY,
+                created_on datetime(6) NOT NULL,
+                username varchar(255) NOT NULL,
+                minutes integer NOT NULL
+            )
+            """
+        )
+        schema_editor.execute(
+            """
+            CREATE INDEX created_on_idx
+            ON standingfleet_standingfleetvoicerecord (created_on)
+            """
+        )
+        schema_editor.execute(
+            """
+            CREATE INDEX username_idx
+            ON standingfleet_standingfleetvoicerecord (username)
+            """
+        )
+        return
+
+    schema_editor.execute(
+        """
+        CREATE TABLE standingfleet_standingfleetvoicerecord (
+            id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+            created_on datetime NOT NULL,
+            username varchar(255) NOT NULL,
+            minutes integer NOT NULL
+        )
+        """
+    )
+    schema_editor.execute(
+        """
+        CREATE INDEX created_on_idx
+        ON standingfleet_standingfleetvoicerecord (created_on)
+        """
+    )
+    schema_editor.execute(
+        """
+        CREATE INDEX username_idx
+        ON standingfleet_standingfleetvoicerecord (username)
+        """
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        (
+            "discord",
+            "0011_discordrole_created_at_discordrole_updated_at_and_more",
+        ),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.CreateModel(
+                    name="DiscordVoiceMinuteRecord",
+                    fields=[
+                        (
+                            "id",
+                            models.BigAutoField(
+                                auto_created=True,
+                                primary_key=True,
+                                serialize=False,
+                                verbose_name="ID",
+                            ),
+                        ),
+                        (
+                            "created_on",
+                            models.DateTimeField(auto_now_add=True),
+                        ),
+                        ("username", models.CharField(max_length=255)),
+                        ("minutes", models.IntegerField()),
+                    ],
+                    options={
+                        "db_table": "standingfleet_standingfleetvoicerecord",
+                    },
+                ),
+                migrations.AddIndex(
+                    model_name="discordvoiceminuterecord",
+                    index=models.Index(
+                        fields=["created_on"], name="created_on_idx"
+                    ),
+                ),
+                migrations.AddIndex(
+                    model_name="discordvoiceminuterecord",
+                    index=models.Index(
+                        fields=["username"], name="username_idx"
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunPython(
+                    adopt_or_create_table,
+                    migrations.RunPython.noop,
+                ),
+            ],
+        ),
+    ]

--- a/backend/discord/migrations/0012_discordvoiceminuterecord.py
+++ b/backend/discord/migrations/0012_discordvoiceminuterecord.py
@@ -7,52 +7,40 @@ def adopt_or_create_table(apps, schema_editor):
         return
 
     if schema_editor.connection.vendor == "mysql":
-        schema_editor.execute(
-            """
+        schema_editor.execute("""
             CREATE TABLE standingfleet_standingfleetvoicerecord (
                 id BIGINT AUTO_INCREMENT NOT NULL PRIMARY KEY,
                 created_on datetime(6) NOT NULL,
                 username varchar(255) NOT NULL,
                 minutes integer NOT NULL
             )
-            """
-        )
-        schema_editor.execute(
-            """
+            """)
+        schema_editor.execute("""
             CREATE INDEX created_on_idx
             ON standingfleet_standingfleetvoicerecord (created_on)
-            """
-        )
-        schema_editor.execute(
-            """
+            """)
+        schema_editor.execute("""
             CREATE INDEX username_idx
             ON standingfleet_standingfleetvoicerecord (username)
-            """
-        )
+            """)
         return
 
-    schema_editor.execute(
-        """
+    schema_editor.execute("""
         CREATE TABLE standingfleet_standingfleetvoicerecord (
             id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
             created_on datetime NOT NULL,
             username varchar(255) NOT NULL,
             minutes integer NOT NULL
         )
-        """
-    )
-    schema_editor.execute(
-        """
+        """)
+    schema_editor.execute("""
         CREATE INDEX created_on_idx
         ON standingfleet_standingfleetvoicerecord (created_on)
-        """
-    )
-    schema_editor.execute(
-        """
+        """)
+    schema_editor.execute("""
         CREATE INDEX username_idx
         ON standingfleet_standingfleetvoicerecord (username)
-        """
-    )
+        """)
 
 
 class Migration(migrations.Migration):

--- a/backend/discord/migrations/0013_discordvoiceminuterecord_channel_fields.py
+++ b/backend/discord/migrations/0013_discordvoiceminuterecord_channel_fields.py
@@ -1,0 +1,45 @@
+from django.db import migrations, models
+
+LEGACY_STANDING_FLEET_CHANNEL_ID = 1306515072650313728
+
+
+def backfill_legacy_channel_id(apps, schema_editor):
+    record_model = apps.get_model("discord", "DiscordVoiceMinuteRecord")
+    record_model.objects.filter(channel_id__isnull=True).update(
+        channel_id=LEGACY_STANDING_FLEET_CHANNEL_ID
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("discord", "0012_discordvoiceminuterecord"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="discordvoiceminuterecord",
+            name="channel_id",
+            field=models.BigIntegerField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="discordvoiceminuterecord",
+            name="channel_name",
+            field=models.CharField(blank=True, max_length=255, null=True),
+        ),
+        migrations.RunPython(
+            backfill_legacy_channel_id,
+            migrations.RunPython.noop,
+        ),
+        migrations.AlterModelTable(
+            name="discordvoiceminuterecord",
+            table="discord_discordvoiceminuterecord",
+        ),
+        migrations.AddIndex(
+            model_name="discordvoiceminuterecord",
+            index=models.Index(
+                fields=["channel_id", "created_on"],
+                name="channel_created_on_idx",
+            ),
+        ),
+    ]

--- a/backend/discord/migrations/0014_discordchannel.py
+++ b/backend/discord/migrations/0014_discordchannel.py
@@ -1,0 +1,53 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("discord", "0013_discordvoiceminuterecord_channel_fields"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DiscordChannel",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("channel_id", models.BigIntegerField(unique=True)),
+                ("name", models.CharField(max_length=255)),
+                (
+                    "channel_type",
+                    models.CharField(
+                        choices=[
+                            ("text", "Text"),
+                            ("voice", "Voice"),
+                            ("stage", "Stage"),
+                            ("forum", "Forum"),
+                            ("category", "Category"),
+                            ("unknown", "Unknown"),
+                        ],
+                        max_length=32,
+                    ),
+                ),
+                (
+                    "track_voice_activity",
+                    models.BooleanField(
+                        default=False,
+                        help_text="When enabled, the bot records voice presence in this channel each minute.",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "ordering": ["name"],
+            },
+        ),
+    ]

--- a/backend/discord/migrations/0015_discordchannelactivityrecord.py
+++ b/backend/discord/migrations/0015_discordchannelactivityrecord.py
@@ -1,0 +1,43 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("discord", "0014_discordchannel"),
+    ]
+
+    operations = [
+        migrations.RenameModel(
+            old_name="DiscordVoiceMinuteRecord",
+            new_name="DiscordChannelActivityRecord",
+        ),
+        migrations.RenameField(
+            model_name="discordchannelactivityrecord",
+            old_name="minutes",
+            new_name="quantity",
+        ),
+        migrations.AddField(
+            model_name="discordchannelactivityrecord",
+            name="activity_type",
+            field=models.CharField(
+                choices=[
+                    ("text_message", "Text message"),
+                    ("voice_minute", "Voice minute"),
+                ],
+                default="voice_minute",
+                max_length=32,
+            ),
+        ),
+        migrations.AlterModelTable(
+            name="discordchannelactivityrecord",
+            table="discord_discordchannelactivityrecord",
+        ),
+        migrations.AddIndex(
+            model_name="discordchannelactivityrecord",
+            index=models.Index(
+                fields=["activity_type", "created_on"],
+                name="activity_type_created_on_idx",
+            ),
+        ),
+    ]

--- a/backend/discord/migrations/0016_discordguild.py
+++ b/backend/discord/migrations/0016_discordguild.py
@@ -1,0 +1,47 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("discord", "0015_discordchannelactivityrecord"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DiscordGuild",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("guild_id", models.BigIntegerField(unique=True)),
+                ("name", models.CharField(max_length=255)),
+                (
+                    "is_primary",
+                    models.BooleanField(
+                        default=False,
+                        help_text="Matches DISCORD_GUILD_ID in application settings.",
+                    ),
+                ),
+                (
+                    "is_active",
+                    models.BooleanField(
+                        default=True,
+                        help_text="Bot was present in this guild on the last sync.",
+                    ),
+                ),
+                ("last_seen_at", models.DateTimeField(blank=True, null=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "ordering": ["name"],
+            },
+        ),
+    ]

--- a/backend/discord/migrations/0017_discordchannel_guild.py
+++ b/backend/discord/migrations/0017_discordchannel_guild.py
@@ -1,0 +1,54 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def backfill_discord_channel_guild(apps, schema_editor):
+    discord_guild = apps.get_model("discord", "DiscordGuild")
+    discord_channel = apps.get_model("discord", "DiscordChannel")
+
+    primary_guild, _ = discord_guild.objects.get_or_create(
+        guild_id=settings.DISCORD_GUILD_ID,
+        defaults={
+            "name": "Primary guild",
+            "is_primary": True,
+            "is_active": True,
+        },
+    )
+    discord_channel.objects.filter(guild__isnull=True).update(
+        guild=primary_guild
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("discord", "0016_discordguild"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="discordchannel",
+            name="guild",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="channels",
+                to="discord.discordguild",
+            ),
+        ),
+        migrations.RunPython(
+            backfill_discord_channel_guild,
+            migrations.RunPython.noop,
+        ),
+        migrations.AlterField(
+            model_name="discordchannel",
+            name="guild",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="channels",
+                to="discord.discordguild",
+            ),
+        ),
+    ]

--- a/backend/discord/models.py
+++ b/backend/discord/models.py
@@ -65,3 +65,103 @@ class DiscordRole(models.Model):
         indexes = [
             models.Index(fields=["role_id"]),
         ]
+
+
+class DiscordChannelActivityRecord(models.Model):
+    TEXT_MESSAGE = "text_message"
+    VOICE_MINUTE = "voice_minute"
+
+    ACTIVITY_TYPE_CHOICES = [
+        (TEXT_MESSAGE, "Text message"),
+        (VOICE_MINUTE, "Voice minute"),
+    ]
+
+    created_on = models.DateTimeField(auto_now_add=True)
+    activity_type = models.CharField(
+        max_length=32, choices=ACTIVITY_TYPE_CHOICES
+    )
+    username = models.CharField(max_length=255)
+    quantity = models.IntegerField(
+        help_text="Minutes for voice activity, message count for text activity."
+    )
+    channel_id = models.BigIntegerField(null=True, blank=True)
+    channel_name = models.CharField(max_length=255, null=True, blank=True)
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["created_on"], name="created_on_idx"),
+            models.Index(fields=["username"], name="username_idx"),
+            models.Index(
+                fields=["channel_id", "created_on"],
+                name="channel_created_on_idx",
+            ),
+            models.Index(
+                fields=["activity_type", "created_on"],
+                name="activity_type_created_on_idx",
+            ),
+        ]
+
+
+class DiscordGuild(models.Model):
+    guild_id = models.BigIntegerField(unique=True)
+    name = models.CharField(max_length=255)
+    is_primary = models.BooleanField(
+        default=False,
+        help_text="Matches DISCORD_GUILD_ID in application settings.",
+    )
+    is_active = models.BooleanField(
+        default=True,
+        help_text="Bot was present in this guild on the last sync.",
+    )
+    last_seen_at = models.DateTimeField(null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ["name"]
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class DiscordChannel(models.Model):
+    TEXT = "text"
+    VOICE = "voice"
+    STAGE = "stage"
+    FORUM = "forum"
+    CATEGORY = "category"
+    UNKNOWN = "unknown"
+
+    CHANNEL_TYPE_CHOICES = [
+        (TEXT, "Text"),
+        (VOICE, "Voice"),
+        (STAGE, "Stage"),
+        (FORUM, "Forum"),
+        (CATEGORY, "Category"),
+        (UNKNOWN, "Unknown"),
+    ]
+
+    channel_id = models.BigIntegerField(unique=True)
+    guild = models.ForeignKey(
+        DiscordGuild,
+        on_delete=models.CASCADE,
+        related_name="channels",
+    )
+    name = models.CharField(max_length=255)
+    channel_type = models.CharField(
+        max_length=32, choices=CHANNEL_TYPE_CHOICES
+    )
+    track_voice_activity = models.BooleanField(
+        default=False,
+        help_text=(
+            "When enabled, the bot records voice presence in this channel each minute."
+        ),
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ["name"]
+
+    def __str__(self) -> str:
+        return f"{self.name} ({self.get_channel_type_display()})"

--- a/backend/discord/router.py
+++ b/backend/discord/router.py
@@ -1,0 +1,144 @@
+from ninja import Router
+from pydantic import BaseModel
+
+from authentication import AuthBearer
+from discord.channels import VOICE_TRACKING_CHANNEL_TYPES
+from discord.guilds import sync_discord_guilds
+from discord.models import DiscordChannel, DiscordChannelActivityRecord
+
+router = Router(tags=["Discord"])
+
+
+class SyncGuildItem(BaseModel):
+    id: int
+    name: str
+
+
+class SyncGuildsRequest(BaseModel):
+    guilds: list[SyncGuildItem]
+
+
+class SyncGuildsResponse(BaseModel):
+    synced: int
+
+
+class CreateActivityRecordRequest(BaseModel):
+    activity_type: str
+    quantity: int
+    channel_id: int
+    channel_name: str
+    usernames: list[str]
+
+
+class CreateVoiceTrackingRequest(BaseModel):
+    minutes: int
+    channel_id: int
+    channel_name: str
+    usernames: list[str]
+
+
+class ActivityRecordResponse(BaseModel):
+    ids: list[int]
+
+
+class TrackedVoiceChannelResponse(BaseModel):
+    channel_id: int
+    name: str
+
+
+class TrackedVoiceChannelsResponse(BaseModel):
+    channels: list[TrackedVoiceChannelResponse]
+
+
+@router.post(
+    "/guilds/sync",
+    response=SyncGuildsResponse,
+    auth=AuthBearer(),
+)
+def sync_guilds_from_bot(request, payload: SyncGuildsRequest):
+    synced = sync_discord_guilds(
+        source_guilds=[
+            {"id": guild.id, "name": guild.name} for guild in payload.guilds
+        ]
+    )
+    return {"synced": synced}
+
+
+@router.get(
+    "/voicetracking/channels",
+    response=TrackedVoiceChannelsResponse,
+    auth=AuthBearer(),
+)
+def get_tracked_voice_channels(request):
+    channels = DiscordChannel.objects.filter(
+        track_voice_activity=True,
+        channel_type__in=VOICE_TRACKING_CHANNEL_TYPES,
+    ).order_by("name")
+    return {
+        "channels": [
+            {"channel_id": channel.channel_id, "name": channel.name}
+            for channel in channels
+        ]
+    }
+
+
+def _is_voice_minute_allowed(channel_id: int) -> bool:
+    return DiscordChannel.objects.filter(
+        channel_id=channel_id,
+        track_voice_activity=True,
+        channel_type__in=VOICE_TRACKING_CHANNEL_TYPES,
+    ).exists()
+
+
+@router.post(
+    "/activity/records",
+    response=ActivityRecordResponse,
+    auth=AuthBearer(),
+)
+def create_activity_records(request, payload: CreateActivityRecordRequest):
+    valid_types = {
+        choice[0]
+        for choice in DiscordChannelActivityRecord.ACTIVITY_TYPE_CHOICES
+    }
+    if payload.activity_type not in valid_types:
+        return {"ids": []}
+
+    if payload.activity_type == DiscordChannelActivityRecord.VOICE_MINUTE:
+        if not _is_voice_minute_allowed(payload.channel_id):
+            return {"ids": []}
+    elif payload.activity_type == DiscordChannelActivityRecord.TEXT_MESSAGE:
+        return {"ids": []}
+
+    records = DiscordChannelActivityRecord.objects.bulk_create(
+        [
+            DiscordChannelActivityRecord(
+                activity_type=payload.activity_type,
+                username=username,
+                quantity=payload.quantity,
+                channel_id=payload.channel_id,
+                channel_name=payload.channel_name,
+            )
+            for username in payload.usernames
+        ]
+    )
+    return {"ids": [record.id for record in records]}
+
+
+@router.post(
+    "/voicetracking/records",
+    response=ActivityRecordResponse,
+    auth=AuthBearer(),
+)
+def create_voice_tracking_records(
+    request, payload: CreateVoiceTrackingRequest
+):
+    return create_activity_records(
+        request,
+        CreateActivityRecordRequest(
+            activity_type=DiscordChannelActivityRecord.VOICE_MINUTE,
+            quantity=payload.minutes,
+            channel_id=payload.channel_id,
+            channel_name=payload.channel_name,
+            usernames=payload.usernames,
+        ),
+    )

--- a/backend/discord/tasks.py
+++ b/backend/discord/tasks.py
@@ -12,10 +12,22 @@ from .helpers import (
     notify_technology_team,
     remove_all_roles_from_guild_member,
 )
+from .guilds import sync_discord_guilds
 from .models import DiscordRole, DiscordUser
 
 discord = DiscordClient()
 logger = logging.getLogger(__name__)
+
+
+@app.task()
+def sync_discord_guilds_task():
+    try:
+        count = sync_discord_guilds()
+        logger.info("Synced %s Discord guild(s)", count)
+    except Exception as error:
+        notify_technology_team("sync_discord_guilds")
+        logger.exception("Failed to sync Discord guilds: %s", error)
+        raise
 
 
 @app.task()

--- a/backend/discord/tests.py
+++ b/backend/discord/tests.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch, Mock, MagicMock
 
 from django.contrib.auth.models import User, Group
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, Client
 from django.db.models import signals
 
 from eveonline.models import (
@@ -13,7 +13,15 @@ from eveonline.helpers.characters import set_primary_character
 
 from app.test import TestCase
 from discord.core import DISCORD_NICKNAME_MAX_LENGTH, make_nickname
-from discord.models import DiscordUser, DiscordRole
+from discord.models import (
+    DiscordUser,
+    DiscordRole,
+    DiscordChannelActivityRecord,
+    DiscordChannel,
+    DiscordGuild,
+)
+from discord.forms import DiscordChannelAdminForm
+from discord.guilds import sync_discord_guilds
 from discord.views import discord_login_redirect, fake_login
 
 from discord.tasks import sync_discord_nickname, sync_discord_user
@@ -284,6 +292,199 @@ class DiscordTests(TestCase):
         # Should not raise, should just return
         remove_all_roles_from_guild_member(12345)
         mock_discord.remove_user_role.assert_not_called()
+
+
+class VoiceTrackingRouterTestCase(TestCase):
+    """Test cases for Discord voice tracking ingestion."""
+
+    def setUp(self):
+        self.client = Client()
+        super().setUp()
+        self.guild, _ = DiscordGuild.objects.get_or_create(
+            guild_id=1041384161505722368,
+            defaults={
+                "name": "Minmatar",
+                "is_primary": True,
+                "is_active": True,
+            },
+        )
+        self.channel = DiscordChannel.objects.create(
+            guild=self.guild,
+            channel_id=1306515072650313728,
+            name="Fleet 1",
+            channel_type=DiscordChannel.VOICE,
+            track_voice_activity=True,
+        )
+
+    def test_get_tracked_voice_channels(self):
+        DiscordChannel.objects.create(
+            guild=self.guild,
+            channel_id=999,
+            name="AFK",
+            channel_type=DiscordChannel.VOICE,
+            track_voice_activity=False,
+        )
+
+        response = self.client.get(
+            "/api/discord/voicetracking/channels",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+
+        self.assertEqual(200, response.status_code)
+        channels = response.json()["channels"]
+        self.assertEqual(1, len(channels))
+        self.assertEqual(1306515072650313728, channels[0]["channel_id"])
+        self.assertEqual("Fleet 1", channels[0]["name"])
+
+    def test_create_voice_tracking_records(self):
+        data = {
+            "minutes": 7,
+            "channel_id": self.channel.channel_id,
+            "channel_name": self.channel.name,
+            "usernames": [self.user.username],
+        }
+
+        response = self.client.post(
+            "/api/discord/voicetracking/records",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+
+        self.assertEqual(200, response.status_code)
+        ids = response.json()["ids"]
+        self.assertEqual(1, len(ids))
+
+        record = DiscordChannelActivityRecord.objects.get(id=ids[0])
+        self.assertEqual(
+            DiscordChannelActivityRecord.VOICE_MINUTE, record.activity_type
+        )
+        self.assertEqual(7, record.quantity)
+        self.assertEqual(self.channel.channel_id, record.channel_id)
+        self.assertEqual("Fleet 1", record.channel_name)
+
+    def test_create_activity_records(self):
+        data = {
+            "activity_type": DiscordChannelActivityRecord.VOICE_MINUTE,
+            "quantity": 3,
+            "channel_id": self.channel.channel_id,
+            "channel_name": self.channel.name,
+            "usernames": [self.user.username],
+        }
+
+        response = self.client.post(
+            "/api/discord/activity/records",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+
+        self.assertEqual(200, response.status_code)
+        record = DiscordChannelActivityRecord.objects.get(
+            id=response.json()["ids"][0]
+        )
+        self.assertEqual(
+            DiscordChannelActivityRecord.VOICE_MINUTE, record.activity_type
+        )
+        self.assertEqual(3, record.quantity)
+
+    def test_create_voice_tracking_records_ignores_untracked_channel(self):
+        data = {
+            "minutes": 7,
+            "channel_id": 123456789,
+            "channel_name": "Untracked",
+            "usernames": [self.user.username],
+        }
+
+        response = self.client.post(
+            "/api/discord/voicetracking/records",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual([], response.json()["ids"])
+        self.assertEqual(0, DiscordChannelActivityRecord.objects.count())
+
+
+class DiscordGuildSyncTestCase(TestCase):
+    def setUp(self):
+        self.client = Client()
+        super().setUp()
+
+    @patch("discord.guilds.discord.get_bot_guilds")
+    def test_sync_discord_guilds_from_api(self, mock_get_bot_guilds):
+        mock_get_bot_guilds.return_value = [
+            {"id": 1041384161505722368, "name": "Minmatar"},
+            {"id": 999, "name": "Other Server"},
+        ]
+
+        synced = sync_discord_guilds()
+
+        self.assertEqual(2, synced)
+        self.assertTrue(
+            DiscordGuild.objects.get(guild_id=1041384161505722368).is_primary
+        )
+        self.assertTrue(DiscordGuild.objects.get(guild_id=999).is_active)
+
+        mock_get_bot_guilds.return_value = [
+            {"id": 1041384161505722368, "name": "Minmatar"},
+        ]
+        sync_discord_guilds()
+        self.assertFalse(DiscordGuild.objects.get(guild_id=999).is_active)
+
+    def test_sync_guilds_from_bot_endpoint(self):
+        response = self.client.post(
+            "/api/discord/guilds/sync",
+            {
+                "guilds": [
+                    {"id": 1041384161505722368, "name": "Minmatar"},
+                ]
+            },
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(1, response.json()["synced"])
+        guild = DiscordGuild.objects.get(guild_id=1041384161505722368)
+        self.assertEqual("Minmatar", guild.name)
+        self.assertTrue(guild.is_active)
+
+
+class DiscordChannelAdminFormTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.guild = DiscordGuild.objects.create(
+            guild_id=999888777,
+            name="Test Guild",
+            is_active=True,
+        )
+
+    @patch("discord.forms.fetch_active_guild_channels")
+    @patch("discord.forms.get_guild_channel")
+    def test_track_voice_activity_rejected_for_text_channel(
+        self, mock_get_channel, mock_fetch_active
+    ):
+        mock_fetch_active.return_value = [
+            {
+                "id": 123,
+                "name": "general",
+                "type": "text",
+                "guild_id": self.guild.guild_id,
+            },
+        ]
+        mock_get_channel.return_value = mock_fetch_active.return_value[0]
+        form = DiscordChannelAdminForm(
+            data={
+                "discord_channel_pick": "123",
+                "track_voice_activity": True,
+            }
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("track_voice_activity", form.errors)
 
 
 if __name__ == "__main__":

--- a/backend/tech/seed_data.py
+++ b/backend/tech/seed_data.py
@@ -18,6 +18,7 @@ from market.models import EveMarketContractExpectation
 from groups.models import AffiliationType, EveCorporationGroup
 from fittings.models import EveDoctrine, EveDoctrineFitting, EveFitting
 from fleets.models import EveFleetAudience, EveLocation
+from discord.channels import fetch_guild_channels
 
 logger = logging.getLogger(__name__)
 
@@ -251,29 +252,22 @@ def seed_fleet_audiences():
         logger.error("Alliance group not found")
         return
 
-    discord_channels = get_discord_channels()  # Call the function!
+    discord_channels = fetch_guild_channels()
 
     alliance_pings_channel_id = None
-    fleet1_voice_channel = None
 
     for channel in discord_channels:
         if channel["name"] == "alliance-pings" and channel["type"] == "text":
             alliance_pings_channel_id = channel["id"]
-        if channel["name"] == "Fleet 1" and channel["type"] == "voice":
-            fleet1_voice_channel = channel["id"]
 
-    if not alliance_pings_channel_id or not fleet1_voice_channel:
-        logger.error(
-            "Discord channels for alliance pings or fleet voice not found"
-        )
+    if not alliance_pings_channel_id:
+        logger.error("Discord channel for alliance pings not found")
         return
     fleet_audience, created = EveFleetAudience.objects.get_or_create(
         name="Alliance",
         defaults={
             "discord_channel_id": alliance_pings_channel_id,
             "discord_channel_name": "alliance-pings",
-            "discord_voice_channel_name": "Fleet 1",
-            "discord_voice_channel": fleet1_voice_channel,
             "add_to_schedule": True,
             "hidden": False,
         },
@@ -431,28 +425,3 @@ def find_discord_channel_id(channel_name, discord_channels):
         ):
             return channel["id"]
     return None
-
-
-def get_discord_channels():
-    """Get all channels from Discord server"""
-    session = requests.Session()
-    access_token = settings.DISCORD_BOT_TOKEN
-    guild_id = settings.DISCORD_GUILD_ID
-
-    response = session.get(
-        f"https://discord.com/api/v9/guilds/{guild_id}/channels",
-        headers={"Authorization": f"Bot {access_token}"},
-        timeout=10,
-    )
-    response.raise_for_status()
-    response_data = response.json()
-
-    type_map = {0: "text", 2: "voice", 4: "category", 13: "stage", 15: "forum"}
-    return [
-        {
-            "name": channel["name"],
-            "type": type_map.get(channel["type"], "unknown"),
-            "id": channel["id"],
-        }
-        for channel in response_data
-    ]

--- a/bot/app/client.py
+++ b/bot/app/client.py
@@ -3,36 +3,43 @@ import asyncio
 import discord
 import requests
 from discord import app_commands
+from discord.ext import tasks
 
 from app.settings import settings
 
 from .timer_form import TimerForm
+from .voicetracking_api import (
+    ACTIVITY_RECORDS_URL,
+    GUILDS_SYNC_URL,
+    TRACKED_VOICE_CHANNELS_URL,
+    CreateActivityRecordRequest,
+    SyncGuildsRequest,
+    SyncGuildItem,
+    TrackedVoiceChannelsResponse,
+)
 
 GUILD_ID = settings.DISCORD_GUILD_ID
 GUILD_IDS = [GUILD_ID]
 GUILDS = [discord.Object(id=guild_id) for guild_id in GUILD_IDS]
 
+
 class MyClient(discord.Client):
     def __init__(self) -> None:
-        # Just default intents and a `discord.Client` instance
-        # We don't need a `commands.Bot` instance because we are not
-        # creating text-based commands.
         intents = discord.Intents.default()
         intents.guilds = True
-        intents.voice_states = True  # Needed to access voice state information
-        intents.members = True  # Needed to access member information
+        intents.voice_states = True
+        intents.members = True
         super().__init__(intents=intents)
 
-        # We need an `discord.app_commands.CommandTree` instance
-        # to register application commands (slash commands in this case)
         self.tree = app_commands.CommandTree(self)
 
     async def on_ready(self):
         print(f"Logged in as {self.user} (ID: {self.user.id})")
         print("------")
+        await sync_guilds_to_api()
+        track_voice_channels.start()
 
     async def setup_hook(self) -> None:
-        # Sync the application command with Discord.
         for guild in GUILDS:
             print(f"Syncing commands for {guild.id}")
             await self.tree.sync(guild=guild)
@@ -46,9 +53,6 @@ RAT_QUOTE_URL = f"{settings.API_URL}/reminders/rat-quote"
 
 @client.tree.command(guilds=GUILDS, description="Submit a timer")
 async def timer(interaction: discord.Interaction):
-    # Send the modal with an instance of our `Feedback` class
-    # Since modals require an interaction, they cannot be done as a response to a text command.
-    # They can only be done as a response to either an application command or a button press.
     await interaction.response.send_modal(TimerForm())
 
 
@@ -71,3 +75,106 @@ async def bible(interaction: discord.Interaction):
         await interaction.followup.send(quote)
     except requests.RequestException as e:
         await interaction.followup.send(f"Could not fetch a Rat Bible quote: {e!s}")
+
+
+def _fetch_tracked_voice_channels():
+    response = requests.get(
+        TRACKED_VOICE_CHANNELS_URL,
+        headers={"Authorization": f"Bearer {settings.MINMATAR_API_TOKEN}"},
+        timeout=5,
+    )
+    response.raise_for_status()
+    return TrackedVoiceChannelsResponse.model_validate(response.json()).channels
+
+
+async def sync_guilds_to_api():
+    guilds = [
+        SyncGuildItem(id=guild.id, name=guild.name) for guild in client.guilds
+    ]
+    if not guilds:
+        print("No guilds connected; skipping guild sync.")
+        return
+
+    try:
+        response = await asyncio.to_thread(
+            requests.post,
+            GUILDS_SYNC_URL,
+            json=SyncGuildsRequest(guilds=guilds).model_dump(),
+            headers={"Authorization": f"Bearer {settings.MINMATAR_API_TOKEN}"},
+            timeout=5,
+        )
+        response.raise_for_status()
+        print("Synced guilds to API:", response.json())
+    except requests.RequestException as error:
+        print("Failed to sync guilds to API: %s" % error)
+
+
+@tasks.loop(seconds=60)
+async def track_voice_channels():
+    """Poll configured voice channels and submit minute records to the API."""
+    guild = client.get_guild(int(GUILD_ID))
+    if not guild:
+        print(f"Guild with ID {GUILD_ID} not found.")
+        return
+
+    try:
+        tracked_channels = await asyncio.to_thread(_fetch_tracked_voice_channels)
+    except requests.RequestException as error:
+        print("Failed to fetch tracked voice channels: %s" % error)
+        return
+
+    if not tracked_channels:
+        return
+
+    for tracked_channel in tracked_channels:
+        voice_channel = guild.get_channel(tracked_channel.channel_id)
+        if not voice_channel:
+            print(
+                "Tracked channel %s (%s) not found in guild."
+                % (tracked_channel.name, tracked_channel.channel_id)
+            )
+            continue
+        if not isinstance(
+            voice_channel, (discord.VoiceChannel, discord.StageChannel)
+        ):
+            print(
+                "Tracked channel %s (%s) is not a voice channel."
+                % (tracked_channel.name, tracked_channel.channel_id)
+            )
+            continue
+        if not voice_channel.members:
+            continue
+
+        usernames = [member.name for member in voice_channel.members]
+        print(
+            "Submitting voice tracking for %s users in %s"
+            % (len(usernames), voice_channel.name)
+        )
+        try:
+            response = await asyncio.to_thread(
+                requests.post,
+                ACTIVITY_RECORDS_URL,
+                json=CreateActivityRecordRequest(
+                    activity_type="voice_minute",
+                    quantity=1,
+                    channel_id=voice_channel.id,
+                    channel_name=voice_channel.name,
+                    usernames=usernames,
+                ).model_dump(),
+                headers={
+                    "Authorization": f"Bearer {settings.MINMATAR_API_TOKEN}"
+                },
+                timeout=5,
+            )
+            response.raise_for_status()
+            print(response.json())
+        except requests.RequestException as error:
+            print(
+                "Failed to submit voice tracking for %s: %s"
+                % (voice_channel.name, error)
+            )
+
+
+@track_voice_channels.before_loop
+async def before_track_voice_channels():
+    await client.wait_until_ready()

--- a/bot/app/voicetracking_api.py
+++ b/bot/app/voicetracking_api.py
@@ -1,0 +1,39 @@
+from pydantic import BaseModel
+
+from app.settings import settings
+
+ACTIVITY_RECORDS_URL = f"{settings.API_URL}/discord/activity/records"
+GUILDS_SYNC_URL = f"{settings.API_URL}/discord/guilds/sync"
+TRACKED_VOICE_CHANNELS_URL = (
+    f"{settings.API_URL}/discord/voicetracking/channels"
+)
+
+
+class SyncGuildItem(BaseModel):
+    id: int
+    name: str
+
+
+class SyncGuildsRequest(BaseModel):
+    guilds: list[SyncGuildItem]
+
+
+class CreateActivityRecordRequest(BaseModel):
+    activity_type: str
+    quantity: int
+    channel_id: int
+    channel_name: str
+    usernames: list[str]
+
+
+class ActivityRecordResponse(BaseModel):
+    ids: list[int]
+
+
+class TrackedVoiceChannelResponse(BaseModel):
+    channel_id: int
+    name: str
+
+
+class TrackedVoiceChannelsResponse(BaseModel):
+    channels: list[TrackedVoiceChannelResponse]


### PR DESCRIPTION
Reintroduce minute ingestion via the discord app, preserving historical standing-fleet rows through safe migrations, and replace single-channel bot polling with admin-configured channels, guild sync, and generic activity types.