### PR TITLE
Fix SEO indexing issues for canonical URLs and crawl errors.

### DIFF
--- a/frontend/app/src/helpers/seo.ts
+++ b/frontend/app/src/helpers/seo.ts
@@ -1,0 +1,22 @@
+import { get_prod_url, is_prod_mode } from '@helpers/env'
+
+export function get_site_origin(fallbackOrigin?: string): string {
+    if (is_prod_mode()) {
+        return get_prod_url().replace(/\/$/, '')
+    }
+    return (fallbackOrigin ?? get_prod_url()).replace(/\/$/, '')
+}
+
+export function build_canonical_url(
+    path: string,
+    translatePath: (path: string) => string,
+    fallbackOrigin?: string,
+): string {
+    return new URL(translatePath(path), get_site_origin(fallbackOrigin)).href
+}
+
+export const NOINDEX_PATH_PREFIXES = ['/partials/', '/redirects/'] as const
+
+export function is_noindex_path(pathname: string): boolean {
+    return NOINDEX_PATH_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+}

--- a/frontend/app/src/layouts/Viewport.astro
+++ b/frontend/app/src/layouts/Viewport.astro
@@ -62,6 +62,7 @@ import {
 } from '@components/partials/AlpineScripts.astro';
 
 import type { ViewportComponents } from '@dtypes/layout_components'
+import { get_site_origin } from '@helpers/seo'
 
 interface Props {
 	title: 					string;
@@ -73,9 +74,12 @@ interface Props {
 	components?:			ViewportComponents;
 }
 
+const site_origin = get_site_origin(Astro.url.origin)
+const default_meta_image = `${site_origin}/images/fleet-logo.png`
+
 const {
 	title,
-	meta_image = `${Astro.url.origin}/images/fleet-logo.png`,
+	meta_image = default_meta_image,
 	meta_description = t('generic.meta_description'),
 	canonical_url,
 	og_type = 'website',
@@ -83,7 +87,7 @@ const {
 	components = {},
 } = Astro.props
 
-const default_meta_image = `${Astro.url.origin}/images/fleet-logo.png`
+const resolved_canonical_url = canonical_url ?? new URL(Astro.url.pathname, site_origin).href
 const use_large_image_card = meta_image !== default_meta_image
 
 components.modal = components.modal ?? true
@@ -115,12 +119,12 @@ import RifterIcon from '@components/icons/RifterIcon.astro';
 		<title>{title}</title>
 		<ClientRouter />
 
-		{canonical_url && <link rel="canonical" href={canonical_url} />}
+		<link rel="canonical" href={resolved_canonical_url} />
 		<meta property="og:title" content={title}>
 		{meta_description && <meta property="og:description" content={meta_description} />}
 		<meta property="og:image" content={meta_image}>
 		<meta property="og:type" content={og_type}>
-		<meta property="og:url" content={canonical_url ?? Astro.url}>
+		<meta property="og:url" content={resolved_canonical_url}>
 		<meta property="og:site_name" content={t('index.page_title')}>
 		<meta name="twitter:title" content={title}>
 		{meta_description && <meta name="twitter:description" content={meta_description} />}

--- a/frontend/app/src/middleware.ts
+++ b/frontend/app/src/middleware.ts
@@ -1,5 +1,6 @@
 import { i18n } from '@helpers/i18n'
 import { prod_error_messages } from '@helpers/env'
+import { is_noindex_path } from '@helpers/seo'
 import type { Character } from '@dtypes/api.minmatar.org'
 import { get_primary_characters } from '@helpers/api.minmatar.org/characters'
 import { remove_subscription } from '@helpers/api.minmatar.org/notifications'
@@ -51,5 +52,11 @@ export const onRequest = async ({ locals, cookies, request }, next) => {
         }
     }
 
-    return next();
+    const response = await next()
+
+    if (is_noindex_path(url.pathname)) {
+        response.headers.set('X-Robots-Tag', 'noindex, nofollow')
+    }
+
+    return response
 };

--- a/frontend/app/src/pages/alliance/corporations/list.astro
+++ b/frontend/app/src/pages/alliance/corporations/list.astro
@@ -2,5 +2,5 @@
 import { i18n } from '@helpers/i18n'
 const { translatePath } = i18n(Astro.url)
 
-return Astro.redirect(translatePath('/alliance/corporations/'))
+return Astro.redirect(translatePath('/alliance/corporations/'), 301)
 ---

--- a/frontend/app/src/pages/alliance/propaganda/[post_id].astro
+++ b/frontend/app/src/pages/alliance/propaganda/[post_id].astro
@@ -21,7 +21,6 @@ if (isNaN(post_id))
     return HTTP_400_Bad_Request()
 
 let post:PostUI | null = null
-let get_post_error: Error | false = false
 let is_user_post:boolean = false
 
 try {
@@ -32,15 +31,16 @@ try {
     if (post?.state !== 'published' && !is_user_post)
         return HTTP_404_Not_Found()
 } catch (error) {
-    get_post_error = error
+    return HTTP_404_Not_Found()
 }
+
+if (!post)
+    return HTTP_404_Not_Found()
 
 import { marked } from 'marked';
 import { renderer } from '@helpers/marked';
 import { strip_markdown } from '@helpers/string';
 import { format_date } from '@helpers/date'
-
-const POST_PARTIAL_URL = translatePath(`/partials/post_component?id=${post_id}`)
 
 import Viewport from '@layouts/Viewport.astro';
 
@@ -56,8 +56,6 @@ import BlockList from '@components/compositions/BlockList.astro';
 import PilotBadge from '@components/blocks/PilotBadge.astro';
 import Button from '@components/blocks/Button.astro';
 import ClipboardButton from '@components/blocks/ClipboardButton.astro'
-import ErrorRefetch from '@components/blocks/ErrorRefetch.astro'
-import DebugTag from '@components/blocks/DebugTag.astro'
 
 const page_title = post?.title ?? t('new_post')
 const page_description = post?.excerpt ?? page_title
@@ -106,46 +104,33 @@ const page_description = post?.excerpt ?? page_title
             </FlexInline>
             <TextBox>
                 <BlockList gap='var(--space-xl)'>
-                    {get_post_error !== false ?
-                        <ErrorRefetch
-                            args={{
-                                partial: POST_PARTIAL_URL,
-                                error: get_post_error,
-                                delay: 0,
-                            }}
-                        />
-                        :
-                        <>{post ?
-                            <PilotBadge
-                                character_id={post?.author?.character_id as number}
-                                character_name={post?.author?.character_name as string}
-                                heading={true}
-                            >
-                                <small>{format_date(lang, post?.date_posted)}</small>
-                            </PilotBadge>
+                    <PilotBadge
+                        character_id={post.author.character_id as number}
+                        character_name={post.author.character_name as string}
+                        heading={true}
+                    >
+                        <small>{format_date(lang, post.date_posted)}</small>
+                    </PilotBadge>
 
-                            <>{post?.excerpt &&
-                                <Flexblock class="[ excerpt ]" gap='var(--space-m)' set:html={marked.parse(post?.excerpt as string, { renderer })}></Flexblock>
-                            }</>
-
-                            <div
-                                class="[ prose ]"
-                                set:html={marked.parse(post?.content as string, { renderer })}
-                                x-data={`{
-                                    init_zoom() {
-                                        mediumZoom('img[data-zoomable]', {
-                                            background: 'var(--solid-transparency-background)',
-                                            scrollOffset: 0,
-                                            margin: 24,
-                                            metaClick: false,
-                                        })
-                                    }
-                                }`}
-                                x-init="init_zoom()"
-                            /> :
-                            <DebugTag>{t('unexpected_error')}</DebugTag>
-                        }</>
+                    {post.excerpt &&
+                        <Flexblock class="[ excerpt ]" gap='var(--space-m)' set:html={marked.parse(post.excerpt as string, { renderer })}></Flexblock>
                     }
+
+                    <div
+                        class="[ prose ]"
+                        set:html={marked.parse(post.content as string, { renderer })}
+                        x-data={`{
+                            init_zoom() {
+                                mediumZoom('img[data-zoomable]', {
+                                    background: 'var(--solid-transparency-background)',
+                                    scrollOffset: 0,
+                                    margin: 24,
+                                    metaClick: false,
+                                })
+                            }
+                        }`}
+                        x-init="init_zoom()"
+                    />
 
                     <hr class="[ border-bottom ]" />
 

--- a/frontend/app/src/pages/campaigns/etherium-reach.astro
+++ b/frontend/app/src/pages/campaigns/etherium-reach.astro
@@ -4,6 +4,7 @@ const { t, translatePath } = i18n(Astro.url)
 
 import { COVER_IMAGE } from '@/data/campaigns/etherium-reach'
 import { buildEtheriumReachCampaignJsonLd } from '@/data/campaigns/etherium-reach-seo'
+import { get_site_origin } from '@helpers/seo'
 
 import Viewport from '@layouts/Viewport.astro'
 import PageLanding from '@components/page/PageLanding.astro'
@@ -19,13 +20,14 @@ const page_description = t('campaigns.etherium_reach.leading_text')
 const meta_title = t('campaigns.etherium_reach.meta_title')
     .replace('{site}', t('index.page_title'))
 const meta_description = t('campaigns.etherium_reach.meta_description')
-const canonical_url = new URL(translatePath('/campaigns/etherium-reach/'), Astro.url.origin).href
-const meta_image = new URL(COVER_IMAGE, Astro.url.origin).href
+const site_origin = get_site_origin(Astro.url.origin)
+const canonical_url = new URL(translatePath('/campaigns/etherium-reach/'), site_origin).href
+const meta_image = new URL(COVER_IMAGE, site_origin).href
 
 const structured_data = buildEtheriumReachCampaignJsonLd({
     canonicalUrl: canonical_url,
     siteName: t('index.page_title'),
-    siteOrigin: Astro.url.origin,
+    siteOrigin: site_origin,
     metaTitle: page_title,
     metaDescription: meta_description,
     metaImage: meta_image,

--- a/frontend/app/src/pages/guides/[name].astro
+++ b/frontend/app/src/pages/guides/[name].astro
@@ -9,6 +9,7 @@ import { buildGuideJsonLd, getGuidePageSeo } from '@/data/guides/seo'
 import { marked } from 'marked'
 import { renderer } from '@helpers/marked'
 import { HTTP_404_Not_Found } from '@helpers/http_responses'
+import { get_site_origin } from '@helpers/seo'
 
 const slug = Astro.params.name ?? ''
 const guide = getGuideBySlug(slug)
@@ -17,12 +18,13 @@ if (!guide) {
     return HTTP_404_Not_Found()
 }
 
+const site_origin = get_site_origin(Astro.url.origin)
 const { module } = guide
 const coverImage = getGuideCoverImage(guide)
 const seo = getGuidePageSeo({
     guide,
     siteName: t('index.page_title'),
-    siteOrigin: Astro.url.origin,
+    siteOrigin: site_origin,
     translatePath,
     t,
     coverImage,
@@ -30,7 +32,7 @@ const seo = getGuidePageSeo({
 const structured_data = buildGuideJsonLd({
     guide,
     siteName: t('index.page_title'),
-    siteOrigin: Astro.url.origin,
+    siteOrigin: site_origin,
     ...seo,
 })
 

--- a/frontend/app/src/pages/guides/index.astro
+++ b/frontend/app/src/pages/guides/index.astro
@@ -5,18 +5,20 @@ const { t, translatePath } = i18n(Astro.url)
 import { getGuidesByCategory, guideCategories, getIndexedGuides } from '@/data/guides'
 import { GUIDES_INDEX_COVER } from '@/data/guides/covers'
 import { buildGuidesIndexJsonLd, getGuidesIndexSeo } from '@/data/guides/seo'
+import { get_site_origin } from '@helpers/seo'
 
+const site_origin = get_site_origin(Astro.url.origin)
 const indexedGuides = getIndexedGuides()
 const seo = getGuidesIndexSeo({
     siteName: t('index.page_title'),
-    siteOrigin: Astro.url.origin,
+    siteOrigin: site_origin,
     translatePath,
     t,
     coverImage: GUIDES_INDEX_COVER.image,
 })
 const structured_data = buildGuidesIndexJsonLd({
     siteName: t('index.page_title'),
-    siteOrigin: Astro.url.origin,
+    siteOrigin: site_origin,
     metaTitle: seo.metaTitle,
     metaDescription: seo.metaDescription,
     canonicalUrl: seo.canonicalUrl,

--- a/frontend/app/src/pages/guides/navy-destroyer-metagame/index.astro
+++ b/frontend/app/src/pages/guides/navy-destroyer-metagame/index.astro
@@ -3,6 +3,7 @@ import { i18n } from '@helpers/i18n'
 const { t, translatePath } = i18n(Astro.url)
 
 import { guideMeta, credits, buildNavyDestroyerMetagameJsonLd } from '@/data/navy-destroyer-metagame'
+import { get_site_origin } from '@helpers/seo'
 
 import Viewport from '@layouts/Viewport.astro'
 import PageLanding from '@components/page/PageLanding.astro'
@@ -17,14 +18,15 @@ const page_description = t('ships.navy_destroyer_metagame.leading_text')
 const meta_title = t('ships.navy_destroyer_metagame.meta_title')
     .replace('{site}', t('index.page_title'))
 const meta_description = t('ships.navy_destroyer_metagame.meta_description')
-const canonical_url = new URL(translatePath('/guides/navy-destroyer-metagame/'), Astro.url.origin).href
-const meta_image = new URL(guideMeta.coverImage, Astro.url.origin).href
-const guides_url = new URL(translatePath('/guides/'), Astro.url.origin).href
+const site_origin = get_site_origin(Astro.url.origin)
+const canonical_url = new URL(translatePath('/guides/navy-destroyer-metagame/'), site_origin).href
+const meta_image = new URL(guideMeta.coverImage, site_origin).href
+const guides_url = new URL(translatePath('/guides/'), site_origin).href
 
 const structured_data = buildNavyDestroyerMetagameJsonLd({
     canonicalUrl: canonical_url,
     siteName: t('index.page_title'),
-    siteOrigin: Astro.url.origin,
+    siteOrigin: site_origin,
     metaTitle: page_title,
     metaDescription: meta_description,
     metaImage: meta_image,

--- a/frontend/app/src/pages/robots.txt.ts
+++ b/frontend/app/src/pages/robots.txt.ts
@@ -8,6 +8,8 @@ export const GET: APIRoute = ({ request }) => {
     const origin = getSitemapOrigin(request)
     const body = `User-agent: *
 Allow: /
+Disallow: /partials/
+Disallow: /redirects/
 
 Sitemap: ${origin}/sitemap.xml
 `

--- a/frontend/app/src/pages/ships/doctrines/list.astro
+++ b/frontend/app/src/pages/ships/doctrines/list.astro
@@ -4,5 +4,5 @@
 import { i18n } from '@helpers/i18n'
 const { translatePath } = i18n(Astro.url)
 
-return Astro.redirect(translatePath('/ships/doctrines/'))
+return Astro.redirect(translatePath('/ships/doctrines/'), 301)
 ---

--- a/frontend/app/src/pages/ships/doctrines/list/[doctrine_id].astro
+++ b/frontend/app/src/pages/ships/doctrines/list/[doctrine_id].astro
@@ -5,5 +5,5 @@ const { translatePath } = i18n(Astro.url)
 
 const doctrine_id = Astro.params.doctrine_id ?? '0';
 
-return Astro.redirect(translatePath(`/ships/doctrines/${doctrine_id}`))
+return Astro.redirect(translatePath(`/ships/doctrines/${doctrine_id}`), 301)
 ---

--- a/frontend/app/src/pages/ships/fitting/[fitting_id].astro
+++ b/frontend/app/src/pages/ships/fitting/[fitting_id].astro
@@ -3,5 +3,5 @@ import { i18n } from '@helpers/i18n'
 const { translatePath } = i18n(Astro.url)
 
 const id = Astro.params?.fitting_id ?? '0'
-return Astro.redirect(translatePath(`/ships/fittings/normal/${id}`))
+return Astro.redirect(translatePath(`/ships/fittings/normal/${id}`), 301)
 ---

--- a/frontend/app/src/pages/ships/fitting/list.astro
+++ b/frontend/app/src/pages/ships/fitting/list.astro
@@ -2,5 +2,5 @@
 import { i18n } from '@helpers/i18n'
 const { translatePath } = i18n(Astro.url)
 
-return Astro.redirect(translatePath('/ships/fittings/'))
+return Astro.redirect(translatePath('/ships/fittings/'), 301)
 ---

--- a/frontend/app/src/pages/ships/fitting/normal/[fitting_id].astro
+++ b/frontend/app/src/pages/ships/fitting/normal/[fitting_id].astro
@@ -4,5 +4,5 @@ const { translatePath } = i18n(Astro.url)
 
 const fitting_id = Astro.params.fitting_id ?? 0;
 
-return Astro.redirect(translatePath(`/ships/fittings/normal/${fitting_id}`))
+return Astro.redirect(translatePath(`/ships/fittings/normal/${fitting_id}`), 301)
 ---

--- a/frontend/app/src/pages/ships/fitting/render/[fitting_id].astro
+++ b/frontend/app/src/pages/ships/fitting/render/[fitting_id].astro
@@ -4,5 +4,5 @@ const { translatePath } = i18n(Astro.url)
 
 const fitting_id = Astro.params.fitting_id ?? 0;
 
-return Astro.redirect(translatePath(`/ships/fittings/render/${fitting_id}`))
+return Astro.redirect(translatePath(`/ships/fittings/render/${fitting_id}`), 301)
 ---

--- a/frontend/app/src/pages/ships/fittings.astro
+++ b/frontend/app/src/pages/ships/fittings.astro
@@ -14,6 +14,7 @@ import {
     buildFittingsListMetaDescription,
     buildFittingsListMetaTitle,
 } from '@helpers/fitting_seo'
+import { get_site_origin } from '@helpers/seo'
 
 let fittings:FittingItem[] = []
 let get_fittings_error:string | false = false
@@ -110,9 +111,10 @@ const page_title = t('fitting.list.page_title');
 const site_name = t('index.page_title')
 const meta_title = buildFittingsListMetaTitle(site_name, t)
 const meta_description = buildFittingsListMetaDescription(fittings.length, t)
-const canonical_url = new URL(translatePath('/ships/fittings/'), Astro.url.origin).href
-const meta_image = new URL('/images/fits-cover.jpg', Astro.url.origin).href
-const ships_url = new URL(translatePath('/ships/'), Astro.url.origin).href
+const site_origin = get_site_origin(Astro.url.origin)
+const canonical_url = new URL(translatePath('/ships/fittings/'), site_origin).href
+const meta_image = new URL('/images/fits-cover.jpg', site_origin).href
+const ships_url = new URL(translatePath('/ships/'), site_origin).href
 
 const structured_data = buildFittingsListJsonLd(
     {
@@ -120,10 +122,10 @@ const structured_data = buildFittingsListJsonLd(
             id: fitting.id,
             name: fitting.fitting_name.replace(/^\[[^\]]+\]\s*/, ''),
             shipName: fitting.ship_name,
-            url: new URL(translatePath(`/ships/fittings/${fitting.id}`), Astro.url.origin).href,
+            url: new URL(translatePath(`/ships/fittings/${fitting.id}`), site_origin).href,
         })),
         siteName: site_name,
-        siteOrigin: Astro.url.origin,
+        siteOrigin: site_origin,
         fittingsListUrl: canonical_url,
         shipsUrl: ships_url,
         canonicalUrl: canonical_url,

--- a/frontend/app/src/pages/ships/fittings/[fitting_id].astro
+++ b/frontend/app/src/pages/ships/fittings/[fitting_id].astro
@@ -3,5 +3,5 @@ import { i18n } from '@helpers/i18n'
 const { translatePath } = i18n(Astro.url)
 
 const id = Astro.params?.fitting_id ?? '0'
-return Astro.redirect(translatePath(`/ships/fittings/normal/${id}`))
+return Astro.redirect(translatePath(`/ships/fittings/normal/${id}`), 301)
 ---

--- a/frontend/app/src/pages/ships/fittings/normal/[fitting_id].astro
+++ b/frontend/app/src/pages/ships/fittings/normal/[fitting_id].astro
@@ -7,6 +7,8 @@ const { fitting_id } = Astro.params;
 import type { FittingGroup, Module, CargoItem } from '@dtypes/layout_components';
 import { get_fitting_by_id } from '@helpers/api.minmatar.org/ships'
 import type { Fitting } from '@dtypes/api.minmatar.org'
+import { HTTP_404_Not_Found } from '@helpers/http_responses'
+import { get_site_origin } from '@helpers/seo'
 
 let fitting:Fitting | null = null
 let get_fitting_error:string | false = false
@@ -18,7 +20,7 @@ try {
 }
 
 if (!fitting)
-    throw new Error(t('invalid_fitting'))
+    return HTTP_404_Not_Found()
 
 import { get_item_icon } from '@helpers/eve_image_server';
 import { parse_eft, parse_pod } from '@helpers/fit_parser.ts';
@@ -156,6 +158,8 @@ const ship_display_name = fitting_parsed?.ship_name ?? ''
 const site_name = t('index.page_title')
 const tag_labels = format_fitting_tags_line(fitting?.tags, t)
 
+const site_origin = get_site_origin(Astro.url.origin)
+
 const seo_input: FittingDetailSeoInput = {
     fittingId: parseInt(fitting_id ?? '0'),
     fittingName: fitting_display_name,
@@ -165,11 +169,11 @@ const seo_input: FittingDetailSeoInput = {
     tagLabels: tag_labels,
     updatedAt: fitting?.updated_at,
     siteName: site_name,
-    siteOrigin: Astro.url.origin,
-    fittingsListUrl: new URL(translatePath('/ships/fittings/'), Astro.url.origin).href,
-    shipsUrl: new URL(translatePath('/ships/'), Astro.url.origin).href,
-    canonicalUrl: new URL(translatePath(`/ships/fittings/normal/${fitting_id}`), Astro.url.origin).href,
-    metaImage: ship_id && Number(ship_id) > 0 ? get_item_icon(ship_id as number, 256) : `${Astro.url.origin}/images/fits-cover.jpg`,
+    siteOrigin: site_origin,
+    fittingsListUrl: new URL(translatePath('/ships/fittings/'), site_origin).href,
+    shipsUrl: new URL(translatePath('/ships/'), site_origin).href,
+    canonicalUrl: new URL(translatePath(`/ships/fittings/normal/${fitting_id}`), site_origin).href,
+    metaImage: ship_id && Number(ship_id) > 0 ? get_item_icon(ship_id as number, 256) : `${site_origin}/images/fits-cover.jpg`,
 }
 
 const meta_title = buildFittingDetailMetaTitle(seo_input, t)

--- a/frontend/app/src/pages/ships/fittings/render/[fitting_id].astro
+++ b/frontend/app/src/pages/ships/fittings/render/[fitting_id].astro
@@ -16,6 +16,8 @@ import type { FleetCombatLog, CargoItem } from '@dtypes/layout_components'
 import { get_fitting_by_id } from '@helpers/api.minmatar.org/ships'
 import type { Fitting } from '@dtypes/api.minmatar.org'
 import { get_ship_info } from '@helpers/sde/ships'
+import { HTTP_404_Not_Found } from '@helpers/http_responses'
+import { get_site_origin } from '@helpers/seo'
 
 let fitting:Fitting | null = null
 let get_fitting_error: Error | false = false
@@ -30,6 +32,9 @@ try {
 } catch (error) {
     get_fitting_error = error
 }
+
+if (!fitting)
+    return HTTP_404_Not_Found()
 
 try {
     saved_logs = [] // user && !fetch_fleets_error ? await get_fitting_combatlogs(auth_token as string, parseInt(fitting_id ?? '0')) : []
@@ -53,10 +58,10 @@ import {
     type FittingDetailSeoInput,
 } from '@helpers/fitting_seo'
 
-const fitting_parsed = await parse_eft(fitting?.eft_format ?? '')
+const fitting_parsed = await parse_eft(fitting.eft_format ?? '')
 
 if (!fitting_parsed)
-    throw new Error(t('invalid_fitting'))
+    return HTTP_404_Not_Found()
 
 let turrets:string[] = []
 
@@ -79,6 +84,8 @@ const ship_display_name = fitting_parsed.ship_name ?? ''
 const site_name = t('index.page_title')
 const tag_labels = format_fitting_tags_line(fitting?.tags, t)
 
+const site_origin = get_site_origin(Astro.url.origin)
+
 const seo_input: FittingDetailSeoInput = {
     fittingId: parseInt(fitting_id ?? '0'),
     fittingName: fitting_display_name,
@@ -88,11 +95,11 @@ const seo_input: FittingDetailSeoInput = {
     tagLabels: tag_labels,
     updatedAt: fitting?.updated_at,
     siteName: site_name,
-    siteOrigin: Astro.url.origin,
-    fittingsListUrl: new URL(translatePath('/ships/fittings/'), Astro.url.origin).href,
-    shipsUrl: new URL(translatePath('/ships/'), Astro.url.origin).href,
-    canonicalUrl: new URL(translatePath(`/ships/fittings/normal/${fitting_id}`), Astro.url.origin).href,
-    metaImage: ship_id && Number(ship_id) > 0 ? get_item_icon(ship_id, 256) : `${Astro.url.origin}/images/fits-cover.jpg`,
+    siteOrigin: site_origin,
+    fittingsListUrl: new URL(translatePath('/ships/fittings/'), site_origin).href,
+    shipsUrl: new URL(translatePath('/ships/'), site_origin).href,
+    canonicalUrl: new URL(translatePath(`/ships/fittings/normal/${fitting_id}`), site_origin).href,
+    metaImage: ship_id && Number(ship_id) > 0 ? get_item_icon(ship_id, 256) : `${site_origin}/images/fits-cover.jpg`,
 }
 
 const meta_title = buildFittingDetailMetaTitle(seo_input, t)

--- a/frontend/app/testing/helpers/seo.test.ts
+++ b/frontend/app/testing/helpers/seo.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+    build_canonical_url,
+    get_site_origin,
+    is_noindex_path,
+} from '@helpers/seo'
+
+describe('seo', () => {
+    it('detects noindex paths', () => {
+        expect(is_noindex_path('/partials/fitting_finder_component')).toBe(true)
+        expect(is_noindex_path('/redirects/auth_init')).toBe(true)
+        expect(is_noindex_path('/alliance/')).toBe(false)
+    })
+
+    it('builds canonical URLs from translated paths', () => {
+        const translatePath = (path: string) => path
+        const url = build_canonical_url('/guides/', translatePath, 'http://localhost:4321')
+
+        expect(url).toMatch(/\/guides\/$/)
+    })
+
+    it('uses fallback origin outside production', () => {
+        expect(get_site_origin('http://localhost:4321')).toBe('http://localhost:4321')
+    })
+})


### PR DESCRIPTION
Use HTTPS production origin for canonicals, return 404 for missing fittings and posts, block partials/redirects from indexing, and upgrade permanent URL migrations to 301 redirects.