### PR TITLE
Fix Docker builds for mysqlclient and missing pytz.

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10.12-slim-bookworm
 
 # install git for doctine pulling and various other dependencies
-RUN apt-get update && apt-get install -y git libmariadb-dev gcc
+RUN apt-get update && apt-get install -y git libmariadb-dev gcc pkg-config
 
 # add user and set up repos
 WORKDIR /opt/minmatar

--- a/backend/Dockerfile.mumble
+++ b/backend/Dockerfile.mumble
@@ -1,7 +1,7 @@
 FROM python:3.10.12-slim-bookworm
 
 # install git for doctine pulling and various other dependencies
-RUN apt-get update && apt-get install -y git libmariadb-dev wget gcc g++ libssl-dev libbz2-dev unzip cmake
+RUN apt-get update && apt-get install -y git libmariadb-dev wget gcc g++ libssl-dev libbz2-dev unzip cmake pkg-config
 
 WORKDIR /opt/mariadb
 RUN wget https://archive.mariadb.org/connector-c-3.3.1/mariadb-connector-c-3.3.1-src.zip

--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -31,6 +31,7 @@ black = "*"
 docker = "*"
 django-safedelete = "*"
 pillow = "*"
+pytz = "*"
 
 [dev-packages]
 pylint = "*"

--- a/backend/Pipfile.lock
+++ b/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8eed302e60e1e4e69c602668a872d3bf5d5149b167e918edcf100ccef90703ba"
+            "sha256": "d5e78839b2538044232ec155c7fbbe10ba4ec39476085670d0239834c42b984d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1511,6 +1511,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==0.4.1"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126",
+                "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a"
+            ],
+            "index": "pypi",
+            "version": "==2026.2"
         },
         "pyyaml": {
             "hashes": [


### PR DESCRIPTION
pkg-config is required to compile mysqlclient against MariaDB, and Django 5.2 no longer pulls in pytz while app code still imports it.