### PR TITLE
Top up compressed ore against UI display refine rate

### DIFF
--- a/backend/industry/helpers/compressed_ore.py
+++ b/backend/industry/helpers/compressed_ore.py
@@ -717,7 +717,8 @@ def conservative_refine_rate(refine_rate: float) -> float:
     """
     if refine_rate <= 0:
         return refine_rate
-    display = round(refine_rate * 100.0, 2) / 100.0
+    # Round via hundredths-of-a-percent integers to avoid 0.8576999999999999.
+    display = round(refine_rate * 10000) / 10000.0
     return min(display, refine_rate)
 
 

--- a/backend/industry/helpers/compressed_ore.py
+++ b/backend/industry/helpers/compressed_ore.py
@@ -707,28 +707,48 @@ def _sum_reprocess_outputs(
     return totals
 
 
+def conservative_refine_rate(refine_rate: float) -> float:
+    """
+    Yield used for shopping-list coverage checks.
+
+    UI shows refine as ``(rate * 100).toFixed(2)``; Janice users typically
+    enter that rounded percent. Never use a rate above the true facility
+    yield (rounding can bump 85.775% → 85.78%).
+    """
+    if refine_rate <= 0:
+        return refine_rate
+    display = round(refine_rate * 100.0, 2) / 100.0
+    return min(display, refine_rate)
+
+
 def _top_up_floor_coverage(
     belt_compressed: Dict[str, int],
     mineral_needs: Dict[str, int],
     mineral_imports: Dict[str, int],
     refine_rate: float,
     *,
-    max_iterations: int = 10_000,
+    max_iterations: int = 100_000,
 ) -> None:
     """
     Add primary belt ore until floored reprocess meets covered mineral needs.
 
-    Continuous blend sizing can undershoot by a few units after Janice-style
-    portion flooring; top up one compressed unit at a time.
+    Coverage is checked at ``conservative_refine_rate`` (UI/Janice 2-dp
+    percent) so shopping lists still cover after portion flooring when
+    validated at the displayed yield. Continuous blend sizing alone can
+    undershoot by a few units at full precision, or by more when the
+    displayed rate is slightly below the true facility rate.
     """
+    coverage_rate = conservative_refine_rate(refine_rate)
     for _ in range(max_iterations):
-        expected = _sum_reprocess_outputs(belt_compressed, refine_rate)
+        expected = _sum_reprocess_outputs(belt_compressed, coverage_rate)
         shortfall: Optional[str] = None
+        shortfall_qty = 0
         for mineral in COMPRESSION_COVERED_MINERALS:
             need = mineral_needs.get(mineral, 0)
             got = expected.get(mineral, 0) + mineral_imports.get(mineral, 0)
             if got < need:
                 shortfall = mineral
+                shortfall_qty = need - got
                 break
         if shortfall is None:
             return
@@ -736,7 +756,12 @@ def _top_up_floor_coverage(
         if not ore:
             return
         name = compressed_type_name(ore)
-        belt_compressed[name] = belt_compressed.get(name, 0) + 1
+        base_qty = ore_materials_per_portion(ore).get(shortfall, 0.0)
+        yield_per = (base_qty / ORE_BATCH_SIZE) * coverage_rate
+        if yield_per <= 0:
+            return
+        add = max(1, math.ceil(shortfall_qty / yield_per))
+        belt_compressed[name] = belt_compressed.get(name, 0) + add
 
 
 def _mineral_delta(
@@ -829,6 +854,8 @@ def build_compressed_ore_plan(
     plan.ice_imports.update(buckets.ice)
     plan.other_imports.update(buckets.other)
 
+    # Expected / delta at the true facility rate (in-game). Top-up used the
+    # conservative display rate, so these deltas are typically a small surplus.
     plan.expected_minerals = _sum_reprocess_outputs(
         {**plan.moon_ore_compressed, **plan.belt_ore_compressed},
         refine_rate,

--- a/backend/industry/tests/test_compressed_ore.py
+++ b/backend/industry/tests/test_compressed_ore.py
@@ -9,16 +9,19 @@ from industry.helpers.compressed_ore import (
     COMPRESSION_COVERED_MINERALS,
     PRIMARY_BELT_ORE_FOR_MINERAL,
     MaterialBuckets,
+    base_ore_name,
     belt_ore_compressed_volume_m3,
     best_belt_ore_for_mineral,
     build_compressed_ore_plan,
     compression_covered_materials,
     compute_practical_belt_blend,
+    conservative_refine_rate,
     mineral_density,
     moon_ore_for_pi_p0,
     reprocess_output,
     to_compressed_units,
 )
+from industry.helpers.facility_profiles import get_facility_refine_rate
 from industry.helpers.reprocessing_skills import resolve_refine_rate
 
 
@@ -459,6 +462,69 @@ class CompressedOrePlanTestCase(TestCase):
                 + plan.mineral_imports.get(mineral, 0),
                 plan.mineral_needs.get(mineral, 0),
             )
+
+    def test_conservative_refine_rate_matches_ui_percent(self):
+        full = get_facility_refine_rate("amamake", implant=0.04)
+        self.assertAlmostEqual(full, 0.8577302848, places=7)
+        # UI: (full * 100).toFixed(2) → 85.77%
+        self.assertEqual(conservative_refine_rate(full), 0.8577)
+        # Never round above the true rate.
+        self.assertEqual(conservative_refine_rate(0.85775), 0.85775)
+        self.assertEqual(conservative_refine_rate(0.84), 0.84)
+
+    def test_top_up_covers_at_display_refine_rate(self):
+        """
+        Amamake+RX804 plans must still cover Trit/Pye/Mex when refined at the
+        UI/Janice 2-decimal percent (85.77%), not only at full float precision.
+        """
+        full = get_facility_refine_rate("amamake", implant=0.04)
+        display = conservative_refine_rate(full)
+        # Typhoon Fleet Issue ×40 mineral leaves (ME 0) — Discord / Order #38.
+        needs = {
+            "Tritanium": 304_761_600,
+            "Pyerite": 152_380_800,
+            "Mexallon": 22_857_120,
+            "Isogen": 15_238_080,
+            "Nocxium": 1_142_856,
+            "Zydrine": 304_762,
+            "Megacyte": 152_381,
+        }
+        plan = build_compressed_ore_plan(
+            needs,
+            refine_rate=full,
+            use_moon_ore=False,
+            require_market=False,
+        )
+        expected_at_display: dict[str, int] = {}
+        for ore_name, qty in plan.belt_ore_compressed.items():
+            for mat, produced in reprocess_output(
+                base_ore_name(ore_name), qty, refine_rate=display
+            ).items():
+                expected_at_display[mat] = (
+                    expected_at_display.get(mat, 0) + produced
+                )
+        for mineral in COMPRESSION_COVERED_MINERALS:
+            got = expected_at_display.get(
+                mineral, 0
+            ) + plan.mineral_imports.get(mineral, 0)
+            self.assertGreaterEqual(
+                got,
+                needs[mineral],
+                msg=(
+                    f"{mineral}: display refine {display} produced {got}, "
+                    f"need {needs[mineral]}"
+                ),
+            )
+        # Slight overage vs the pre-fix exact stacks from continuous sizing.
+        self.assertGreater(
+            plan.belt_ore_compressed["Compressed Veldspar"], 77_724_433
+        )
+        self.assertGreater(
+            plan.belt_ore_compressed["Compressed Zeolites"], 2_220_699
+        )
+        self.assertGreater(
+            plan.belt_ore_compressed["Compressed Plagioclase"], 25_379_407
+        )
 
     def test_covered_minerals_never_negative_delta(self):
         plan = build_compressed_ore_plan(


### PR DESCRIPTION
## Summary
- Compressed-ore shopping lists are now topped up so floored Trit/Pye/Mex still cover when refined at the planner’s **2-decimal display yield** (e.g. 85.77%), not only at full float precision (85.7730…%).
- This closes Order #38 / Janice-style shortfalls (~11k Trit) with a tiny ore pad (~0.003–0.005%), without a flat 1% overage.
- Bulk top-up adds ore by shortfall estimate so large jobs stay fast.

## Test plan
- [x] `pipenv run python manage.py test industry.tests.test_compressed_ore --settings=app.settings_test`
- [ ] Re-plan Order #38 (40× Typhoon Fleet Issue, Amamake, implant ON) and confirm Compressed Veldspar/Zeolites/Plagioclase are slightly above the previous exact stacks
- [ ] Paste the new multibuy into Janice at 85.77% and confirm Trit/Pye/Mex To Buy is 0 (or surplus)


Made with [Cursor](https://cursor.com)