### PR TITLE
Defer product producers for faster supply chain page

### DIFF
--- a/backend/industry/endpoints/products/get_products.py
+++ b/backend/industry/endpoints/products/get_products.py
@@ -1,20 +1,20 @@
-"""GET "" - list all industry products with type, strategy, volume, relations, producers."""
+"""GET "" - list all industry products with type, strategy, volume, relations.
+
+Producers are loaded separately via GET /products/{id} (lazy on the products page).
+"""
 
 from typing import List
 
 from industry.endpoints.products.schemas import (
-    CharacterProducerRef,
-    CorporationProducerRef,
     IndustryProductListItem,
     IndustryProductRef,
 )
-from industry.helpers.producers import get_producers_for_types
 from industry.models import IndustryProduct
 
 PATH = ""
 METHOD = "get"
 ROUTE_SPEC = {
-    "summary": "List all industry products with strategy, volume, relations, character/corp producers",
+    "summary": "List all industry products with strategy, volume, and relations (no producers)",
     "response": {200: List[IndustryProductListItem]},
 }
 
@@ -34,8 +34,6 @@ def get_products(request):
         .prefetch_related("supplied_for__eve_type", "supplies__eve_type")
         .order_by("eve_type__name")
     )
-    type_ids = [p.eve_type_id for p in products]
-    producers_by_type = get_producers_for_types(type_ids)
     return [
         IndustryProductListItem(
             id=p.pk,
@@ -46,26 +44,6 @@ def get_products(request):
             blueprint_or_reaction_type_id=p.blueprint_or_reaction_type_id,
             supplied_for=_refs(p.supplied_for.all()),
             supplies=_refs(p.supplies.all()),
-            character_producers=[
-                CharacterProducerRef(
-                    id=c["id"],
-                    name=c["name"],
-                    total_value_isk=c.get("total_value_isk", 0.0),
-                )
-                for c in producers_by_type.get(p.eve_type_id, {}).get(
-                    "character_producers", []
-                )
-            ],
-            corporation_producers=[
-                CorporationProducerRef(
-                    id=c["id"],
-                    name=c["name"],
-                    total_value_isk=c.get("total_value_isk", 0.0),
-                )
-                for c in producers_by_type.get(p.eve_type_id, {}).get(
-                    "corporation_producers", []
-                )
-            ],
         )
         for p in products
     ]

--- a/backend/industry/endpoints/products/schemas.py
+++ b/backend/industry/endpoints/products/schemas.py
@@ -30,7 +30,10 @@ class CorporationProducerRef(BaseModel):
 
 
 class IndustryProductListItem(BaseModel):
-    """One industry product in list: type, strategy, volume, blueprint/reaction, relations, producers."""
+    """One industry product in list: type, strategy, volume, blueprint/reaction, relations.
+
+    Producers are omitted from the list payload; fetch via GET /products/{id}.
+    """
 
     id: int
     type_id: int
@@ -40,8 +43,6 @@ class IndustryProductListItem(BaseModel):
     blueprint_or_reaction_type_id: Optional[int] = None
     supplied_for: List[IndustryProductRef] = []
     supplies: List[IndustryProductRef] = []
-    character_producers: List[CharacterProducerRef] = []
-    corporation_producers: List[CorporationProducerRef] = []
 
 
 class IndustryProductDetail(BaseModel):

--- a/backend/industry/tests/test_product_breakdown.py
+++ b/backend/industry/tests/test_product_breakdown.py
@@ -110,10 +110,8 @@ class ProductBreakdownTestCase(AppTestCase):
         self.assertIn("supplies", data[0])
         self.assertEqual(data[0]["supplied_for"], [])
         self.assertEqual(data[0]["supplies"], [])
-        self.assertIn("character_producers", data[0])
-        self.assertIn("corporation_producers", data[0])
-        self.assertEqual(data[0]["character_producers"], [])
-        self.assertEqual(data[0]["corporation_producers"], [])
+        self.assertNotIn("character_producers", data[0])
+        self.assertNotIn("corporation_producers", data[0])
 
     def test_get_product_returns_200_with_detail(self):
         """GET /products/{id} returns full detail including supplied_for and supplies."""

--- a/frontend/app/src/components/blocks/IndustryTiles.astro
+++ b/frontend/app/src/components/blocks/IndustryTiles.astro
@@ -51,18 +51,6 @@ import Tile from '@components/blocks/Tile.astro';
             <Button size='sm' href={translatePath('/industry/products/')}>
                 {t('browse')}
             </Button>
-            
-            <Button size='sm' href={translatePath('/industry/products?strategy=produced')}>
-                {t('produced')}
-            </Button>
-
-            <Button size='sm' href={translatePath('/industry/products?strategy=harvested')}>
-                {t('harvested')}
-            </Button>
-
-            <Button size='sm' href={translatePath('/industry/products?strategy=imported')}>
-                {t('imported')}
-            </Button>
         </Tile>
 
         <Tile

--- a/frontend/app/src/components/blocks/ProductItem.astro
+++ b/frontend/app/src/components/blocks/ProductItem.astro
@@ -14,6 +14,13 @@ const {
     init_tooltips,
 } = Astro.props
 
+const has_producers = (
+    product.character_producers !== undefined
+    || product.corporation_producers !== undefined
+)
+
+const PRODUCT_PRODUCERS_PARTIAL_URL = `${translatePath('/partials/product_producers_component')}?product_id=${product.id}`
+
 import { get_bpc_icon } from '@helpers/eve_image_server';
 import { query_string } from '@helpers/string';
 
@@ -28,12 +35,14 @@ import Picture from '@components/blocks/Picture.astro';
 import ProducersList from '@components/blocks/ProducersList.astro';
 
 import IndustryIcon from '@components/icons/IndustryIcon.astro';
+import IndustrialistIcon from '@components/icons/IndustrialistIcon.astro';
 ---
 
 <FixedFluid
     class="[ product-item ]"
-    width='450px'
+    width='min(450px, 100%)'
     gap='var(--space-3xs)'
+    breakpoint='min(100%, 28rem)'
     x-show="show_item($el)"
 >
     <div>
@@ -61,11 +70,11 @@ import IndustryIcon from '@components/icons/IndustryIcon.astro';
 
     <div class="[ alignment-hack ]">
         <FlexInline
-            class="[ items-center! flex-nowrap! ]"
+            class="[ items-center! product-item-actions ]"
             gap='var(--space-s)'
             justification='space-between'
         >
-            <Grid class="[ pl-[64px] grow min-w-0 ]" min_item_width='250px'>
+            <Grid class="[ product-item-meta grow min-w-0 ]" min_item_width='200px'>
                 <FixedFluid width='32px' gap='var(--space-2xs)' breakpoint='30%' class="[  items-center! ]">
                     <div
                         class="[ text-highlight ]"
@@ -74,11 +83,11 @@ import IndustryIcon from '@components/icons/IndustryIcon.astro';
                     >
                         <IndustryIcon size={32} />
                     </div>
-                    
+
                     {product.supplied_for.length > 0 ?
                         <FlexInline gap='var(--space-3xs)'>
                             {product.supplied_for.map(material =>
-                                <div 
+                                <div
                                     data-tippy-content={material.name}
                                     x-init={init_tooltips ? 'tippy($el, tippy_options)' : undefined}
                                 >
@@ -96,11 +105,33 @@ import IndustryIcon from '@components/icons/IndustryIcon.astro';
                     }
                 </FixedFluid>
 
-                <ProducersList
-                    character_producers={product.character_producers}
-                    corporation_producers={product.corporation_producers}
-                    init_tooltips={init_tooltips}
-                />
+                {has_producers ?
+                    <ProducersList
+                        character_producers={product.character_producers}
+                        corporation_producers={product.corporation_producers}
+                        init_tooltips={init_tooltips}
+                    />
+                    :
+                    <FixedFluid
+                        class="[ loading ]"
+                        width='32px'
+                        breakpoint='30%'
+                        gap='var(--space-2xs)'
+                        hx-get={PRODUCT_PRODUCERS_PARTIAL_URL}
+                        hx-trigger="intersect once"
+                        hx-sync="#products-list:queue all"
+                        hx-indicator=".loader"
+                        hx-swap="outerHTML transition:true"
+                    >
+                        <div
+                            class="[ text-highlight h-[32px] ]"
+                            data-tippy-content={t('industrialists')}
+                        >
+                            <IndustrialistIcon size={32} />
+                        </div>
+                        <small>{t('fetching_producers')}</small>
+                    </FixedFluid>
+                }
             </Grid>
 
             <Button
@@ -120,5 +151,20 @@ import IndustryIcon from '@components/icons/IndustryIcon.astro';
 <style lang="scss">
     .alignment-hack {
         padding-left: var(--space-s);
+        min-width: 0;
+        width: 100%;
+    }
+
+    .product-item-meta {
+        padding-left: 0;
+
+        @media (min-width: 640px) {
+            padding-left: 64px;
+        }
+    }
+
+    .product-item-actions {
+        flex-wrap: wrap;
+        row-gap: var(--space-2xs);
     }
 </style>

--- a/frontend/app/src/components/blocks/ProductsList.astro
+++ b/frontend/app/src/components/blocks/ProductsList.astro
@@ -18,7 +18,7 @@ import ProductItem from '@components/blocks/ProductItem.astro';
 import Table from '@components/blocks/Table.astro';
 ---
 
-<Table>
+<Table id="products-list" width="100%" responsive={false}>
     {products.map(product =>
         <ProductItem product={product} init_tooltips={init_tooltips} />
     )}

--- a/frontend/app/src/i18n/ui.ts
+++ b/frontend/app/src/i18n/ui.ts
@@ -481,8 +481,8 @@ export const ui = {
         'industry.orders.invoice.page_title': 'Delivery Contract Invoice',
         'industry.orders.invoice.leading_text': 'Check the in-game contract values are correct.',
 
-        'industry.products.page_title': 'Products',
-        'industry.products.leading_text': 'Products are the inputs: everything our alliance needs to keep the supply chain running. Each product is categorized as produced, harvested, or imported, and linked to the people who make or source it. Find a gap and fill it.',
+        'industry.products.page_title': 'Supply Chain',
+        'industry.products.leading_text': 'Our supply chain is what keeps our war machine running. Learn about our various products and their downstream inputs, as well as who is involved in every step.',
         'industry.products.meta_description': 'Industry products, materials, components, and goods categorized by production strategy with live producer tracking.',
 
         'industry.industrialists.page_title': 'Industrialists',
@@ -2130,6 +2130,7 @@ export const ui = {
         'material': 'Material',
         'final_product': 'Final product',
         'no_producers': 'No producers',
+        'fetching_producers': 'Fetching producers',
         'producers': 'Producers',
         'all_strategies': 'All strategies',
         'no_products_to_display': 'No products to display.',
@@ -2332,6 +2333,7 @@ export const ui = {
         'all_resource_types': 'All resource types',
         'planetary_harvest_drilldown': 'Planetary harvest drill down',
         'invalid_resource_type': 'The resource type is not valid.',
+        'invalid_product_id': 'The product id is not valid.',
         'fetching_drilldown': 'Fetching drill down',
         'planetary_production_drilldown': 'Planetary production drill down',
         'colonies': 'Colonies',

--- a/frontend/app/src/pages/partials/product_producers_component.astro
+++ b/frontend/app/src/pages/partials/product_producers_component.astro
@@ -1,0 +1,43 @@
+---
+import { i18n } from '@helpers/i18n'
+const { t, translatePath } = i18n(Astro.url)
+
+const product_id = parseInt(Astro.url.searchParams.get('product_id') ?? '0')
+
+import type { Product } from '@dtypes/api.minmatar.org'
+import { get_product_by_id } from '@helpers/api.minmatar.org/industry'
+
+let product: Product | null = null
+let fetch_error: Error | false = false
+
+try {
+    if (isNaN(product_id) || product_id <= 0)
+        throw new Error(t('invalid_product_id'), { cause: 400 })
+
+    product = await get_product_by_id(product_id)
+} catch (error) {
+    fetch_error = error
+}
+
+const PRODUCT_PRODUCERS_PARTIAL_URL = `${translatePath('/partials/product_producers_component')}?product_id=${product_id}`
+
+const delay = parseInt(Astro.url.searchParams.get('delay') ?? '5')
+
+import ProducersList from '@components/blocks/ProducersList.astro'
+import ErrorRefetch from '@components/blocks/ErrorRefetch.astro'
+---
+
+{fetch_error ?
+    <ErrorRefetch
+        args={{
+            partial: PRODUCT_PRODUCERS_PARTIAL_URL,
+            error: fetch_error,
+            delay: delay,
+        }}
+    /> :
+    <ProducersList
+        character_producers={product?.character_producers ?? []}
+        corporation_producers={product?.corporation_producers ?? []}
+        init_tooltips={true}
+    />
+}

--- a/frontend/app/src/types/api.minmatar.org.ts
+++ b/frontend/app/src/types/api.minmatar.org.ts
@@ -1006,8 +1006,9 @@ export interface Product extends ProductBase {
     blueprint_or_reaction_type_id:  number;
     supplied_for:                   ProductBase[];
     supplies:                       ProductBase[];
-    character_producers:            Producer[];
-    corporation_producers:          Producer[]
+    /** Present on GET /products/{id}; omitted from list responses. */
+    character_producers?:           Producer[];
+    corporation_producers?:         Producer[];
 }
 
 /** Planetary (PI) API types */


### PR DESCRIPTION
## Summary
- Stop embedding character/corp producers on `GET /products` so the list path skips `get_producers_for_types` for the full catalog
- Lazy-load producers per visible row via a new HTMX partial (queued on intersect) while keeping the original product row layout
- Retitle the industry tile to Supply Chain with updated copy and a single Browse button; make the products list wrap on narrow screens so Planner stays reachable

## Test plan
- [ ] Open `/industry/products/` and confirm the list loads without waiting on full producer aggregation
- [ ] Scroll/visible rows fill producers (avatars or “No producers”) without request stampede
- [ ] Strategy tabs + search still work
- [ ] Planner links still work on desktop and a thin viewport
- [ ] Industry landing tile shows Supply Chain with Browse only
- [ ] `pipenv run python manage.py test industry.tests.test_product_breakdown --settings=app.settings_test`


Made with [Cursor](https://cursor.com)