### PR TITLE
Digest-only doctrine/fitting change DMs

### DIFF
--- a/backend/fittings/admin.py
+++ b/backend/fittings/admin.py
@@ -67,10 +67,6 @@ from fittings.models import (
     EveFittingRefit,
     FittingTag,
 )
-from fittings.tasks import (
-    notify_doctrine_change_request_proposed,
-    notify_fitting_change_request_proposed,
-)
 from srp.models import PodReimbursementProgram
 
 from .forms import (
@@ -131,7 +127,6 @@ def _queue_refit_delete_request(
             refit=inline_form.instance,
         )
         if req:
-            notify_fitting_change_request_proposed.delay(req.pk)
             return True, False
     except (PermissionError, ValueError) as exc:
         messages.error(request, str(exc))
@@ -164,7 +159,6 @@ def _queue_refit_upsert_request(
             refit=refit if refit.pk else None,
         )
         if req:
-            notify_fitting_change_request_proposed.delay(req.pk)
             return True, False
     except (PermissionError, ValueError) as exc:
         messages.error(request, str(exc))
@@ -528,7 +522,6 @@ class EveFittingAdmin(ApprovalQueuedAdminMixin, SafeDeleteAdmin):
                 return
 
             if req:
-                notify_fitting_change_request_proposed.delay(req.pk)
                 url = reverse(
                     "admin:fittings_evefittingchangerequest_change",
                     args=[req.pk],
@@ -573,7 +566,6 @@ class EveFittingAdmin(ApprovalQueuedAdminMixin, SafeDeleteAdmin):
             return
 
         if req:
-            notify_fitting_change_request_proposed.delay(req.pk)
             url = reverse(
                 "admin:fittings_evefittingchangerequest_change",
                 args=[req.pk],
@@ -602,7 +594,6 @@ class EveFittingAdmin(ApprovalQueuedAdminMixin, SafeDeleteAdmin):
             return
 
         if req:
-            notify_fitting_change_request_proposed.delay(req.pk)
             url = reverse(
                 "admin:fittings_evefittingchangerequest_change",
                 args=[req.pk],
@@ -633,7 +624,6 @@ class EveFittingAdmin(ApprovalQueuedAdminMixin, SafeDeleteAdmin):
                 messages.error(request, str(exc))
                 return
             if req:
-                notify_fitting_change_request_proposed.delay(req.pk)
                 queued += 1
         if queued:
             messages.warning(
@@ -1213,7 +1203,6 @@ class EveDoctrineAdmin(ApprovalQueuedAdminMixin, admin.ModelAdmin):
                 messages.error(request, str(exc))
                 return
             if req:
-                notify_doctrine_change_request_proposed.delay(req.pk)
                 url = reverse(
                     "admin:fittings_evedoctrinechangerequest_change",
                     args=[req.pk],
@@ -1240,7 +1229,6 @@ class EveDoctrineAdmin(ApprovalQueuedAdminMixin, admin.ModelAdmin):
             messages.error(request, str(exc))
             return
         if req:
-            notify_doctrine_change_request_proposed.delay(req.pk)
             url = reverse(
                 "admin:fittings_evedoctrinechangerequest_change",
                 args=[req.pk],

--- a/backend/fittings/helpers/notifications.py
+++ b/backend/fittings/helpers/notifications.py
@@ -3,14 +3,9 @@
 import logging
 
 from django.conf import settings
-from django.urls import reverse
 
 from discord.client import DiscordClient
 from discord.models import DiscordUser
-from fittings.helpers.permissions import (
-    users_who_can_approve_doctrine_request,
-    users_who_can_approve_fitting_request,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -42,52 +37,6 @@ def _send_dm(user, message: str):
             user,
             exc_info=True,
         )
-
-
-def notify_doctrine_change_proposed(change_request):
-    base = _admin_site_base()
-    path = reverse(
-        "admin:fittings_evedoctrinechangerequest_change",
-        args=[change_request.pk],
-    )
-    link = f"{base}{path}" if base else path
-    tier = change_request.tier.replace("_", " ")
-    submitter = (
-        change_request.submitted_by.username
-        if change_request.submitted_by
-        else "unknown"
-    )
-    message = (
-        f"**Doctrine change proposed** ({tier})\n"
-        f"Doctrine: **{change_request.doctrine.name}**\n"
-        f"Submitted by: {submitter}\n"
-        f"Review: {link}"
-    )
-    for user in users_who_can_approve_doctrine_request(change_request.tier):
-        _send_dm(user, message)
-
-
-def notify_fitting_change_proposed(change_request):
-    base = _admin_site_base()
-    path = reverse(
-        "admin:fittings_evefittingchangerequest_change",
-        args=[change_request.pk],
-    )
-    link = f"{base}{path}" if base else path
-    tier = change_request.tier.replace("_", " ")
-    submitter = (
-        change_request.submitted_by.username
-        if change_request.submitted_by
-        else "unknown"
-    )
-    message = (
-        f"**Fitting change proposed** ({tier})\n"
-        f"Fitting: **{change_request.fitting.name}**\n"
-        f"Submitted by: {submitter}\n"
-        f"Review: {link}"
-    )
-    for user in users_who_can_approve_fitting_request(change_request.tier):
-        _send_dm(user, message)
 
 
 def build_daily_reminder_message(

--- a/backend/fittings/tasks.py
+++ b/backend/fittings/tasks.py
@@ -1,13 +1,9 @@
-import logging
-
 from django.contrib.auth import get_user_model
 
 from app.celery import app
 from fittings.helpers.notifications import (
     _send_dm,
     build_daily_reminder_message,
-    notify_doctrine_change_proposed,
-    notify_fitting_change_proposed,
 )
 from fittings.helpers.permissions import (
     can_approve_doctrine_request,
@@ -19,43 +15,7 @@ from fittings.models import (
     EveFittingChangeRequest,
 )
 
-logger = logging.getLogger(__name__)
-
 user_model = get_user_model()
-
-
-@app.task
-def notify_doctrine_change_request_proposed(change_request_id: int):
-    change_request = (
-        EveDoctrineChangeRequest.objects.select_related(
-            "doctrine", "submitted_by"
-        )
-        .filter(pk=change_request_id)
-        .first()
-    )
-    if (
-        not change_request
-        or change_request.status != ChangeRequestStatus.PENDING
-    ):
-        return
-    notify_doctrine_change_proposed(change_request)
-
-
-@app.task
-def notify_fitting_change_request_proposed(change_request_id: int):
-    change_request = (
-        EveFittingChangeRequest.objects.select_related(
-            "fitting", "submitted_by"
-        )
-        .filter(pk=change_request_id)
-        .first()
-    )
-    if (
-        not change_request
-        or change_request.status != ChangeRequestStatus.PENDING
-    ):
-        return
-    notify_fitting_change_proposed(change_request)
 
 
 @app.task

--- a/backend/fittings/tests_approval.py
+++ b/backend/fittings/tests_approval.py
@@ -1,7 +1,5 @@
 """Tests for doctrine/fitting approval workflow."""
 
-from unittest.mock import patch
-
 from django.contrib.auth.models import Permission, User
 from django.contrib.contenttypes.models import ContentType
 from django.test import Client
@@ -37,7 +35,6 @@ from fittings.helpers.permissions import (
     protection_tier_for_doctrine,
     users_who_can_approve_fitting_request,
 )
-from fittings.tasks import notify_fitting_change_request_proposed
 from fittings.models import (
     ChangeRequestStatus,
     DOCTRINE_TYPE_EXPERIMENTAL,
@@ -765,54 +762,11 @@ class FittingChangeRequestTestCase(TestCase):
         self.assertEqual("before", fitting.description)
 
 
-class NotificationTasksTestCase(TestCase):
-    """Discord notify on propose (mocked)."""
+class ApproverRecipientTestCase(TestCase):
+    """Who receives change-request review eligibility."""
 
     def _create_user(self, username, *, is_staff=False):
         return User.objects.create(username=username, is_staff=is_staff)
-
-    def test_notify_task_sends_dm_to_approvers(self):
-        proposer = self._create_user("proposer")
-        proposer.user_permissions.add(
-            _perm("change_doctrine_fitting_strategic")
-        )
-        approver = self._create_user("approver", is_staff=True)
-        approver.user_permissions.add(
-            _perm("approve_doctrine_fitting_strategic")
-        )
-        doctrine = EveDoctrine.objects.create(
-            name="Strat",
-            type=DOCTRINE_TYPE_STRATEGIC,
-            description="",
-        )
-        fitting = EveFitting.objects.create(
-            name="Fit",
-            eft_format="[Rifter, Fit]",
-            ship_id=587,
-            description="",
-        )
-        EveDoctrineFitting.objects.create(
-            doctrine=doctrine, fitting=fitting, role="primary"
-        )
-        req = submit_fitting_change_request(
-            fitting,
-            change_kind="fitting_versioned",
-            payload={
-                "eft_format": "[Rifter, X]",
-                "description": "x",
-                "aliases": "",
-                "minimum_pod": "",
-                "recommended_pod": "",
-                "tags": [],
-            },
-            user=proposer,
-        )
-        self.assertIsNotNone(req)
-        with patch("fittings.helpers.notifications._send_dm") as mock_dm:
-            notify_fitting_change_request_proposed(req.pk)
-            self.assertGreaterEqual(mock_dm.call_count, 1)
-            dm_users = [call.args[0] for call in mock_dm.call_args_list]
-            self.assertIn(approver, dm_users)
 
     def test_users_who_can_approve_fitting_non_strategic(self):
         skirmish = self._create_user("skirmish", is_staff=True)


### PR DESCRIPTION
## Summary
- Remove immediate Discord DMs when doctrine/fitting/refit change requests are proposed
- Keep the daily pending-review digest (`send_pending_change_request_reminders` at 15:00 UTC) as the only approver notification path
- Drop the unused propose-notify Celery tasks and helpers

## Test plan
- [x] `pipenv run python manage.py test fittings.tests_approval fittings.tests --settings=app.settings_test`
- [ ] Propose several fitting changes in admin and confirm no immediate Discord DMs
- [ ] Confirm pending items still appear in the daily digest DM for eligible staff approvers

Made with [Cursor](https://cursor.com)