### PR TITLE
Chain capital pings across systems and show fleet composition

### DIFF
--- a/backend/feed/helpers/capital_pings.py
+++ b/backend/feed/helpers/capital_pings.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections import Counter
 from datetime import timedelta
 from typing import Any
 
@@ -22,9 +23,14 @@ from feed.helpers.capital_ships import (
     filter_capital_ship_type_ids,
     killmail_involves_capital,
 )
-from feed.helpers.eve_names import resolve_character_names, resolve_type_names
+from feed.helpers.eve_names import (
+    resolve_character_names,
+    resolve_entity_names,
+    resolve_type_names,
+    without_capsule_ship_counts,
+)
 from feed.helpers.ingest import parse_r2z2_payload
-from feed.helpers.killmail_classify import is_npc_kill
+from feed.helpers.killmail_classify import attacker_pilot_count, is_npc_kill
 from feed.helpers.system_distance import light_years_between_systems
 from feed.models import FeedCapitalAlert, FeedCapitalPing
 
@@ -96,6 +102,77 @@ def _merge_character_lists(
             "name": entry.get("name") or f"Pilot {character_id}",
         }
     return list(merged.values())
+
+
+def _capital_character_ids(capitals: list[dict[str, Any]] | None) -> set[int]:
+    character_ids: set[int] = set()
+    for entry in capitals or []:
+        for character in entry.get("characters") or []:
+            character_id = character.get("character_id")
+            if character_id:
+                character_ids.add(int(character_id))
+    return character_ids
+
+
+def _system_entry(
+    *,
+    solar_system_id: int,
+    system_name: str,
+    distance_ly: float,
+) -> dict[str, Any]:
+    return {
+        "solar_system_id": int(solar_system_id),
+        "system_name": system_name,
+        "distance_ly": float(distance_ly),
+    }
+
+
+def _append_system(
+    systems: list[dict[str, Any]] | None,
+    *,
+    solar_system_id: int,
+    system_name: str,
+    distance_ly: float,
+) -> list[dict[str, Any]]:
+    """Extend the sighting chain; refresh tip if still in the same system."""
+    entry = _system_entry(
+        solar_system_id=solar_system_id,
+        system_name=system_name,
+        distance_ly=distance_ly,
+    )
+    chain = list(systems or [])
+    if chain and int(chain[-1]["solar_system_id"]) == int(solar_system_id):
+        chain[-1] = entry
+        return chain
+    chain.append(entry)
+    return chain
+
+
+def _systems_for_alert(alert: FeedCapitalAlert) -> list[dict[str, Any]]:
+    """Return stored chain, or a single-entry fallback for older alerts."""
+    if alert.systems:
+        return list(alert.systems)
+    return [
+        _system_entry(
+            solar_system_id=int(alert.solar_system_id),
+            system_name=alert.system_name,
+            distance_ly=float(alert.distance_ly),
+        )
+    ]
+
+
+def _format_system_line(
+    systems: list[dict[str, Any]] | None,
+    fallback_name: str,
+) -> str:
+    names = [
+        str(entry["system_name"])
+        for entry in systems or []
+        if entry.get("system_name")
+    ]
+    if not names:
+        return fallback_name
+    return " → ".join(names)
 
 
 def _capital_entries(raw: dict[str, Any]) -> list[dict[str, Any]]:
@@ -227,22 +304,181 @@ def _kill_entry(raw: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _attacker_rows_for_composition(
+    raw: dict[str, Any],
+) -> list[dict[str, Any]]:
+    return [
+        attacker
+        for attacker in raw.get("attackers") or []
+        if attacker.get("corporation_id") != _CONCORD_CORPORATION_ID
+    ]
+
+
+def _group_count_key(kind: str, entity_id: int) -> str:
+    return f"{kind}:{int(entity_id)}"
+
+
+def _parse_group_count_key(key: str) -> tuple[str, int] | None:
+    kind, _, raw_id = str(key).partition(":")
+    if kind not in ("alliance", "corporation") or not raw_id:
+        return None
+    try:
+        return kind, int(raw_id)
+    except (TypeError, ValueError):
+        return None
+
+
+def _composition_from_killmail(raw: dict[str, Any]) -> dict[str, Any]:
+    """Summarize attacking fleet size, main group, and top ship for one mail."""
+    attackers = _attacker_rows_for_composition(raw)
+    group_counts: Counter[str] = Counter()
+    ship_counts: Counter[str] = Counter()
+
+    for attacker in attackers:
+        alliance_id = attacker.get("alliance_id")
+        corporation_id = attacker.get("corporation_id")
+        if alliance_id:
+            group_counts[_group_count_key("alliance", int(alliance_id))] += 1
+        elif corporation_id:
+            group_counts[
+                _group_count_key("corporation", int(corporation_id))
+            ] += 1
+        ship_type_id = attacker.get("ship_type_id")
+        if ship_type_id:
+            ship_counts[str(int(ship_type_id))] += 1
+
+    return _finalize_composition(
+        attacker_count=attacker_pilot_count(raw),
+        group_counts=dict(group_counts),
+        ship_counts=dict(ship_counts),
+    )
+
+
+def _finalize_composition(
+    *,
+    attacker_count: int,
+    group_counts: dict[str, int],
+    ship_counts: dict[str, int],
+) -> dict[str, Any]:
+    composition: dict[str, Any] = {
+        "attacker_count": int(attacker_count),
+        "group_counts": {
+            key: int(count) for key, count in group_counts.items() if count
+        },
+        "ship_counts": {
+            key: int(count) for key, count in ship_counts.items() if count
+        },
+    }
+
+    if group_counts:
+        top_key, _ = max(group_counts.items(), key=lambda row: row[1])
+        parsed = _parse_group_count_key(top_key)
+        if parsed is not None:
+            kind, entity_id = parsed
+            names = resolve_entity_names([entity_id])
+            composition["main_group"] = {
+                "id": entity_id,
+                "name": names.get(entity_id, f"Entity {entity_id}"),
+                "kind": kind,
+            }
+
+    filtered_ships = without_capsule_ship_counts(ship_counts)
+    if filtered_ships:
+        top_type_key, top_count = max(
+            filtered_ships.items(), key=lambda row: row[1]
+        )
+        type_id = int(top_type_key)
+        ship_names = resolve_type_names([type_id])
+        composition["top_ship"] = {
+            "type_id": type_id,
+            "name": ship_names.get(type_id, f"Type {type_id}"),
+            "count": int(top_count),
+        }
+
+    return composition
+
+
+def _merge_counts(
+    existing: dict[str, int] | None,
+    incoming: dict[str, int] | None,
+) -> dict[str, int]:
+    merged: Counter[str] = Counter()
+    for key, count in dict(existing or {}).items():
+        merged[str(key)] += int(count)
+    for key, count in dict(incoming or {}).items():
+        merged[str(key)] += int(count)
+    return {key: value for key, value in merged.items() if value}
+
+
+def _merge_composition(
+    existing: dict[str, Any] | None,
+    incoming: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if not existing:
+        return dict(incoming or {})
+    if not incoming:
+        return dict(existing)
+    return _finalize_composition(
+        attacker_count=max(
+            int(existing.get("attacker_count") or 0),
+            int(incoming.get("attacker_count") or 0),
+        ),
+        group_counts=_merge_counts(
+            existing.get("group_counts"),
+            incoming.get("group_counts"),
+        ),
+        ship_counts=_merge_counts(
+            existing.get("ship_counts"),
+            incoming.get("ship_counts"),
+        ),
+    )
+
+
+def _composition_description_lines(
+    composition: dict[str, Any] | None,
+) -> list[str]:
+    if not composition:
+        return []
+    lines: list[str] = []
+    attacker_count = int(composition.get("attacker_count") or 0)
+    if attacker_count:
+        lines.append(f"**Attackers:** {attacker_count}")
+    main_group = composition.get("main_group") or {}
+    main_group_name = main_group.get("name")
+    if main_group_name:
+        lines.append(f"**Main group:** {main_group_name}")
+    top_ship = composition.get("top_ship") or {}
+    top_ship_name = top_ship.get("name")
+    if top_ship_name:
+        top_count = int(top_ship.get("count") or 1)
+        top_label = (
+            f"{top_ship_name} ×{top_count}" if top_count > 1 else top_ship_name
+        )
+        lines.append(f"**Top attacking ship:** {top_label}")
+    return lines
+
+
 def build_capital_alert_payload(
     *,
     system_name: str,
     distance_ly: float,
     capitals: list[dict[str, Any]],
     kills: list[dict[str, Any]],
+    systems: list[dict[str, Any]] | None = None,
+    composition: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build Discord payload for a capital presence alert.
 
     The Kills line is only included once there is more than one killmail
     associated with the alert (follow-up activity edits the original message).
+    ``systems`` is an ordered sighting chain; when present it is shown as
+    ``Aset → Frerstorn → Amamake`` on the System line.
     """
     description_lines = [
-        f"**System:** {system_name}",
+        f"**System:** {_format_system_line(systems, system_name)}",
         f"**Distance from Amamake:** {distance_ly:.1f} LY",
     ]
+    description_lines.extend(_composition_description_lines(composition))
     capital_labels = _capital_labels(capitals)
     if capital_labels:
         description_lines.append(
@@ -282,27 +518,52 @@ def build_capital_ping_payload(
     distance_ly: float,
 ) -> dict[str, Any]:
     del zkb  # presence alerts do not use zkb totals
-    system_name = _system_label(int(raw["solar_system_id"]))
+    solar_system_id = int(raw["solar_system_id"])
+    system_name = _system_label(solar_system_id)
     capitals = _capital_entries(raw)
     kills = [_kill_entry(raw)]
+    systems = [
+        _system_entry(
+            solar_system_id=solar_system_id,
+            system_name=system_name,
+            distance_ly=distance_ly,
+        )
+    ]
     return build_capital_alert_payload(
         system_name=system_name,
         distance_ly=distance_ly,
         capitals=capitals,
         kills=kills,
+        systems=systems,
+        composition=_composition_from_killmail(raw),
     )
 
 
-def _active_alert(solar_system_id: int) -> FeedCapitalAlert | None:
+def _active_alert(
+    solar_system_id: int,
+    capital_character_ids: set[int],
+) -> FeedCapitalAlert | None:
+    """Find a live alert for this system, or the same capital pilot(s) nearby.
+
+    Same-system matches win so unrelated caps in one system still coalesce.
+    Otherwise match on overlapping capital character ids so a pilot crossing
+    systems edits the original message instead of spamming new ones.
+    """
     cutoff = timezone.now() - timedelta(seconds=CAPITAL_PING_SESSION_SECONDS)
-    return (
-        FeedCapitalAlert.objects.filter(
-            solar_system_id=solar_system_id,
-            last_activity_at__gte=cutoff,
+    candidates = list(
+        FeedCapitalAlert.objects.filter(last_activity_at__gte=cutoff).order_by(
+            "-last_activity_at"
         )
-        .order_by("-last_activity_at")
-        .first()
     )
+    for alert in candidates:
+        if int(alert.solar_system_id) == int(solar_system_id):
+            return alert
+    if not capital_character_ids:
+        return None
+    for alert in candidates:
+        if _capital_character_ids(alert.capitals) & capital_character_ids:
+            return alert
+    return None
 
 
 def _post_alert_messages(
@@ -381,13 +642,23 @@ def _create_capital_alert(
     distance_ly: float,
     capitals: list[dict[str, Any]],
     kill: dict[str, Any],
+    composition: dict[str, Any],
     discord_client: DiscordClient,
 ) -> FeedCapitalAlert | None:
+    systems = [
+        _system_entry(
+            solar_system_id=solar_system_id,
+            system_name=system_name,
+            distance_ly=distance_ly,
+        )
+    ]
     discord_payload = build_capital_alert_payload(
         system_name=system_name,
         distance_ly=distance_ly,
         capitals=capitals,
         kills=[kill],
+        systems=systems,
+        composition=composition,
     )
     discord_messages = _post_alert_messages(
         discord_payload, discord_client=discord_client
@@ -398,8 +669,10 @@ def _create_capital_alert(
         solar_system_id=solar_system_id,
         system_name=system_name,
         distance_ly=distance_ly,
+        systems=systems,
         capitals=capitals,
         kills=[kill],
+        composition=composition,
         discord_messages=discord_messages,
         last_activity_at=timezone.now(),
     )
@@ -408,14 +681,24 @@ def _create_capital_alert(
 def _update_capital_alert(
     alert: FeedCapitalAlert,
     *,
+    solar_system_id: int,
     system_name: str,
     distance_ly: float,
     capitals: list[dict[str, Any]],
     kill: dict[str, Any],
+    composition: dict[str, Any],
     discord_client: DiscordClient,
 ) -> FeedCapitalAlert:
     alert.capitals = _merge_capitals(alert.capitals or [], capitals)
     alert.kills = list(alert.kills or []) + [kill]
+    alert.composition = _merge_composition(alert.composition, composition)
+    alert.systems = _append_system(
+        _systems_for_alert(alert),
+        solar_system_id=solar_system_id,
+        system_name=system_name,
+        distance_ly=distance_ly,
+    )
+    alert.solar_system_id = solar_system_id
     alert.distance_ly = distance_ly
     alert.system_name = system_name
     alert.last_activity_at = timezone.now()
@@ -424,12 +707,17 @@ def _update_capital_alert(
         distance_ly=alert.distance_ly,
         capitals=alert.capitals,
         kills=alert.kills,
+        systems=alert.systems,
+        composition=alert.composition,
     )
     _edit_alert_messages(alert, discord_payload, discord_client=discord_client)
     alert.save(
         update_fields=[
+            "solar_system_id",
             "capitals",
             "kills",
+            "composition",
+            "systems",
             "distance_ly",
             "system_name",
             "last_activity_at",
@@ -505,8 +793,12 @@ def maybe_notify_capital_kill(
     client = discord_client or DiscordClient()
     capitals = _capital_entries(raw)
     kill = _kill_entry(raw)
+    composition = _composition_from_killmail(raw)
     system_name = _system_label(int(solar_system_id))
-    existing = _active_alert(int(solar_system_id))
+    existing = _active_alert(
+        int(solar_system_id),
+        _capital_character_ids(capitals),
+    )
     created = existing is None
 
     try:
@@ -517,6 +809,7 @@ def maybe_notify_capital_kill(
                 distance_ly=distance_ly,
                 capitals=capitals,
                 kill=kill,
+                composition=composition,
                 discord_client=client,
             )
             if alert is None:
@@ -524,10 +817,12 @@ def maybe_notify_capital_kill(
         else:
             alert = _update_capital_alert(
                 existing,
+                solar_system_id=int(solar_system_id),
                 system_name=system_name,
                 distance_ly=distance_ly,
                 capitals=capitals,
                 kill=kill,
+                composition=composition,
                 discord_client=client,
             )
     except Exception:

--- a/backend/feed/helpers/eve_names.py
+++ b/backend/feed/helpers/eve_names.py
@@ -64,6 +64,34 @@ def resolve_type_names(type_ids: Iterable[int]) -> dict[int, str]:
     return names
 
 
+def _resolve_universe_names_via_esi(
+    ids: set[int],
+    *,
+    missing_label: str = "Entity",
+) -> dict[int, str]:
+    if not ids:
+        return {}
+
+    client = EsiClient(None)
+    names: dict[int, str] = {}
+    for chunk in _chunks(sorted(ids), 1000):
+        response = client.resolve_universe_names(chunk)
+        if response.success():
+            for row in response.results():
+                names[row["id"]] = row["name"]
+    for entity_id in ids:
+        names.setdefault(entity_id, f"{missing_label} {entity_id}")
+    return names
+
+
+def resolve_entity_names(entity_ids: Iterable[int]) -> dict[int, str]:
+    """Resolve alliance/corporation/character ids to names via ESI."""
+    ids = {int(entity_id) for entity_id in entity_ids if entity_id}
+    if not ids:
+        return {}
+    return _resolve_universe_names_via_esi(ids)
+
+
 def resolve_character_names(character_ids: Iterable[int]) -> dict[int, str]:
     ids = {int(character_id) for character_id in character_ids if character_id}
     if not ids:
@@ -78,23 +106,9 @@ def resolve_character_names(character_ids: Iterable[int]) -> dict[int, str]:
     }
     missing = ids - names.keys()
     if missing:
-        names.update(_resolve_universe_names_via_esi(missing))
-    return names
-
-
-def _resolve_universe_names_via_esi(ids: set[int]) -> dict[int, str]:
-    if not ids:
-        return {}
-
-    client = EsiClient(None)
-    names: dict[int, str] = {}
-    for chunk in _chunks(sorted(ids), 1000):
-        response = client.resolve_universe_names(chunk)
-        if response.success():
-            for row in response.results():
-                names[row["id"]] = row["name"]
-    for entity_id in ids:
-        names.setdefault(entity_id, f"Pilot {entity_id}")
+        names.update(
+            _resolve_universe_names_via_esi(missing, missing_label="Pilot")
+        )
     return names
 
 

--- a/backend/feed/migrations/0012_feedcapitalalert_systems.py
+++ b/backend/feed/migrations/0012_feedcapitalalert_systems.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("feed", "0011_feed_capital_alert"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="feedcapitalalert",
+            name="systems",
+            field=models.JSONField(default=list),
+        ),
+        migrations.AddField(
+            model_name="feedcapitalalert",
+            name="composition",
+            field=models.JSONField(default=dict),
+        ),
+    ]

--- a/backend/feed/models.py
+++ b/backend/feed/models.py
@@ -262,17 +262,22 @@ class FeedEventFleetLink(models.Model):
 class FeedCapitalAlert(models.Model):
     """One Discord message for a capital presence near Amamake.
 
-    Further capital-related kills in the same system (within the session TTL)
-    edit this message instead of posting new ones.
+    Further capital-related kills in the same system, or the same capital
+    pilot(s) crossing systems (within the session TTL), edit this message
+    instead of posting new ones. ``systems`` holds the ordered chain.
     """
 
     solar_system_id = models.BigIntegerField(db_index=True)
     system_name = models.CharField(max_length=64)
     distance_ly = models.FloatField()
-    # [{type_id, name, role, count}, ...]
+    # [{solar_system_id, system_name, distance_ly}, ...] ordered sighting chain
+    systems = models.JSONField(default=list)
+    # [{type_id, name, role, count, characters}, ...]
     capitals = models.JSONField(default=list)
     # [{killmail_id, ship_name, time_hhmm}, ...]
     kills = models.JSONField(default=list)
+    # {attacker_count, main_group, top_ship, group_counts, ship_counts}
+    composition = models.JSONField(default=dict)
     # [{channel_id, message_id}, ...]
     discord_messages = models.JSONField(default=list)
     last_activity_at = models.DateTimeField(db_index=True)

--- a/backend/feed/tests/test_capital_pings.py
+++ b/backend/feed/tests/test_capital_pings.py
@@ -213,9 +213,9 @@ class CapitalPingTestCase(TestCase):
         make_capital_ping_channel()
         esi_patcher = patch(
             "feed.helpers.eve_names._resolve_universe_names_via_esi",
-            side_effect=lambda ids: {
-                int(character_id): f"Pilot {character_id}"
-                for character_id in ids
+            side_effect=lambda ids, missing_label="Entity": {
+                int(entity_id): f"{missing_label} {entity_id}"
+                for entity_id in ids
             },
         )
         esi_patcher.start()
@@ -239,6 +239,19 @@ class CapitalPingTestCase(TestCase):
                     ],
                 }
             ],
+            composition={
+                "attacker_count": 4,
+                "main_group": {
+                    "id": 99000000,
+                    "name": "Test Alliance",
+                    "kind": "alliance",
+                },
+                "top_ship": {
+                    "type_id": 73790,
+                    "name": "Revelation Navy Issue",
+                    "count": 1,
+                },
+            },
             kills=[
                 {
                     "killmail_id": 1,
@@ -250,6 +263,12 @@ class CapitalPingTestCase(TestCase):
         embed = built["embeds"][0]
         self.assertEqual(embed["title"], CAPITAL_ALERT_TITLE)
         self.assertIn("Amamake", embed["description"])
+        self.assertIn("**Attackers:** 4", embed["description"])
+        self.assertIn("**Main group:** Test Alliance", embed["description"])
+        self.assertIn(
+            "**Top attacking ship:** Revelation Navy Issue",
+            embed["description"],
+        )
         self.assertIn("Revelation Navy Issue", embed["description"])
         self.assertIn(
             "[Dread Pilot](https://zkillboard.com/character/2111000001/)",
@@ -296,6 +315,56 @@ class CapitalPingTestCase(TestCase):
             description,
         )
 
+    def test_build_capital_alert_payload_system_chain(self):
+        built = build_capital_alert_payload(
+            system_name="Amamake",
+            distance_ly=0.0,
+            systems=[
+                {
+                    "solar_system_id": 30002084,
+                    "system_name": "Aset",
+                    "distance_ly": 3.2,
+                },
+                {
+                    "solar_system_id": 30002090,
+                    "system_name": "Frerstorn",
+                    "distance_ly": 3.5,
+                },
+                {
+                    "solar_system_id": AMAMAKE_SOLAR_SYSTEM_ID,
+                    "system_name": "Amamake",
+                    "distance_ly": 0.0,
+                },
+            ],
+            capitals=[
+                {
+                    "type_id": 73790,
+                    "name": "Revelation Navy Issue",
+                    "role": "attacker",
+                    "count": 1,
+                    "characters": [
+                        {
+                            "character_id": 2111000001,
+                            "name": "Dread Pilot",
+                        }
+                    ],
+                }
+            ],
+            kills=[
+                {
+                    "killmail_id": 1,
+                    "ship_name": "Exequror Navy Issue",
+                    "time_hhmm": "17:00",
+                }
+            ],
+        )
+        description = built["embeds"][0]["description"]
+        self.assertIn(
+            "**System:** Aset → Frerstorn → Amamake",
+            description,
+        )
+        self.assertIn("**Distance from Amamake:** 0.0 LY", description)
+
     def test_build_capital_ping_payload(self):
         victim_character_id = 80000001
         EveCharacter.objects.create(
@@ -306,6 +375,7 @@ class CapitalPingTestCase(TestCase):
             136500001,
             solar_system_id=AMAMAKE_SOLAR_SYSTEM_ID,
             ship_type_id=73790,
+            attacker_ship_type_id=17726,
             attacker_count=5,
         )
         raw = payload["killmail"]
@@ -319,6 +389,12 @@ class CapitalPingTestCase(TestCase):
         description = built["embeds"][0]["description"]
         self.assertIn("Amamake", description)
         self.assertIn("Revelation Navy Issue", description)
+        self.assertIn("**Attackers:** 5", description)
+        self.assertIn("**Main group:** Entity 99000000", description)
+        self.assertIn(
+            "**Top attacking ship:** Machariel ×5",
+            description,
+        )
         self.assertIn(
             f"[Capital Victim]({ZKILL_CHARACTER_URL.format(character_id=victim_character_id)})",
             description,
@@ -362,11 +438,110 @@ class CapitalPingTestCase(TestCase):
 
         alert = FeedCapitalAlert.objects.get()
         self.assertEqual(len(alert.kills), 2)
+        self.assertEqual(len(alert.systems), 1)
+        self.assertEqual(alert.systems[0]["system_name"], "Amamake")
         edit_payload = mock_client.update_message.call_args.kwargs["payload"]
         self.assertIn(
             "Kills: Exequror Navy Issue (17:00), Exequror Navy Issue (17:01)",
             edit_payload["embeds"][0]["description"],
         )
+
+    @patch("feed.helpers.capital_pings.DiscordClient")
+    def test_same_capital_crossing_systems_edits_chain(self, mock_client_cls):
+        mock_client = MagicMock()
+        create_response = MagicMock()
+        create_response.json.return_value = {"id": "999888780"}
+        mock_client.create_message.return_value = create_response
+        mock_client_cls.return_value = mock_client
+
+        # ~1 LY from Amamake at origin (METERS_PER_LIGHT_YEAR ≈ 9.46e15).
+        nearby_system_id = 30002084
+        make_test_solar_system(
+            solar_system_id=nearby_system_id,
+            name="Aset",
+            position_x=9.46e15,
+            position_y=0.0,
+            position_z=0.0,
+        )
+
+        first = make_killmail_payload(
+            136500030,
+            solar_system_id=nearby_system_id,
+            ship_type_id=17715,
+            attacker_ship_type_id=73790,
+            attacker_count=1,
+            killmail_time=datetime(2026, 7, 18, 14, 0, 0, tzinfo=dt_tz.utc),
+        )
+        second = make_killmail_payload(
+            136500031,
+            solar_system_id=AMAMAKE_SOLAR_SYSTEM_ID,
+            ship_type_id=17715,
+            attacker_ship_type_id=73790,
+            attacker_count=1,
+            killmail_time=datetime(2026, 7, 18, 14, 10, 0, tzinfo=dt_tz.utc),
+        )
+
+        self.assertTrue(maybe_notify_capital_kill(first))
+        self.assertTrue(maybe_notify_capital_kill(second))
+
+        self.assertEqual(FeedCapitalAlert.objects.count(), 1)
+        self.assertEqual(FeedCapitalPing.objects.count(), 2)
+        mock_client.create_message.assert_called_once()
+        mock_client.update_message.assert_called_once()
+
+        alert = FeedCapitalAlert.objects.get()
+        self.assertEqual(alert.solar_system_id, AMAMAKE_SOLAR_SYSTEM_ID)
+        self.assertEqual(
+            [entry["system_name"] for entry in alert.systems],
+            ["Aset", "Amamake"],
+        )
+        edit_payload = mock_client.update_message.call_args.kwargs["payload"]
+        self.assertIn(
+            "**System:** Aset → Amamake",
+            edit_payload["embeds"][0]["description"],
+        )
+
+    @patch("feed.helpers.capital_pings.DiscordClient")
+    def test_different_capitals_in_different_systems_stay_separate(
+        self, mock_client_cls
+    ):
+        mock_client = MagicMock()
+        create_response = MagicMock()
+        create_response.json.side_effect = [{"id": "111"}, {"id": "222"}]
+        mock_client.create_message.return_value = create_response
+        mock_client_cls.return_value = mock_client
+
+        nearby_system_id = 30002090
+        make_test_solar_system(
+            solar_system_id=nearby_system_id,
+            name="Frerstorn",
+            position_x=9.46e15,
+            position_y=0.0,
+            position_z=0.0,
+        )
+
+        first = make_killmail_payload(
+            136500040,
+            solar_system_id=nearby_system_id,
+            ship_type_id=17715,
+            attacker_ship_type_id=73790,
+            attacker_count=1,
+        )
+        second = make_killmail_payload(
+            136500041,
+            solar_system_id=AMAMAKE_SOLAR_SYSTEM_ID,
+            ship_type_id=17715,
+            attacker_ship_type_id=73790,
+            attacker_count=1,
+        )
+        # Distinct capital pilot so character overlap does not chain alerts.
+        second["killmail"]["attackers"][0]["character_id"] = 91000001
+
+        self.assertTrue(maybe_notify_capital_kill(first))
+        self.assertTrue(maybe_notify_capital_kill(second))
+        self.assertEqual(FeedCapitalAlert.objects.count(), 2)
+        self.assertEqual(mock_client.create_message.call_count, 2)
+        mock_client.update_message.assert_not_called()
 
     @patch("feed.helpers.capital_pings.DiscordClient")
     def test_maybe_notify_ignores_non_capital(self, mock_client_cls):
@@ -399,6 +574,12 @@ class CapitalPingTestCase(TestCase):
         create_payload = mock_client.create_message.call_args.kwargs["payload"]
         description = create_payload["embeds"][0]["description"]
         self.assertIn("Revelation Navy Issue ×6", description)
+        self.assertIn("**Attackers:** 6", description)
+        self.assertIn("**Main group:** Entity 99000000", description)
+        self.assertIn(
+            "**Top attacking ship:** Revelation Navy Issue ×6",
+            description,
+        )
         self.assertIn(
             "[Pilot 90000000](https://zkillboard.com/character/90000000/)",
             description,
@@ -407,6 +588,36 @@ class CapitalPingTestCase(TestCase):
             "[Pilot 90000005](https://zkillboard.com/character/90000005/)",
             description,
         )
+
+    @patch("feed.helpers.capital_pings.DiscordClient")
+    def test_many_capitals_same_system_one_notification(self, mock_client_cls):
+        """Thirty distinct capital pilots in one system still share one alert."""
+        mock_client = MagicMock()
+        create_response = MagicMock()
+        create_response.json.return_value = {"id": "999888790"}
+        mock_client.create_message.return_value = create_response
+        mock_client_cls.return_value = mock_client
+
+        for index in range(30):
+            payload = make_killmail_payload(
+                136500100 + index,
+                solar_system_id=AMAMAKE_SOLAR_SYSTEM_ID,
+                ship_type_id=17715,
+                attacker_ship_type_id=73790,
+                attacker_count=1,
+            )
+            payload["killmail"]["attackers"][0]["character_id"] = (
+                92000000 + index
+            )
+            self.assertTrue(maybe_notify_capital_kill(payload))
+
+        self.assertEqual(FeedCapitalAlert.objects.count(), 1)
+        self.assertEqual(FeedCapitalPing.objects.count(), 30)
+        mock_client.create_message.assert_called_once()
+        self.assertEqual(mock_client.update_message.call_count, 29)
+        alert = FeedCapitalAlert.objects.get()
+        self.assertEqual(len(alert.capitals[0]["characters"]), 30)
+        self.assertEqual(alert.composition["attacker_count"], 1)
 
     @patch("feed.helpers.capital_pings.DiscordClient")
     def test_maybe_notify_ignores_out_of_range(self, mock_client_cls):


### PR DESCRIPTION
## Summary
- Same capital pilots crossing systems now edit the original Discord alert with a system chain (`Aset → Frerstorn → Amamake`) instead of posting duplicate messages
- Alerts include **Attackers**, **Main group**, and **Top attacking ship** (zkill-style fleet composition)
- Same-system activity still coalesces into one message within the session TTL (including many distinct capital pilots)

## Test plan
- [ ] `pipenv run python manage.py test feed.tests.test_capital_pings --settings=app.settings_test`
- [ ] Confirm a capital that moves systems updates one message with a system chain
- [ ] Confirm embed shows attackers / main group / top attacking ship
- [ ] Confirm multiple capital killmails in one system only create/edit a single alert


Made with [Cursor](https://cursor.com)