### PR TITLE
Freeze market contracts when title and content both match (≥80%)

### DIFF
--- a/backend/market/endpoints/get_contracts.py
+++ b/backend/market/endpoints/get_contracts.py
@@ -15,6 +15,7 @@ from market.endpoints.schemas import (
 from market.helpers import (
     get_historical_quantity_for_fitting,
 )
+from market.helpers.contract_stock import outstanding_stock_q
 from market.models import (
     EveMarketContract,
     EveMarketContractExpectation,
@@ -58,10 +59,10 @@ def fetch_eve_market_contracts(request, location_id: int):
     if not all_fitting_ids:
         return []
 
-    # Outstanding contract stats per fitting at this location
+    # Outstanding contract stats per fitting at this location (verified stock)
     outstanding_stats = {
         row["fitting_id"]: (row["count"], row["latest"])
-        for row in contracts_at_location.filter(status="outstanding")
+        for row in contracts_at_location.filter(outstanding_stock_q())
         .values("fitting_id")
         .annotate(
             count=Count("id"),

--- a/backend/market/helpers/contract_items.py
+++ b/backend/market/helpers/contract_items.py
@@ -3,8 +3,11 @@ import logging
 from django.utils import timezone
 
 from eveonline.client import EsiClient
+from eveonline.helpers.corporations import (
+    SCOPE_CORPORATION_CONTRACTS,
+    get_director_with_scope,
+)
 from eveonline.models import (
-    EveCharacter,
     EveCharacterContract,
     EveCorporationContract,
 )
@@ -12,10 +15,10 @@ from fittings.models import EveFitting
 
 from market.helpers.contract_match import (
     is_match_accepted,
+    market_relevant_same_ship_candidates,
     match_contract_to_fitting,
     normalize_contract_items,
 )
-from market.helpers.qualification import get_qualified_contract_fittings
 from market.models import EveMarketContract, EveMarketContractItem
 
 logger = logging.getLogger(__name__)
@@ -47,22 +50,29 @@ def store_contract_items(
 def apply_content_match(
     contract: EveMarketContract, contract_items: dict[int, int]
 ):
-    location = contract.location
-    candidates = (
-        list(get_qualified_contract_fittings(location))
-        if location
-        else list(EveFitting.objects.filter(deleted__isnull=True))
-    )
-    if not candidates and contract.fitting_id:
-        candidates = [contract.fitting]
+    """
+    Persist the highest-% same-ship fit and freeze it via items_fetched.
+
+    Below MATCH_THRESHOLD: clear fitting (drops out of verified stock) but keep
+    match_score for admin attention.
+    """
+    name_fitting = contract.fitting
+    if name_fitting:
+        candidates = market_relevant_same_ship_candidates(name_fitting)
+    else:
+        candidates = list(EveFitting.objects.filter(deleted__isnull=True))
 
     fitting, score, missing, extra = match_contract_to_fitting(
-        contract_items, candidates
+        contract_items,
+        candidates,
+        preferred_fitting=name_fitting,
     )
     contract.match_score = score
-    contract.match_is_flagged = score < 1.0 if score else False
+    contract.match_is_flagged = bool(score < 1.0) if score else True
     if fitting and is_match_accepted(score):
         contract.fitting = fitting
+    else:
+        contract.fitting = None
     contract.save(update_fields=["fitting", "match_score", "match_is_flagged"])
     return fitting, score, missing, extra
 
@@ -100,10 +110,9 @@ def fetch_private_contract_items(
         .first()
     )
     if corp_contract and corp_contract.corporation:
-        character = EveCharacter.objects.filter(
-            corporation_id=corp_contract.corporation.corporation_id,
-            token__isnull=False,
-        ).first()
+        character = get_director_with_scope(
+            corp_contract.corporation, SCOPE_CORPORATION_CONTRACTS
+        )
         if character:
             response = EsiClient(character).get_corporation_contract_items(
                 corp_contract.corporation.corporation_id,
@@ -111,6 +120,13 @@ def fetch_private_contract_items(
             )
             if response.success():
                 return True, response.results() or []
+        else:
+            logger.warning(
+                "No director with corporation contracts scope for corp %s "
+                "(contract %s)",
+                corp_contract.corporation.corporation_id,
+                contract.pk,
+            )
     return False, []
 
 

--- a/backend/market/helpers/contract_items.py
+++ b/backend/market/helpers/contract_items.py
@@ -13,10 +13,9 @@ from eveonline.models import (
 )
 
 from market.helpers.contract_match import (
-    content_match_candidates,
     is_match_accepted,
-    match_contract_to_fitting,
     normalize_contract_items,
+    score_contract_against_fitting,
 )
 from market.models import EveMarketContract, EveMarketContractItem
 
@@ -50,30 +49,31 @@ def apply_content_match(
     contract: EveMarketContract, contract_items: dict[int, int]
 ):
     """
-    Persist the highest-% market-relevant fit and freeze via items_fetched.
+    Require name AND content: score only against the title-resolved fitting.
 
-    Works with or without a title match: wrong/missing titles still assign a
-    fitting when module-weighted coverage is >= MATCH_THRESHOLD. Below
-    threshold: clear fitting but keep match_score for admin attention.
+    Keep fitting when module-weighted coverage >= MATCH_THRESHOLD; otherwise
+    clear fitting (keep match_score for admin). Freeze via items_fetched.
     """
-    preferred = contract.fitting
-    candidates = content_match_candidates(contract, contract_items)
-    if not candidates and preferred:
-        candidates = [preferred]
+    named = contract.fitting
+    if not named:
+        contract.match_score = 0.0
+        contract.match_is_flagged = True
+        contract.save(
+            update_fields=["fitting", "match_score", "match_is_flagged"]
+        )
+        return None, 0.0, [], []
 
-    fitting, score, missing, extra = match_contract_to_fitting(
-        contract_items,
-        candidates,
-        preferred_fitting=preferred,
+    score, missing, extra = score_contract_against_fitting(
+        contract_items, named
     )
     contract.match_score = score
     contract.match_is_flagged = bool(score < 1.0) if score else True
-    if fitting and is_match_accepted(score):
-        contract.fitting = fitting
+    if is_match_accepted(score):
+        contract.fitting = named
     else:
         contract.fitting = None
     contract.save(update_fields=["fitting", "match_score", "match_is_flagged"])
-    return fitting, score, missing, extra
+    return named if is_match_accepted(score) else None, score, missing, extra
 
 
 def fetch_public_contract_items(contract_id: int) -> tuple[bool, list[dict]]:

--- a/backend/market/helpers/contract_items.py
+++ b/backend/market/helpers/contract_items.py
@@ -11,11 +11,10 @@ from eveonline.models import (
     EveCharacterContract,
     EveCorporationContract,
 )
-from fittings.models import EveFitting
 
 from market.helpers.contract_match import (
+    content_match_candidates,
     is_match_accepted,
-    market_relevant_same_ship_candidates,
     match_contract_to_fitting,
     normalize_contract_items,
 )
@@ -51,21 +50,21 @@ def apply_content_match(
     contract: EveMarketContract, contract_items: dict[int, int]
 ):
     """
-    Persist the highest-% same-ship fit and freeze it via items_fetched.
+    Persist the highest-% market-relevant fit and freeze via items_fetched.
 
-    Below MATCH_THRESHOLD: clear fitting (drops out of verified stock) but keep
-    match_score for admin attention.
+    Works with or without a title match: wrong/missing titles still assign a
+    fitting when module-weighted coverage is >= MATCH_THRESHOLD. Below
+    threshold: clear fitting but keep match_score for admin attention.
     """
-    name_fitting = contract.fitting
-    if name_fitting:
-        candidates = market_relevant_same_ship_candidates(name_fitting)
-    else:
-        candidates = list(EveFitting.objects.filter(deleted__isnull=True))
+    preferred = contract.fitting
+    candidates = content_match_candidates(contract, contract_items)
+    if not candidates and preferred:
+        candidates = [preferred]
 
     fitting, score, missing, extra = match_contract_to_fitting(
         contract_items,
         candidates,
-        preferred_fitting=name_fitting,
+        preferred_fitting=preferred,
     )
     contract.match_score = score
     contract.match_is_flagged = bool(score < 1.0) if score else True

--- a/backend/market/helpers/contract_match.py
+++ b/backend/market/helpers/contract_match.py
@@ -1,11 +1,23 @@
+import re
 from collections import defaultdict
 
+from django.db.models import Q
 from eveuniverse.models import EveType
-from fittings.models import EveFitting
+from fittings.models import EveDoctrineFitting, EveFitting
 
+from market.helpers.contract_stock import MATCH_THRESHOLD
+from market.models.contract import EveMarketContractExpectation
 from market.models.item import parse_eft_items
 
-MATCH_THRESHOLD = 0.90
+# Hull, modules, subsystems, and rigs — exclude charges/drones/paste/fuel.
+_STRUCTURAL_CATEGORIES = frozenset({"Ship", "Module", "Subsystem"})
+
+_TAG_PREFIX = re.compile(r"^\[[^\]]+\]\s*")
+
+
+def strip_fitting_tag(name: str) -> str:
+    """Lowercase fitting/contract title with a leading [TAG] removed."""
+    return _TAG_PREFIX.sub("", (name or "").strip()).strip().lower()
 
 
 def normalize_contract_items(raw_items: list[dict]) -> dict[int, int]:
@@ -21,6 +33,7 @@ def normalize_contract_items(raw_items: list[dict]) -> dict[int, int]:
 
 
 def fitting_type_quantities(fitting: EveFitting) -> dict[int, int]:
+    """Full EFT type quantities including consumables (for missing/extra display)."""
     per_name = parse_eft_items(fitting.eft_format)
     if not per_name:
         return {}
@@ -33,6 +46,35 @@ def fitting_type_quantities(fitting: EveFitting) -> dict[int, int]:
         type_id = name_to_id.get(name)
         if type_id:
             aggregated[type_id] += qty
+    return dict(aggregated)
+
+
+def fitting_structural_type_quantities(fitting: EveFitting) -> dict[int, int]:
+    """
+    Hull/module/subsystem quantities only.
+
+    Bulk charges and other consumables dominate FAX fits and erase Active vs
+    Buffer discrimination if left in the match score.
+    """
+    per_name = parse_eft_items(fitting.eft_format)
+    if not per_name:
+        return {}
+    names = list(per_name.keys())
+    type_rows = EveType.objects.filter(name__in=names).values_list(
+        "name", "id", "eve_group__eve_category__name"
+    )
+    name_to_meta = {
+        name: (type_id, category) for name, type_id, category in type_rows
+    }
+    aggregated = defaultdict(int)
+    for name, qty in per_name.items():
+        meta = name_to_meta.get(name)
+        if not meta:
+            continue
+        type_id, category = meta
+        if category not in _STRUCTURAL_CATEGORIES:
+            continue
+        aggregated[type_id] += qty
     return dict(aggregated)
 
 
@@ -49,29 +91,35 @@ def score_contract_against_fitting(
     contract_items: dict[int, int], fitting: EveFitting
 ) -> tuple[float, list[tuple[str, int]], list[tuple[str, int]]]:
     """
-    Quantity-weighted coverage of fitting requirements.
-    Returns (score, missing, extra) where missing/extra are (item_name, qty).
+    Module-weighted coverage of fitting requirements.
+
+    Score uses structural items only. Missing/extra lists still include the
+    full EFT (consumables) for admin display.
     """
-    fit_items = fitting_type_quantities(fitting)
-    if not fit_items:
+    score_items = fitting_structural_type_quantities(fitting)
+    display_items = fitting_type_quantities(fitting)
+    if not score_items and not display_items:
         return 0.0, [], []
 
-    total_required = sum(fit_items.values())
+    total_required = sum(score_items.values())
     matched = 0
     missing = []
-    fit_type_ids = set(fit_items.keys())
+    fit_type_ids = set(display_items.keys())
     type_names = _type_names_for_ids(fit_type_ids | set(contract_items.keys()))
 
-    for type_id, required in fit_items.items():
+    for type_id, required in score_items.items():
         have = contract_items.get(type_id, 0)
         matched += min(have, required)
+
+    for type_id, required in display_items.items():
+        have = contract_items.get(type_id, 0)
         if have < required:
             name = type_names.get(type_id, str(type_id))
             missing.append((name, required - have))
 
     extra = []
     for type_id, have in contract_items.items():
-        required = fit_items.get(type_id, 0)
+        required = display_items.get(type_id, 0)
         if have > required:
             name = type_names.get(type_id, str(type_id))
             extra.append((name, have - required))
@@ -86,13 +134,16 @@ def score_contract_against_fitting(
 def match_contract_to_fitting(
     contract_items: dict[int, int],
     candidates,
+    preferred_fitting: EveFitting | None = None,
 ) -> tuple[
     EveFitting | None, float, list[tuple[str, int]], list[tuple[str, int]]
 ]:
+    """Pick the highest-scoring candidate; ties prefer preferred_fitting."""
     best_fitting = None
-    best_score = 0.0
+    best_score = -1.0
     best_missing: list[tuple[str, int]] = []
     best_extra: list[tuple[str, int]] = []
+    preferred_pk = preferred_fitting.pk if preferred_fitting else None
 
     for fitting in candidates:
         score, missing, extra = score_contract_against_fitting(
@@ -103,7 +154,14 @@ def match_contract_to_fitting(
             best_fitting = fitting
             best_missing = missing
             best_extra = extra
-        elif score == best_score and best_fitting and fitting.ship_id:
+            continue
+        if score < best_score or best_fitting is None:
+            continue
+        if preferred_pk is not None and fitting.pk == preferred_pk:
+            best_fitting = fitting
+            best_missing = missing
+            best_extra = extra
+        elif preferred_pk is None and fitting.ship_id:
             if (
                 fitting.ship_id in contract_items
                 and best_fitting.ship_id not in contract_items
@@ -112,8 +170,39 @@ def match_contract_to_fitting(
                 best_missing = missing
                 best_extra = extra
 
+    if best_score < 0:
+        return None, 0.0, [], []
     return best_fitting, best_score, best_missing, best_extra
 
 
 def is_match_accepted(score: float) -> bool:
     return score >= MATCH_THRESHOLD
+
+
+def market_relevant_same_ship_candidates(
+    name_fitting: EveFitting,
+) -> list[EveFitting]:
+    """
+    Name-resolved fit plus other active same-ship fits that are on a doctrine
+    or have a contract expectation (so Active Apostle is included when named).
+    """
+    if not name_fitting.ship_id:
+        return [name_fitting]
+
+    doctrine_ids = EveDoctrineFitting.objects.values_list(
+        "fitting_id", flat=True
+    )
+    expectation_ids = EveMarketContractExpectation.objects.values_list(
+        "fitting_id", flat=True
+    )
+    return list(
+        EveFitting.objects.filter(
+            deleted__isnull=True, ship_id=name_fitting.ship_id
+        )
+        .filter(
+            Q(pk=name_fitting.pk)
+            | Q(pk__in=doctrine_ids)
+            | Q(pk__in=expectation_ids)
+        )
+        .order_by("name")
+    )

--- a/backend/market/helpers/contract_match.py
+++ b/backend/market/helpers/contract_match.py
@@ -3,16 +3,10 @@ from __future__ import annotations
 import re
 from collections import defaultdict
 
-from django.db.models import Q
 from eveuniverse.models import EveType
-from fittings.models import EveDoctrineFitting, EveFitting
+from fittings.models import EveFitting
 
 from market.helpers.contract_stock import MATCH_THRESHOLD
-from market.helpers.qualification import get_qualified_contract_fittings
-from market.models.contract import (
-    EveMarketContract,
-    EveMarketContractExpectation,
-)
 from market.models.item import parse_eft_items
 
 # Hull, modules, subsystems, and rigs — exclude charges/drones/paste/fuel.
@@ -183,76 +177,3 @@ def match_contract_to_fitting(
 
 def is_match_accepted(score: float) -> bool:
     return score >= MATCH_THRESHOLD
-
-
-def _market_relevant_fitting_ids() -> set[int]:
-    doctrine_ids = set(
-        EveDoctrineFitting.objects.values_list("fitting_id", flat=True)
-    )
-    expectation_ids = set(
-        EveMarketContractExpectation.objects.values_list(
-            "fitting_id", flat=True
-        )
-    )
-    return doctrine_ids | expectation_ids
-
-
-def market_relevant_same_ship_candidates(
-    name_fitting: EveFitting,
-) -> list[EveFitting]:
-    """
-    Name-resolved fit plus other active same-ship fits that are on a doctrine
-    or have a contract expectation (so Active Apostle is included when named).
-    """
-    if not name_fitting.ship_id:
-        return [name_fitting]
-
-    relevant_ids = _market_relevant_fitting_ids()
-    return list(
-        EveFitting.objects.filter(
-            deleted__isnull=True, ship_id=name_fitting.ship_id
-        )
-        .filter(Q(pk=name_fitting.pk) | Q(pk__in=relevant_ids))
-        .order_by("name")
-    )
-
-
-def content_match_candidates(
-    contract: EveMarketContract,
-    contract_items: dict[int, int],
-) -> list[EveFitting]:
-    """
-    Candidates for content matching.
-
-    Prefer market-relevant fittings whose ship hull appears in the contract
-    items (works when the title is wrong or missing). Fall back to location
-    doctrine fittings, then all market-relevant fittings.
-    """
-    preferred = contract.fitting
-    if preferred:
-        return market_relevant_same_ship_candidates(preferred)
-
-    # No usable title: any active fit for a hull present in the contract.
-    hull_type_ids = set(contract_items.keys())
-    by_hull = list(
-        EveFitting.objects.filter(
-            deleted__isnull=True,
-            ship_id__in=hull_type_ids,
-        ).order_by("name")
-    )
-    if by_hull:
-        return by_hull
-
-    if contract.location_id:
-        location_fits = list(
-            get_qualified_contract_fittings(contract.location)
-        )
-        if location_fits:
-            return location_fits
-
-    relevant_ids = _market_relevant_fitting_ids()
-    return list(
-        EveFitting.objects.filter(
-            deleted__isnull=True, pk__in=relevant_ids
-        ).order_by("name")
-    )

--- a/backend/market/helpers/contract_match.py
+++ b/backend/market/helpers/contract_match.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from collections import defaultdict
 
@@ -6,7 +8,11 @@ from eveuniverse.models import EveType
 from fittings.models import EveDoctrineFitting, EveFitting
 
 from market.helpers.contract_stock import MATCH_THRESHOLD
-from market.models.contract import EveMarketContractExpectation
+from market.helpers.qualification import get_qualified_contract_fittings
+from market.models.contract import (
+    EveMarketContract,
+    EveMarketContractExpectation,
+)
 from market.models.item import parse_eft_items
 
 # Hull, modules, subsystems, and rigs — exclude charges/drones/paste/fuel.
@@ -179,6 +185,18 @@ def is_match_accepted(score: float) -> bool:
     return score >= MATCH_THRESHOLD
 
 
+def _market_relevant_fitting_ids() -> set[int]:
+    doctrine_ids = set(
+        EveDoctrineFitting.objects.values_list("fitting_id", flat=True)
+    )
+    expectation_ids = set(
+        EveMarketContractExpectation.objects.values_list(
+            "fitting_id", flat=True
+        )
+    )
+    return doctrine_ids | expectation_ids
+
+
 def market_relevant_same_ship_candidates(
     name_fitting: EveFitting,
 ) -> list[EveFitting]:
@@ -189,20 +207,52 @@ def market_relevant_same_ship_candidates(
     if not name_fitting.ship_id:
         return [name_fitting]
 
-    doctrine_ids = EveDoctrineFitting.objects.values_list(
-        "fitting_id", flat=True
-    )
-    expectation_ids = EveMarketContractExpectation.objects.values_list(
-        "fitting_id", flat=True
-    )
+    relevant_ids = _market_relevant_fitting_ids()
     return list(
         EveFitting.objects.filter(
             deleted__isnull=True, ship_id=name_fitting.ship_id
         )
-        .filter(
-            Q(pk=name_fitting.pk)
-            | Q(pk__in=doctrine_ids)
-            | Q(pk__in=expectation_ids)
-        )
+        .filter(Q(pk=name_fitting.pk) | Q(pk__in=relevant_ids))
         .order_by("name")
+    )
+
+
+def content_match_candidates(
+    contract: EveMarketContract,
+    contract_items: dict[int, int],
+) -> list[EveFitting]:
+    """
+    Candidates for content matching.
+
+    Prefer market-relevant fittings whose ship hull appears in the contract
+    items (works when the title is wrong or missing). Fall back to location
+    doctrine fittings, then all market-relevant fittings.
+    """
+    preferred = contract.fitting
+    if preferred:
+        return market_relevant_same_ship_candidates(preferred)
+
+    # No usable title: any active fit for a hull present in the contract.
+    hull_type_ids = set(contract_items.keys())
+    by_hull = list(
+        EveFitting.objects.filter(
+            deleted__isnull=True,
+            ship_id__in=hull_type_ids,
+        ).order_by("name")
+    )
+    if by_hull:
+        return by_hull
+
+    if contract.location_id:
+        location_fits = list(
+            get_qualified_contract_fittings(contract.location)
+        )
+        if location_fits:
+            return location_fits
+
+    relevant_ids = _market_relevant_fitting_ids()
+    return list(
+        EveFitting.objects.filter(
+            deleted__isnull=True, pk__in=relevant_ids
+        ).order_by("name")
     )

--- a/backend/market/helpers/contract_stock.py
+++ b/backend/market/helpers/contract_stock.py
@@ -1,0 +1,18 @@
+"""Helpers for whether market contracts count toward stock / expectations."""
+
+from django.db.models import Q
+
+# Shared with content matching (kept here to avoid model <-> match circular imports).
+MATCH_THRESHOLD = 0.80
+
+
+def outstanding_stock_q() -> Q:
+    """
+    Outstanding contracts that count toward stock.
+
+    Pending name matches (items not fetched yet) still count. After items are
+    fetched, only verified matches at or above MATCH_THRESHOLD count.
+    """
+    return Q(status="outstanding", fitting_id__isnull=False) & (
+        Q(items_fetched=False) | Q(match_score__gte=MATCH_THRESHOLD)
+    )

--- a/backend/market/helpers/contracts.py
+++ b/backend/market/helpers/contracts.py
@@ -9,6 +9,7 @@ from eveonline.models import EveCharacter, EveCorporation, EveLocation
 from fittings.forms import normalize_fitting_aliases
 from fittings.models import EveFitting
 
+from market.helpers.contract_match import strip_fitting_tag
 from market.models import (
     EveMarketContract,
     EveMarketContractError,
@@ -101,6 +102,19 @@ def get_fitting_for_contract(contract_summary: str) -> EveFitting | None:
                 fitting_cache[contract_summary] = candidate
                 return candidate
 
+    # Unique tag-stripped match: "Buffer Apostle" -> "[FL33T] Buffer Apostle"
+    bare_title = strip_fitting_tag(contract_summary)
+    if not bare_title:
+        return None
+    matches = [
+        candidate
+        for candidate in EveFitting.all_objects.filter(deleted__isnull=True)
+        if strip_fitting_tag(candidate.name) == bare_title
+    ]
+    if len(matches) == 1:
+        fitting_cache[contract_summary] = matches[0]
+        return matches[0]
+
     return None
 
 
@@ -122,6 +136,9 @@ def create_or_update_contract_from_db_contract(
     Create or update EveMarketContract from an EveCharacterContract or
     EveCorporationContract. Only stores if type is item_exchange, location
     matches, and title matches a known fitting. Returns True if stored.
+
+    Once items have been fetched and a content match frozen, fitting/match_score
+    are not overwritten from the contract title.
     """
     if db_contract.type != EveMarketContract.esi_contract_type:
         logger.info(
@@ -153,6 +170,7 @@ def create_or_update_contract_from_db_contract(
         defaults={
             "price": db_contract.price or 0,
             "issuer_external_id": db_contract.issuer_id,
+            "fitting": fitting,
         },
     )
     contract.title = db_contract.title or ""
@@ -160,7 +178,8 @@ def create_or_update_contract_from_db_contract(
     contract.issued_at = db_contract.date_issued
     contract.expires_at = db_contract.date_expired
     contract.completed_at = db_contract.date_completed
-    contract.fitting = fitting
+    if not contract.items_fetched:
+        contract.fitting = fitting
     contract.location = location
     contract.is_public = False
     contract.assignee_id = db_contract.assignee_id
@@ -186,13 +205,15 @@ def create_or_update_contract(esi_contract, location: EveLocation):
         defaults={
             "price": esi_contract["price"],
             "issuer_external_id": esi_contract["issuer_id"],
+            "fitting": fitting,
         },
     )
     contract.title = esi_contract["title"]
     contract.status = "outstanding"
     contract.issued_at = esi_contract["date_issued"]
     contract.expires_at = esi_contract["date_expired"]
-    contract.fitting = fitting
+    if not contract.items_fetched:
+        contract.fitting = fitting
     contract.location = location
     contract.is_public = True
     contract.last_updated = timezone.now()

--- a/backend/market/helpers/contracts.py
+++ b/backend/market/helpers/contracts.py
@@ -134,8 +134,9 @@ def create_or_update_contract_from_db_contract(
 ) -> bool:
     """
     Create or update EveMarketContract from an EveCharacterContract or
-    EveCorporationContract. Only stores if type is item_exchange, location
-    matches, and title matches a known fitting. Returns True if stored.
+    EveCorporationContract. Stores item_exchange contracts at the location
+    even when the title does not match a fitting — content matching assigns
+    the fit after items are fetched.
 
     Once items have been fetched and a content match frozen, fitting/match_score
     are not overwritten from the contract title.
@@ -157,13 +158,6 @@ def create_or_update_contract_from_db_contract(
         )
         return False
     fitting = get_fitting_for_contract(db_contract.title or "")
-    if not fitting:
-        logger.info(
-            "Skipping contract %s: no fitting found for title %r",
-            db_contract.contract_id,
-            db_contract.title or "",
-        )
-        return False
     status = _map_contract_status(db_contract.status or "")
     contract, _ = EveMarketContract.objects.get_or_create(
         id=db_contract.contract_id,
@@ -197,8 +191,8 @@ def create_or_update_contract(esi_contract, location: EveLocation):
 
     fitting = get_fitting_for_contract(esi_contract["title"])
     if not fitting:
+        # Still ingest for content matching; keep alliance title errors for admin.
         record_unmatched_contract(esi_contract, location)
-        return
 
     contract, _ = EveMarketContract.objects.get_or_create(
         id=esi_contract["contract_id"],
@@ -210,8 +204,8 @@ def create_or_update_contract(esi_contract, location: EveLocation):
     )
     contract.title = esi_contract["title"]
     contract.status = "outstanding"
-    contract.issued_at = esi_contract["date_issued"]
-    contract.expires_at = esi_contract["date_expired"]
+    contract.issued_at = esi_contract.get("date_issued")
+    contract.expires_at = esi_contract.get("date_expired")
     if not contract.items_fetched:
         contract.fitting = fitting
     contract.location = location

--- a/backend/market/helpers/contracts.py
+++ b/backend/market/helpers/contracts.py
@@ -134,9 +134,9 @@ def create_or_update_contract_from_db_contract(
 ) -> bool:
     """
     Create or update EveMarketContract from an EveCharacterContract or
-    EveCorporationContract. Stores item_exchange contracts at the location
-    even when the title does not match a fitting — content matching assigns
-    the fit after items are fetched.
+    EveCorporationContract. Only stores if type is item_exchange, location
+    matches, and title matches a known fitting (exact / alias / unique
+    tag-strip). Content matching then verifies modules against that fit.
 
     Once items have been fetched and a content match frozen, fitting/match_score
     are not overwritten from the contract title.
@@ -158,6 +158,13 @@ def create_or_update_contract_from_db_contract(
         )
         return False
     fitting = get_fitting_for_contract(db_contract.title or "")
+    if not fitting:
+        logger.info(
+            "Skipping contract %s: no fitting found for title %r",
+            db_contract.contract_id,
+            db_contract.title or "",
+        )
+        return False
     status = _map_contract_status(db_contract.status or "")
     contract, _ = EveMarketContract.objects.get_or_create(
         id=db_contract.contract_id,
@@ -191,8 +198,8 @@ def create_or_update_contract(esi_contract, location: EveLocation):
 
     fitting = get_fitting_for_contract(esi_contract["title"])
     if not fitting:
-        # Still ingest for content matching; keep alliance title errors for admin.
         record_unmatched_contract(esi_contract, location)
+        return
 
     contract, _ = EveMarketContract.objects.get_or_create(
         id=esi_contract["contract_id"],

--- a/backend/market/helpers/expectations_admin.py
+++ b/backend/market/helpers/expectations_admin.py
@@ -7,6 +7,7 @@ from django.utils.http import urlencode
 from fittings.models import EveDoctrineFitting
 
 from market.helpers.contract_admin import count_mismatched_contracts
+from market.helpers.contract_stock import outstanding_stock_q
 from market.helpers.expectations_changelist import (
     _format_doctrine_display,
     build_contract_expectations_changelist,
@@ -201,9 +202,8 @@ def build_contract_expectation_rows(location) -> list[dict]:
     outstanding_by_fitting = {
         row["fitting_id"]: row["c"]
         for row in EveMarketContract.objects.filter(
+            outstanding_stock_q(),
             location=location,
-            status="outstanding",
-            fitting__isnull=False,
         )
         .values("fitting_id")
         .annotate(c=Count("id"))

--- a/backend/market/helpers/ops_monitor.py
+++ b/backend/market/helpers/ops_monitor.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from eveonline.models import EveLocation
 from eveuniverse.models import EveType
 
+from market.helpers.contract_stock import outstanding_stock_q
 from market.helpers.item_ships import item_ships_by_location
 from market.helpers.readiness import fitting_readiness, shortfall
 from market.models import (
@@ -116,9 +117,8 @@ def build_ops_monitor(*, location_id: int | None = None) -> dict:  # noqa: C901
     outstanding = {
         (row["location_id"], row["fitting_id"]): row["count"]
         for row in EveMarketContract.objects.filter(
+            outstanding_stock_q(),
             location_id__in=location_pks,
-            status="outstanding",
-            fitting_id__isnull=False,
         )
         .values("location_id", "fitting_id")
         .annotate(count=Count("id"))

--- a/backend/market/models/contract.py
+++ b/backend/market/models/contract.py
@@ -3,6 +3,8 @@ from django.db import models
 from fittings.models import EveFitting
 from eveonline.models import EveLocation
 
+from market.helpers.contract_stock import outstanding_stock_q
+
 
 class EveMarketContractExpectation(models.Model):
     fitting = models.ForeignKey(EveFitting, on_delete=models.CASCADE)
@@ -15,9 +17,9 @@ class EveMarketContractExpectation(models.Model):
     @property
     def current_quantity(self):
         return EveMarketContract.objects.filter(
+            outstanding_stock_q(),
             fitting=self.fitting,
             location=self.location,
-            status="outstanding",
         ).count()
 
     @property

--- a/backend/market/tasks.py
+++ b/backend/market/tasks.py
@@ -1,6 +1,7 @@
 import logging
 import uuid
 
+from django.core.cache import cache
 from django.db.models import Q
 from django.utils import timezone
 from celery import chain, group
@@ -32,6 +33,12 @@ from market.models import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Global item-fetch pacing (Celery rate_limit is per-process; prod has multiple
+# market workers). Staggered countdown keeps ~10/m cluster-wide.
+CONTRACT_ITEMS_FETCH_CAP = 60
+CONTRACT_ITEMS_FETCH_INTERVAL_SECONDS = 6
+CONTRACT_ITEMS_SCHEDULE_CACHE_TTL = 3600
 
 
 @app.task()
@@ -428,18 +435,38 @@ def fetch_eve_market_contracts():
     logger.info("Updating expired contract statuses (since %s)", start_time)
     update_expired_contracts(start_time)
 
-    outstanding_without_items = EveMarketContract.objects.filter(
-        items_fetched=False,
-        status="outstanding",
-    ).values_list("id", flat=True)
-    for contract_id in outstanding_without_items:
-        fetch_contract_items_task.delay(contract_id)
+    outstanding_without_items = list(
+        EveMarketContract.objects.filter(
+            items_fetched=False,
+            status="outstanding",
+        )
+        .order_by("issued_at", "id")
+        .values_list("id", flat=True)[:CONTRACT_ITEMS_FETCH_CAP]
+    )
+    scheduled = 0
+    for i, contract_id in enumerate(outstanding_without_items):
+        cache_key = f"market:contract_items_scheduled:{contract_id}"
+        if not cache.add(
+            cache_key, "1", timeout=CONTRACT_ITEMS_SCHEDULE_CACHE_TTL
+        ):
+            continue
+        fetch_contract_items_task.apply_async(
+            args=[contract_id],
+            countdown=i * CONTRACT_ITEMS_FETCH_INTERVAL_SECONDS,
+            queue="market",
+        )
+        scheduled += 1
+    logger.info(
+        "Scheduled %s contract item fetch(es) (capped at %s)",
+        scheduled,
+        CONTRACT_ITEMS_FETCH_CAP,
+    )
 
     duration = (timezone.now() - start_time).total_seconds()
     logger.info("fetch_eve_market_contracts complete in %.1fs", duration)
 
 
-@app.task(rate_limit="1/s")
+@app.task(queue="market")
 def fetch_contract_items_task(contract_id: int) -> bool:
     return fetch_and_match_contract_items(contract_id)
 

--- a/backend/market/tests/test_market_vision.py
+++ b/backend/market/tests/test_market_vision.py
@@ -505,6 +505,46 @@ Armor Energizing Charge x1000
         self.assertIn(verified.id, stock_ids)
         self.assertNotIn(failed.id, stock_ids)
 
+    def test_wrong_title_still_content_matches(self):
+        """Contracts with nonsense titles match by hull/modules after items."""
+        location = _make_location(location_id=9104)
+        _make_typed_eve_type(37604, "Apostle", 6, "Ship")
+        _make_typed_eve_type(2048, "Damage Control II", 7, "Module")
+        _make_typed_eve_type(
+            20245,
+            "25000mm Crystalline Carbonide Restrained Plates",
+            7,
+            "Module",
+        )
+        buffer = EveFitting.objects.create(
+            name="[FL33T] Buffer Apostle",
+            ship_id=37604,
+            eft_format="""[Apostle, [FL33T] Buffer Apostle]
+Damage Control II
+25000mm Crystalline Carbonide Restrained Plates
+""",
+        )
+        EveMarketContractExpectation.objects.create(
+            fitting=buffer, location=location, quantity=1
+        )
+        contract = EveMarketContract.objects.create(
+            id=50006,
+            title="totally wrong apostle name",
+            price=1,
+            issuer_external_id=1,
+            status="outstanding",
+            location=location,
+            fitting=None,
+            is_public=False,
+        )
+        apply_content_match(
+            contract,
+            {37604: 1, 2048: 1, 20245: 1},
+        )
+        contract.refresh_from_db()
+        self.assertEqual(buffer.id, contract.fitting_id)
+        self.assertGreaterEqual(contract.match_score, MATCH_THRESHOLD)
+
 
 class SellOrderRowsTestCase(TestCase):
     def setUp(self):

--- a/backend/market/tests/test_market_vision.py
+++ b/backend/market/tests/test_market_vision.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.contrib import admin
@@ -24,6 +25,9 @@ from market.helpers.contract_match import (
     normalize_contract_items,
     score_contract_against_fitting,
 )
+from market.helpers.contract_stock import outstanding_stock_q
+from market.helpers.contracts import create_or_update_contract_from_db_contract
+from market.helpers.contract_items import apply_content_match
 from market.helpers.contract_items import fetch_and_match_contract_items
 from market.helpers.expectations_admin import (
     build_contract_expectation_rows,
@@ -262,10 +266,12 @@ Hail S x2000
 """,
             ship_id=22456,
         )
-        _make_eve_type(22456, "Sabre")
-        _make_eve_type(2605, "Nanofiber Internal Structure II")
-        _make_eve_type(2873, "125mm Gatling AutoCannon II")
-        _make_eve_type(12608, "Hail S")
+        _make_typed_eve_type(22456, "Sabre", 6, "Ship")
+        _make_typed_eve_type(
+            2605, "Nanofiber Internal Structure II", 7, "Module"
+        )
+        _make_typed_eve_type(2873, "125mm Gatling AutoCannon II", 7, "Module")
+        _make_typed_eve_type(12608, "Hail S", 8, "Charge")
 
     def test_normalize_contract_items_aggregates_slots(self):
         raw = [
@@ -316,10 +322,188 @@ Hail S x2000
             12608: 2000,
         }
         fitting, score, _, _ = match_contract_to_fitting(
-            contract_items, [other, self.fitting]
+            contract_items,
+            [other, self.fitting],
+            preferred_fitting=self.fitting,
+        )
+        self.assertEqual(self.fitting, fitting)
+        self.assertEqual(1.0, score)
+
+    def test_match_score_ignores_bulk_charges(self):
+        contract_items = {
+            22456: 1,
+            2605: 2,
+            2873: 5,
+            12608: 50,
+        }
+        score, missing, _ = score_contract_against_fitting(
+            contract_items, self.fitting
         )
         self.assertEqual(1.0, score)
-        self.assertIn(fitting, [self.fitting, other])
+        self.assertTrue(missing)
+
+    def test_highest_percent_wins_close_fits(self):
+        _make_typed_eve_type(37604, "Apostle", 6, "Ship")
+        _make_typed_eve_type(2048, "Damage Control II", 7, "Module")
+        _make_typed_eve_type(
+            41459, "Capital I-a Enduring Armor Repairer", 7, "Module"
+        )
+        _make_typed_eve_type(
+            20245,
+            "25000mm Crystalline Carbonide Restrained Plates",
+            7,
+            "Module",
+        )
+        _make_typed_eve_type(41490, "Armor Energizing Charge", 8, "Charge")
+
+        active = EveFitting.objects.create(
+            name="[FL33T] Active Apostle",
+            ship_id=37604,
+            eft_format="""[Apostle, [FL33T] Active Apostle]
+Damage Control II
+Capital I-a Enduring Armor Repairer
+Armor Energizing Charge x1000
+""",
+        )
+        buffer = EveFitting.objects.create(
+            name="[FL33T] Buffer Apostle",
+            ship_id=37604,
+            eft_format="""[Apostle, [FL33T] Buffer Apostle]
+Damage Control II
+25000mm Crystalline Carbonide Restrained Plates
+Armor Energizing Charge x1000
+""",
+        )
+        active_items = {
+            37604: 1,
+            2048: 1,
+            41459: 1,
+            41490: 1000,
+        }
+        fitting, score, _, _ = match_contract_to_fitting(
+            active_items,
+            [active, buffer],
+            preferred_fitting=buffer,
+        )
+        self.assertEqual(active, fitting)
+        self.assertGreaterEqual(score, MATCH_THRESHOLD)
+
+        buffer_items = {
+            37604: 1,
+            2048: 1,
+            20245: 1,
+            41490: 500,
+        }
+        fitting, score, _, _ = match_contract_to_fitting(
+            buffer_items,
+            [active, buffer],
+            preferred_fitting=buffer,
+        )
+        self.assertEqual(buffer, fitting)
+        self.assertGreaterEqual(score, MATCH_THRESHOLD)
+
+    def test_apply_content_match_clears_fitting_below_threshold(self):
+        location = _make_location(location_id=9101)
+        contract = EveMarketContract.objects.create(
+            id=50001,
+            title=self.fitting.name,
+            price=1,
+            issuer_external_id=1,
+            status="outstanding",
+            location=location,
+            fitting=self.fitting,
+            is_public=False,
+        )
+        apply_content_match(contract, {22456: 1})
+        contract.refresh_from_db()
+        self.assertIsNone(contract.fitting_id)
+        self.assertIsNotNone(contract.match_score)
+        self.assertLess(contract.match_score, MATCH_THRESHOLD)
+
+    def test_list_sync_does_not_overwrite_frozen_match(self):
+        location = _make_location(location_id=9102)
+        other = EveFitting.objects.create(
+            name="[FL33T] Sabre Frozen Sync",
+            eft_format=self.fitting.eft_format.replace(
+                "[FL33T] Sabre]", "[FL33T] Sabre Frozen Sync]", 1
+            ),
+            ship_id=22456,
+        )
+        contract = EveMarketContract.objects.create(
+            id=50002,
+            title=other.name,
+            price=1,
+            issuer_external_id=1,
+            status="outstanding",
+            location=location,
+            fitting=self.fitting,
+            is_public=False,
+            items_fetched=True,
+            match_score=0.95,
+        )
+        db_contract = SimpleNamespace(
+            contract_id=50002,
+            type=EveMarketContract.esi_contract_type,
+            start_location_id=location.location_id,
+            title=other.name,
+            status="outstanding",
+            price=1,
+            issuer_id=1,
+            date_issued=timezone.now(),
+            date_expired=timezone.now() + timedelta(days=7),
+            date_completed=None,
+            assignee_id=None,
+            acceptor_id=None,
+        )
+        self.assertTrue(
+            create_or_update_contract_from_db_contract(db_contract, location)
+        )
+        contract.refresh_from_db()
+        self.assertEqual(self.fitting.id, contract.fitting_id)
+        self.assertEqual(0.95, contract.match_score)
+
+    def test_outstanding_stock_q_pending_and_verified(self):
+        location = _make_location(location_id=9103)
+        pending = EveMarketContract.objects.create(
+            id=50003,
+            title="pending",
+            price=1,
+            issuer_external_id=1,
+            status="outstanding",
+            location=location,
+            fitting=self.fitting,
+            items_fetched=False,
+        )
+        verified = EveMarketContract.objects.create(
+            id=50004,
+            title="verified",
+            price=1,
+            issuer_external_id=1,
+            status="outstanding",
+            location=location,
+            fitting=self.fitting,
+            items_fetched=True,
+            match_score=0.9,
+        )
+        failed = EveMarketContract.objects.create(
+            id=50005,
+            title="failed",
+            price=1,
+            issuer_external_id=1,
+            status="outstanding",
+            location=location,
+            fitting=self.fitting,
+            items_fetched=True,
+            match_score=0.5,
+        )
+        stock_ids = set(
+            EveMarketContract.objects.filter(
+                outstanding_stock_q()
+            ).values_list("id", flat=True)
+        )
+        self.assertIn(pending.id, stock_ids)
+        self.assertIn(verified.id, stock_ids)
+        self.assertNotIn(failed.id, stock_ids)
 
 
 class SellOrderRowsTestCase(TestCase):

--- a/backend/market/tests/test_market_vision.py
+++ b/backend/market/tests/test_market_vision.py
@@ -343,6 +343,7 @@ Hail S x2000
         self.assertTrue(missing)
 
     def test_highest_percent_wins_close_fits(self):
+        """Named Buffer only keeps when items match Buffer (not Active)."""
         _make_typed_eve_type(37604, "Apostle", 6, "Ship")
         _make_typed_eve_type(2048, "Damage Control II", 7, "Module")
         _make_typed_eve_type(
@@ -374,33 +375,43 @@ Damage Control II
 Armor Energizing Charge x1000
 """,
         )
-        active_items = {
-            37604: 1,
-            2048: 1,
-            41459: 1,
-            41490: 1000,
-        }
-        fitting, score, _, _ = match_contract_to_fitting(
-            active_items,
-            [active, buffer],
-            preferred_fitting=buffer,
+        location = _make_location(location_id=9105)
+        buffer_contract = EveMarketContract.objects.create(
+            id=50007,
+            title="Buffer Apostle",
+            price=1,
+            issuer_external_id=1,
+            status="outstanding",
+            location=location,
+            fitting=buffer,
+            is_public=False,
         )
-        self.assertEqual(active, fitting)
-        self.assertGreaterEqual(score, MATCH_THRESHOLD)
+        # Active hull modules under a Buffer title → name matches, fit does not
+        apply_content_match(
+            buffer_contract,
+            {37604: 1, 2048: 1, 41459: 1, 41490: 1000},
+        )
+        buffer_contract.refresh_from_db()
+        self.assertIsNone(buffer_contract.fitting_id)
+        self.assertLess(buffer_contract.match_score, MATCH_THRESHOLD)
 
-        buffer_items = {
-            37604: 1,
-            2048: 1,
-            20245: 1,
-            41490: 500,
-        }
-        fitting, score, _, _ = match_contract_to_fitting(
-            buffer_items,
-            [active, buffer],
-            preferred_fitting=buffer,
+        active_contract = EveMarketContract.objects.create(
+            id=50008,
+            title="Active Apostle",
+            price=1,
+            issuer_external_id=1,
+            status="outstanding",
+            location=location,
+            fitting=active,
+            is_public=False,
         )
-        self.assertEqual(buffer, fitting)
-        self.assertGreaterEqual(score, MATCH_THRESHOLD)
+        apply_content_match(
+            active_contract,
+            {37604: 1, 2048: 1, 41459: 1, 41490: 1000},
+        )
+        active_contract.refresh_from_db()
+        self.assertEqual(active.id, active_contract.fitting_id)
+        self.assertGreaterEqual(active_contract.match_score, MATCH_THRESHOLD)
 
     def test_apply_content_match_clears_fitting_below_threshold(self):
         location = _make_location(location_id=9101)
@@ -505,8 +516,8 @@ Armor Energizing Charge x1000
         self.assertIn(verified.id, stock_ids)
         self.assertNotIn(failed.id, stock_ids)
 
-    def test_wrong_title_still_content_matches(self):
-        """Contracts with nonsense titles match by hull/modules after items."""
+    def test_nonsense_title_is_not_content_matched(self):
+        """Wrong/missing title never assigns from contents alone."""
         location = _make_location(location_id=9104)
         _make_typed_eve_type(37604, "Apostle", 6, "Ship")
         _make_typed_eve_type(2048, "Damage Control II", 7, "Module")
@@ -524,9 +535,6 @@ Damage Control II
 25000mm Crystalline Carbonide Restrained Plates
 """,
         )
-        EveMarketContractExpectation.objects.create(
-            fitting=buffer, location=location, quantity=1
-        )
         contract = EveMarketContract.objects.create(
             id=50006,
             title="totally wrong apostle name",
@@ -542,8 +550,23 @@ Damage Control II
             {37604: 1, 2048: 1, 20245: 1},
         )
         contract.refresh_from_db()
-        self.assertEqual(buffer.id, contract.fitting_id)
-        self.assertGreaterEqual(contract.match_score, MATCH_THRESHOLD)
+        self.assertIsNone(contract.fitting_id)
+        self.assertEqual(0.0, contract.match_score)
+
+        named = EveMarketContract.objects.create(
+            id=50009,
+            title="Buffer Apostle",
+            price=1,
+            issuer_external_id=1,
+            status="outstanding",
+            location=location,
+            fitting=buffer,
+            is_public=False,
+        )
+        apply_content_match(named, {37604: 1, 2048: 1, 20245: 1})
+        named.refresh_from_db()
+        self.assertEqual(buffer.id, named.fitting_id)
+        self.assertGreaterEqual(named.match_score, MATCH_THRESHOLD)
 
 
 class SellOrderRowsTestCase(TestCase):

--- a/backend/market/tests/test_tasks.py
+++ b/backend/market/tests/test_tasks.py
@@ -99,12 +99,14 @@ class MarketTaskTestCase(TestCase):
 
         contracts = EveMarketContract.objects.all()
 
-        self.assertEqual(1, contracts.count())
-        self.assertEqual(10000001, contracts[0].id)
-        self.assertEqual(fitting.id, contracts[0].fitting.id)
-        self.assertEqual(
-            location.location_id, contracts[0].location.location_id
-        )
+        # Matching-title contract + wrong-title contract at the same location
+        # (wrong titles are still ingested for content matching).
+        self.assertEqual(2, contracts.count())
+        matched = EveMarketContract.objects.get(id=10000001)
+        unmatched_title = EveMarketContract.objects.get(id=10000002)
+        self.assertEqual(fitting.id, matched.fitting.id)
+        self.assertIsNone(unmatched_title.fitting_id)
+        self.assertEqual(location.location_id, matched.location.location_id)
 
         contract_errors = EveMarketContractError.objects.all()
         self.assertEqual(1, contract_errors.count())
@@ -113,9 +115,10 @@ class MarketTaskTestCase(TestCase):
             "Seller", contract_errors.first().issuer.character_name
         )
         items_task_mock.apply_async.assert_called()
-        _, kwargs = items_task_mock.apply_async.call_args
-        self.assertEqual("market", kwargs["queue"])
-        self.assertEqual(0, kwargs["countdown"])
+        for call in items_task_mock.apply_async.call_args_list:
+            self.assertEqual("market", call.kwargs["queue"])
+            self.assertIn(call.kwargs["countdown"], (0, 6))
+        self.assertEqual(2, items_task_mock.apply_async.call_count)
 
     def test_get_fitting_id_for_contract(self):
         fitting_cache.clear()

--- a/backend/market/tests/test_tasks.py
+++ b/backend/market/tests/test_tasks.py
@@ -99,14 +99,12 @@ class MarketTaskTestCase(TestCase):
 
         contracts = EveMarketContract.objects.all()
 
-        # Matching-title contract + wrong-title contract at the same location
-        # (wrong titles are still ingested for content matching).
-        self.assertEqual(2, contracts.count())
-        matched = EveMarketContract.objects.get(id=10000001)
-        unmatched_title = EveMarketContract.objects.get(id=10000002)
-        self.assertEqual(fitting.id, matched.fitting.id)
-        self.assertIsNone(unmatched_title.fitting_id)
-        self.assertEqual(location.location_id, matched.location.location_id)
+        self.assertEqual(1, contracts.count())
+        self.assertEqual(10000001, contracts[0].id)
+        self.assertEqual(fitting.id, contracts[0].fitting.id)
+        self.assertEqual(
+            location.location_id, contracts[0].location.location_id
+        )
 
         contract_errors = EveMarketContractError.objects.all()
         self.assertEqual(1, contract_errors.count())
@@ -114,11 +112,10 @@ class MarketTaskTestCase(TestCase):
         self.assertEqual(
             "Seller", contract_errors.first().issuer.character_name
         )
-        items_task_mock.apply_async.assert_called()
-        for call in items_task_mock.apply_async.call_args_list:
-            self.assertEqual("market", call.kwargs["queue"])
-            self.assertIn(call.kwargs["countdown"], (0, 6))
-        self.assertEqual(2, items_task_mock.apply_async.call_count)
+        items_task_mock.apply_async.assert_called_once()
+        _, kwargs = items_task_mock.apply_async.call_args
+        self.assertEqual("market", kwargs["queue"])
+        self.assertEqual(0, kwargs["countdown"])
 
     def test_get_fitting_id_for_contract(self):
         fitting_cache.clear()

--- a/backend/market/tests/test_tasks.py
+++ b/backend/market/tests/test_tasks.py
@@ -18,6 +18,7 @@ from market.helpers import (
     update_completed_contracts,
     update_expired_contracts,
 )
+from market.helpers.contracts import fitting_cache
 from market.models import EveMarketContract, EveMarketContractError
 from market.tasks import fetch_eve_market_contracts
 
@@ -111,13 +112,24 @@ class MarketTaskTestCase(TestCase):
         self.assertEqual(
             "Seller", contract_errors.first().issuer.character_name
         )
+        items_task_mock.apply_async.assert_called()
+        _, kwargs = items_task_mock.apply_async.call_args
+        self.assertEqual("market", kwargs["queue"])
+        self.assertEqual(0, kwargs["countdown"])
 
     def test_get_fitting_id_for_contract(self):
+        fitting_cache.clear()
         fitting = EveFitting.objects.create(
             name="[FL33T] Thrasher",
             eft_format="[Thrasher, [FL33T] Thrasher]",
             ship_id=1001,
             aliases="[NVY-5] Thrasher,[L3ARN] Thrasher",
+        )
+        # Second tagged fit makes bare "Thrasher" ambiguous.
+        EveFitting.objects.create(
+            name="[NVY] Thrasher",
+            eft_format="[Thrasher, [NVY] Thrasher]",
+            ship_id=1001,
         )
 
         self.assertEqual(fitting, get_fitting_for_contract("[FL33T] Thrasher"))
@@ -129,6 +141,23 @@ class MarketTaskTestCase(TestCase):
         self.assertIsNone(get_fitting_for_contract(""))
         self.assertIsNone(get_fitting_for_contract("[FL33T] Stabber"))
         self.assertIsNone(get_fitting_for_contract("Thrasher"))
+
+        buffer = EveFitting.objects.create(
+            name="[FL33T] Buffer Apostle",
+            eft_format="[Apostle, [FL33T] Buffer Apostle]",
+            ship_id=37604,
+        )
+        EveFitting.objects.create(
+            name="[FL33T] Active Apostle",
+            eft_format="[Apostle, [FL33T] Active Apostle]",
+            ship_id=37604,
+        )
+        fitting_cache.clear()
+        self.assertEqual(buffer, get_fitting_for_contract("Buffer Apostle"))
+        self.assertEqual(
+            EveFitting.objects.get(name="[FL33T] Active Apostle"),
+            get_fitting_for_contract("Active Apostle"),
+        )
 
     def test_update_completed_contracts(self):
         cutoff = timezone.now()


### PR DESCRIPTION
## Summary
- **Both** title and contents must match: ingest only when the title resolves a fitting (exact / alias / unique tag-strip), then verify items against **that** fit at ≥80% module-weighted coverage.
- Wrong titles (e.g. `totally wrong apostle name`) are not stocked via contents alone; Rattini `Buffer Apostle` / `Active Apostle` still work via tag-strip + content check.
- Freeze `fitting` / `match_score` after `items_fetched` so hourly list sync cannot overwrite.
- Pace item ESI at ~10/m cluster-wide via staggered `countdown` on the `market` queue (cap 60/hour); corp items use director `read_corporation_contracts` scope.
- Stock counts pending named matches until fetched; after fetch, only verified scores ≥80% count.

## Test plan
- [x] `market.tests.test_tasks` + `ContractMatchTestCase` (name+content gate, Active/Buffer discrimination, nonsense title rejected, freeze, stock Q, pacing)
- [ ] Confirm Rattini Amamake Apostles appear after next hourly contract sync + item drain
- [ ] Confirm junk titles never enter stock / EveMarketContract