### PR TITLE
Fix ESI ETag 304 and singular result() wrapping

### DIFF
--- a/backend/eveonline/client.py
+++ b/backend/eveonline/client.py
@@ -178,6 +178,9 @@ class EsiClient:
         return {"Authorization": f"Bearer {token.valid_access_token()}"}
 
     def _operation_results(self, operation, **kwargs) -> EsiResponse:
+        # django-esi raises HTTPNotModified on 304 instead of returning the
+        # cached body, which surfaces as opaque 906. Default off for sync paths.
+        kwargs.setdefault("use_etag", False)
         try:
             return EsiResponse(
                 response_code=SUCCESS,
@@ -195,6 +198,8 @@ class EsiClient:
             return EsiResponse(response_code=ERROR_CALLING_ESI, response=e)
 
     def _operation_result(self, operation, **kwargs) -> EsiResponse:
+        # See _operation_results — same 304/ETag pitfall for single-object ops.
+        kwargs.setdefault("use_etag", False)
         try:
             return EsiResponse(
                 response_code=SUCCESS,
@@ -216,7 +221,8 @@ class EsiClient:
         operation = esi_provider.client.Character.GetCharactersDetail(
             character_id=char_id
         )
-        return self._operation_results(operation)
+        # Single-object endpoint: result(), not results().
+        return self._operation_result(operation)
 
     def get_character_skills(self) -> EsiResponse:
         """Returns the skills for the character this ESI client was created for."""
@@ -231,7 +237,7 @@ class EsiClient:
         )
 
         try:
-            data = _esi_to_python(operation.results())
+            data = _esi_to_python(operation.result(use_etag=False))
             return EsiResponse(
                 data=data["skills"] if data else None,
                 response_code=SUCCESS,
@@ -252,7 +258,7 @@ class EsiClient:
         )
         try:
             return EsiResponse(
-                data=_esi_to_python(operation.results()),
+                data=_esi_to_python(operation.results(use_etag=False)),
                 response_code=SUCCESS,
             )
         except Exception as e:
@@ -281,7 +287,8 @@ class EsiClient:
                 killmail_id=killmail_id, killmail_hash=killmail_hash
             )
         )
-        return self._operation_results(operation)
+        # Single-object endpoint: result(), not results().
+        return self._operation_result(operation)
 
     def get_character_blueprints(self) -> EsiResponse:
         """
@@ -350,7 +357,7 @@ class EsiClient:
             )
         )
         try:
-            jobs = _esi_to_python(operation.results())
+            jobs = _esi_to_python(operation.results(use_etag=False))
         except Exception as e:
             return EsiResponse(response_code=ERROR_CALLING_ESI, response=e)
         return EsiResponse(response_code=SUCCESS, data=jobs or [])
@@ -384,7 +391,9 @@ class EsiClient:
             token=token,
         )
 
-        return self._operation_results(operation)
+        # Disable ETag — django-esi raises HTTPNotModified on 304 instead of
+        # returning cached body, which would surface as opaque 906.
+        return self._operation_results(operation, use_etag=False)
 
     def get_corporation_blueprints(self, corporation_id: int) -> EsiResponse:
         """
@@ -597,7 +606,8 @@ class EsiClient:
             contract_id=contract_id,
             token=token,
         )
-        return self._operation_results(operation)
+        # Same 304/ETag pitfall as get_corporation_contracts.
+        return self._operation_results(operation, use_etag=False)
 
     def get_region_market_history(
         self, region_id: int, type_id: int
@@ -716,7 +726,7 @@ class EsiClient:
             structure_id=structure_id,
             token=token,
         )
-        all_orders = _esi_to_python(operation.results())
+        all_orders = _esi_to_python(operation.results(use_etag=False))
         count = len(all_orders) if all_orders else 0
         logger.info(
             "get_structure_market_orders_pages: structure_id=%s — received all pages, orders_count=%s",
@@ -1020,7 +1030,8 @@ class EsiClient:
             character_id=self.character_id,
             token=token,
         )
-        return self._operation_results(operation)
+        # Single-object endpoint: result(), not results().
+        return self._operation_result(operation)
 
     def _authenticated_esi_get(
         self, url: str, required_scopes: List[str]

--- a/backend/eveonline/tests/test_client.py
+++ b/backend/eveonline/tests/test_client.py
@@ -45,6 +45,67 @@ class EsiClientTest(SimpleTestCase):
         )
 
     @patch("eveonline.client.Token.get_token")
+    def test_get_corporation_contracts_disables_etag(self, get_token_mock):
+        token = MagicMock()
+        token.valid_access_token.return_value = "access-token-string"
+        token.character_id = 634915984
+        get_token_mock.return_value = token
+
+        client = EsiClient(634915984)
+        operation = MagicMock()
+        contracts = MagicMock()
+        contracts.GetCorporationsCorporationIdContracts.return_value = (
+            operation
+        )
+
+        with patch("eveonline.client.esi_provider") as provider, patch.object(
+            EsiClient,
+            "_operation_results",
+            return_value=EsiResponse(SUCCESS),
+        ) as op_results:
+            provider.client.Contracts = contracts
+            response = client.get_corporation_contracts(98705678)
+
+        contracts.GetCorporationsCorporationIdContracts.assert_called_once_with(
+            corporation_id=98705678,
+            token=token,
+        )
+        op_results.assert_called_once_with(operation, use_etag=False)
+        self.assertEqual(response.response_code, SUCCESS)
+
+    @patch("eveonline.client.Token.get_token")
+    def test_get_corporation_contract_items_disables_etag(
+        self, get_token_mock
+    ):
+        token = MagicMock()
+        token.valid_access_token.return_value = "access-token-string"
+        token.character_id = 634915984
+        get_token_mock.return_value = token
+
+        client = EsiClient(634915984)
+        operation = MagicMock()
+        contracts = MagicMock()
+        contracts.GetCorporationsCorporationIdContractsContractIdItems.return_value = (
+            operation
+        )
+
+        with patch("eveonline.client.esi_provider") as provider, patch.object(
+            EsiClient,
+            "_operation_results",
+            return_value=EsiResponse(SUCCESS),
+        ) as op_results:
+            provider.client.Contracts = contracts
+            response = client.get_corporation_contract_items(98705678, 123)
+
+        contracts.GetCorporationsCorporationIdContractsContractIdItems.assert_called_once_with(
+            corporation_id=98705678,
+            contract_id=123,
+            token=token,
+        )
+        op_results.assert_called_once_with(operation, use_etag=False)
+        self.assertEqual(response.response_code, SUCCESS)
+
+    @patch("eveonline.client.Token.get_token")
     def test_update_fleet_details_passes_token_object(self, get_token_mock):
         token = MagicMock()
         token.valid_access_token.return_value = "access-token-string"
@@ -74,6 +135,83 @@ class EsiClientTest(SimpleTestCase):
         op_result.assert_called_once_with(operation, use_etag=False)
         self.assertEqual(response.response_code, SUCCESS)
 
+    def test_operation_results_defaults_use_etag_false(self):
+        client = EsiClient(634915984)
+        operation = MagicMock()
+        operation.results.return_value = [{"contract_id": 1}]
+        operation.operation.operationId = "GetCharactersCharacterIdContracts"
+
+        # pylint: disable-next=protected-access
+        response = client._operation_results(operation)
+
+        operation.results.assert_called_once_with(use_etag=False)
+        self.assertEqual(response.response_code, SUCCESS)
+        self.assertEqual(response.results(), [{"contract_id": 1}])
+
+    def test_operation_result_defaults_use_etag_false(self):
+        client = EsiClient(634915984)
+        operation = MagicMock()
+        operation.result.return_value = {"fleet_id": 1}
+        operation.operation.operationId = "GetFleetsFleetId"
+
+        # pylint: disable-next=protected-access
+        response = client._operation_result(operation)
+
+        operation.result.assert_called_once_with(use_etag=False)
+        self.assertEqual(response.response_code, SUCCESS)
+        self.assertEqual(response.results(), {"fleet_id": 1})
+
+    @patch("eveonline.client.Token.get_token")
+    def test_get_character_contracts_uses_operation_results(
+        self, get_token_mock
+    ):
+        token = MagicMock()
+        token.valid_access_token.return_value = "access-token-string"
+        token.character_id = 634915984
+        get_token_mock.return_value = token
+
+        client = EsiClient(634915984)
+        operation = MagicMock()
+        contracts = MagicMock()
+        contracts.GetCharactersCharacterIdContracts.return_value = operation
+
+        with patch("eveonline.client.esi_provider") as provider, patch.object(
+            EsiClient,
+            "_operation_results",
+            return_value=EsiResponse(SUCCESS, data=[]),
+        ) as op_results:
+            provider.client.Contracts = contracts
+            response = client.get_character_contracts()
+
+        contracts.GetCharactersCharacterIdContracts.assert_called_once_with(
+            character_id=634915984,
+            token=token,
+        )
+        # Wrapper applies use_etag=False; callers need not pass it.
+        op_results.assert_called_once_with(operation)
+        self.assertEqual(response.response_code, SUCCESS)
+
+    @patch("eveonline.client.Token.get_token")
+    def test_get_character_assets_disables_etag(self, get_token_mock):
+        token = MagicMock()
+        token.valid_access_token.return_value = "access-token-string"
+        token.character_id = 634915984
+        get_token_mock.return_value = token
+
+        client = EsiClient(634915984)
+        operation = MagicMock()
+        operation.results.return_value = [{"item_id": 1}]
+        assets = MagicMock()
+        assets.GetCharactersCharacterIdAssets.return_value = operation
+
+        with patch("eveonline.client.esi_provider") as provider:
+            provider.client.Assets = assets
+            response = client.get_character_assets()
+
+        operation.results.assert_called_once_with(use_etag=False)
+        self.assertEqual(response.response_code, SUCCESS)
+        self.assertEqual(response.results(), [{"item_id": 1}])
+
     def test_operation_result_preserves_underlying_exception(self):
         client = EsiClient(634915984)
         operation = MagicMock()
@@ -88,3 +226,4 @@ class EsiClientTest(SimpleTestCase):
         self.assertEqual(response.response_code, ERROR_CALLING_ESI)
         self.assertIsInstance(response.response, AttributeError)
         self.assertIn("character_id", str(response.response))
+        operation.result.assert_called_once_with(use_etag=False)


### PR DESCRIPTION
## Summary
- Default `use_etag=False` on ESI operation wrappers so django-esi 304/`HTTPNotModified` responses no longer surface as opaque 906 and skip corp/character syncs (root cause of frozen freight contracts on MFL).
- Use `result()` for singular endpoints (`public_data`, skills, killmail detail, FW stats) so callers get dicts instead of one-item lists.
- Cover corp contracts/items and character assets paths with unit tests.

## Test plan
- [x] `pipenv run python manage.py test eveonline.tests.test_client --settings=app.settings_test`
- [x] Live ESI verify with BearThatCares / Rattini: corp contracts double-call (304 regression) succeeds; character public/skills/killmails/assets/contracts/clones; Farms jobs/mining/planets/blueprints; Rattini corp members/contracts/wallet
- [ ] After deploy: re-run `update_corporation_contracts(98705678)` for MFL freight page refresh


Made with [Cursor](https://cursor.com)