### PR TITLE
Fix fitting Share button referral links

### DIFF
--- a/frontend/app/src/components/blocks/FittingShareButton.astro
+++ b/frontend/app/src/components/blocks/FittingShareButton.astro
@@ -3,6 +3,10 @@ import { i18n } from '@helpers/i18n'
 const { t, translatePath } = i18n(Astro.url)
 
 import type { ButtonSizes } from '@dtypes/layout_components';
+import type { User } from '@dtypes/jwt'
+import * as jose from 'jose'
+
+import { get_app_url } from '@helpers/env'
 
 import ClipboardButton from '@components/blocks/ClipboardButton.astro';
 
@@ -22,7 +26,13 @@ const {
     ...attributes
 } = Astro.props
 
-const share_url = new URL(translatePath(`/ships/fittings/${fitting_id}`), Astro.url.origin).href
+const auth_token = Astro.cookies.has('auth_token') ? (Astro.cookies.get('auth_token')?.value as string) : false
+const user: User | false = auth_token ? jose.decodeJwt(auth_token) as User : false
+
+const fitting_path = translatePath(`/ships/fittings/${fitting_id}`)
+const share_url = user
+    ? `${get_app_url(fitting_path)}?ref=${user.user_id}`
+    : get_app_url(fitting_path)
 ---
 
 <ClipboardButton

--- a/frontend/app/src/helpers/fetching/referrals.ts
+++ b/frontend/app/src/helpers/fetching/referrals.ts
@@ -9,16 +9,29 @@ import type { PageFinderUI, ReferralLinkStatsUI } from '@dtypes/layout_component
 import sitemap from '@json/sitemap.json'
 import external_referrals from '@json/external-referrals.json'
 
-export function is_referral_url(pathname:string, lang:'en') {
+function normalize_referral_path(pathname:string) {
+    return pathname.endsWith('/') ? pathname : `${pathname}/`
+}
+
+function find_referral_page(pathname:string, lang:'en') {
     const translatePath = useTranslatedPath(lang)
-    const fixed_pathname = pathname.endsWith('/') ? pathname : pathname+'/'
+    const normalized_pathname = normalize_referral_path(pathname)
 
+    return get_referrable_pages()
+        .map(page => {
+            const normalized_page = normalize_referral_path(translatePath(page.link ?? ''))
+            return { page, normalized_page }
+        })
+        .filter(({ normalized_page }) =>
+            normalized_pathname === normalized_page ||
+            (normalized_page.length > 1 && normalized_pathname.startsWith(normalized_page))
+        )
+        .sort((a, b) => b.normalized_page.length - a.normalized_page.length)[0]?.page
+}
+
+export function is_referral_url(pathname:string, lang:'en') {
     try {
-        const referrable_pages = get_referrable_pages()
-        
-        const referral = referrable_pages.find( page => translatePath(page.link ?? '') === fixed_pathname)
-
-        return referral !== undefined
+        return find_referral_page(pathname, lang) !== undefined
     } catch (error) {
         return undefined
     }
@@ -29,8 +42,7 @@ export function is_referral_url_debug(pathname:string, lang:'en') {
 
     try {
         const referrable_pages = get_referrable_pages()
-        
-        const referral = referrable_pages.find( page => translatePath(page.link ?? '') === pathname)
+        const referral = find_referral_page(pathname, lang)
 
         return [ translatePath(referrable_pages[2].link ?? ''), pathname, referral, referrable_pages ]
     } catch (error) {
@@ -38,11 +50,7 @@ export function is_referral_url_debug(pathname:string, lang:'en') {
     }
 }
 export async function check_referral_url(current_user_id:number, pathname:string, searchParams:URLSearchParams, clientIP:string, lang:'en') {
-    const translatePath = useTranslatedPath(lang)
-
-    const referrable_pages = get_referrable_pages()
-    
-    const referral = referrable_pages.find( page => translatePath(page.link ?? '') === pathname)
+    const referral = find_referral_page(pathname, lang)
     const user_id = parseInt(searchParams.get('ref') ?? '0')
     const page = referral?.name
 

--- a/frontend/app/src/pages/ships/fitting/[fitting_id].astro
+++ b/frontend/app/src/pages/ships/fitting/[fitting_id].astro
@@ -3,5 +3,5 @@ import { i18n } from '@helpers/i18n'
 const { translatePath } = i18n(Astro.url)
 
 const id = Astro.params?.fitting_id ?? '0'
-return Astro.redirect(translatePath(`/ships/fittings/normal/${id}`), 301)
+return Astro.redirect(`${translatePath(`/ships/fittings/normal/${id}`)}${Astro.url.search}`, 301)
 ---

--- a/frontend/app/src/pages/ships/fitting/normal/[fitting_id].astro
+++ b/frontend/app/src/pages/ships/fitting/normal/[fitting_id].astro
@@ -4,5 +4,5 @@ const { translatePath } = i18n(Astro.url)
 
 const fitting_id = Astro.params.fitting_id ?? 0;
 
-return Astro.redirect(translatePath(`/ships/fittings/normal/${fitting_id}`), 301)
+return Astro.redirect(`${translatePath(`/ships/fittings/normal/${fitting_id}`)}${Astro.url.search}`, 301)
 ---

--- a/frontend/app/src/pages/ships/fitting/render/[fitting_id].astro
+++ b/frontend/app/src/pages/ships/fitting/render/[fitting_id].astro
@@ -4,5 +4,5 @@ const { translatePath } = i18n(Astro.url)
 
 const fitting_id = Astro.params.fitting_id ?? 0;
 
-return Astro.redirect(translatePath(`/ships/fittings/render/${fitting_id}`), 301)
+return Astro.redirect(`${translatePath(`/ships/fittings/render/${fitting_id}`)}${Astro.url.search}`, 301)
 ---

--- a/frontend/app/src/pages/ships/fittings/[fitting_id].astro
+++ b/frontend/app/src/pages/ships/fittings/[fitting_id].astro
@@ -3,5 +3,5 @@ import { i18n } from '@helpers/i18n'
 const { translatePath } = i18n(Astro.url)
 
 const id = Astro.params?.fitting_id ?? '0'
-return Astro.redirect(translatePath(`/ships/fittings/normal/${id}`), 301)
+return Astro.redirect(`${translatePath(`/ships/fittings/normal/${id}`)}${Astro.url.search}`, 301)
 ---


### PR DESCRIPTION
## Summary
- Fitting Share copies an absolute URL with `?ref=<user_id>` when logged in (same pattern as page referral shares)
- Fitting short-URL redirects preserve the query string so `ref` survives the hop to `/normal/` or `/render/`
- Referral tracking matches nested paths under referrable pages (e.g. `/ships/fittings/normal/123` → fittings list)

## Test plan
- [ ] Logged in: Share on a fitting copies `…/ships/fittings/<id>?ref=<your user id>`
- [ ] Logged out: Share copies absolute URL without `ref`
- [ ] Opening a shared link with `?ref=` lands on the fitting page and still has `ref` after redirect
- [ ] Visiting that link as another user/IP records a referral under fittings stats


Made with [Cursor](https://cursor.com)