### PR TITLE
Fix tribe landing hang for chiefs (Supply)

### DIFF
--- a/backend/tribes/endpoints/memberships/get_memberships.py
+++ b/backend/tribes/endpoints/memberships/get_memberships.py
@@ -12,6 +12,11 @@ PATH = "/{tribe_id}/groups/{group_id}/memberships"
 METHOD = "get"
 ROUTE_SPEC = {
     "summary": "List memberships for a tribe group (chief sees all; members see own).",
+    "description": (
+        "Use mine=true on tribe landing tiles to fetch only the caller's "
+        "membership without live requirement checks. Use include_requirements=true "
+        "on the members management page when chiefs need per-character qualify status."
+    ),
     "response": {200: List[MembershipSchema], 403: dict, 404: dict},
     "auth": AuthBearer(),
 }
@@ -22,22 +27,31 @@ def get_memberships(
     tribe_id: int,
     group_id: int,
     status: Optional[str] = None,
+    mine: bool = False,
+    include_requirements: bool = False,
 ):
     tg = TribeGroup.objects.filter(pk=group_id, tribe_id=tribe_id).first()
     if not tg:
         return 404, {"detail": "TribeGroup not found."}
 
-    if user_can_manage_group(request.user, tg):
-        qs = TribeGroupMembership.objects.filter(tribe_group=tg)
-    else:
+    can_manage = user_can_manage_group(request.user, tg)
+
+    if mine or not can_manage:
         qs = TribeGroupMembership.objects.filter(
             tribe_group=tg, user=request.user
         )
+    else:
+        qs = TribeGroupMembership.objects.filter(tribe_group=tg)
 
     if status:
         qs = qs.filter(status=status)
 
-    can_manage = user_can_manage_group(request.user, tg)
+    # Landing / own-membership views need committed characters but not live
+    # asset/skill evaluation. Requirement checks are expensive (N+1 against
+    # EveCharacterAsset) and only belong on the members management page.
+    include_characters = mine or can_manage
+    check_requirements = include_requirements and can_manage and not mine
+
     qs = qs.select_related(
         "tribe_group__tribe",
         "user__eveplayer__primary_character",
@@ -51,8 +65,8 @@ def get_memberships(
     return 200, [
         serialize_membership(
             m,
-            include_requirement_status=can_manage,
-            include_characters=can_manage,
+            include_requirement_status=check_requirements,
+            include_characters=include_characters,
         )
         for m in qs
     ]

--- a/backend/tribes/tests/test_routers.py
+++ b/backend/tribes/tests/test_routers.py
@@ -274,6 +274,110 @@ class MembershipLeaveTestCase(TestCase):
         self.assertEqual(self.membership.removed_by, chief)
 
 
+class MembershipListTestCase(TestCase):
+    """GET memberships: mine filter and gated requirement checks."""
+
+    def setUp(self):
+        self.client = Client()
+        self.tribe = Tribe.objects.create(name="Supply", slug="supply")
+        self.tribe_group = TribeGroup.objects.create(
+            tribe=self.tribe, name="Mining"
+        )
+        self.chief = User.objects.create_user(username="chief")
+        self.member = User.objects.create_user(username="member")
+        self.other = User.objects.create_user(username="other")
+        self.tribe_group.chief = self.chief
+        self.tribe_group.save()
+
+        self.member_membership = TribeGroupMembership.objects.create(
+            user=self.member,
+            tribe_group=self.tribe_group,
+            status=TribeGroupMembership.STATUS_ACTIVE,
+        )
+        self.other_membership = TribeGroupMembership.objects.create(
+            user=self.other,
+            tribe_group=self.tribe_group,
+            status=TribeGroupMembership.STATUS_ACTIVE,
+        )
+        self.member_character = EveCharacter.objects.create(
+            character_id=30001,
+            character_name="Member Main",
+            user=self.member,
+        )
+        TribeGroupMembershipCharacter.objects.create(
+            membership=self.member_membership,
+            character=self.member_character,
+        )
+
+        self.list_url = f"{BASE_URL}/{self.tribe.pk}/groups/{self.tribe_group.pk}/memberships"
+
+    def test_chief_list_returns_all_without_requirement_status_by_default(
+        self,
+    ):
+        token = _make_token(self.chief)
+        response = self.client.get(
+            self.list_url, HTTP_AUTHORIZATION=f"Bearer {token}"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 2)
+        for row in data:
+            for character in row["characters"]:
+                self.assertIsNone(character.get("qualifies"))
+                self.assertIsNone(character.get("missing_skills"))
+                self.assertIsNone(character.get("missing_assets"))
+
+    def test_mine_returns_only_caller_membership_with_characters(self):
+        token = _make_token(self.chief)
+        # Chief has no membership of their own — empty list.
+        response = self.client.get(
+            f"{self.list_url}?mine=true",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+        token = _make_token(self.member)
+        response = self.client.get(
+            f"{self.list_url}?mine=true",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["user_id"], self.member.pk)
+        self.assertEqual(len(data[0]["characters"]), 1)
+        self.assertEqual(
+            data[0]["characters"][0]["character_id"],
+            self.member_character.character_id,
+        )
+        self.assertIsNone(data[0]["characters"][0].get("qualifies"))
+
+    def test_include_requirements_adds_qualify_flags_for_chief(self):
+        token = _make_token(self.chief)
+        response = self.client.get(
+            f"{self.list_url}?include_requirements=true",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        member_row = next(r for r in data if r["user_id"] == self.member.pk)
+        self.assertEqual(len(member_row["characters"]), 1)
+        # No group requirements configured → qualifies is True.
+        self.assertTrue(member_row["characters"][0]["qualifies"])
+
+    def test_member_cannot_force_full_roster_via_include_requirements(self):
+        token = _make_token(self.member)
+        response = self.client.get(
+            f"{self.list_url}?include_requirements=true",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["user_id"], self.member.pk)
+
+
 class MembershipCharacterTestCase(TestCase):
     """Tests for committing and removing characters from a membership."""
 

--- a/frontend/app/src/helpers/api.minmatar.org/tribes.ts
+++ b/frontend/app/src/helpers/api.minmatar.org/tribes.ts
@@ -128,14 +128,32 @@ export async function get_tribe_group_activity(
     }
 }
 
+export type GetMembershipsOptions = {
+    status?: string
+    /** Only the caller's membership (for tribe landing tiles). */
+    mine?: boolean
+    /** Live asset/skill checks per committed character (members management page). */
+    include_requirements?: boolean
+}
+
 export async function get_memberships(
     access_token: string,
     tribe_id: number,
     group_id: number,
-    status?: string,
+    statusOrOptions?: string | GetMembershipsOptions,
 ): Promise<TribeMembership[]> {
-    let ENDPOINT = `${API_ENDPOINT}/${tribe_id}/groups/${group_id}/memberships`
-    if (status) ENDPOINT += `?status=${status}`
+    const options: GetMembershipsOptions =
+        typeof statusOrOptions === 'string'
+            ? { status: statusOrOptions }
+            : (statusOrOptions ?? {})
+
+    const params = new URLSearchParams()
+    if (options.status) params.set('status', options.status)
+    if (options.mine) params.set('mine', 'true')
+    if (options.include_requirements) params.set('include_requirements', 'true')
+
+    const query = params.toString()
+    const ENDPOINT = `${API_ENDPOINT}/${tribe_id}/groups/${group_id}/memberships${query ? `?${query}` : ''}`
     console.log(`Requesting: ${ENDPOINT}`)
     try {
         const response = await fetch(ENDPOINT, {

--- a/frontend/app/src/pages/alliance/tribes/[tribe_id].astro
+++ b/frontend/app/src/pages/alliance/tribes/[tribe_id].astro
@@ -55,30 +55,44 @@ try {
     )
 
     if (auth_token && user) {
-        for (const group of tribe_groups) {
-            const memberships = await get_memberships(auth_token, tribe_id, group.id)
-            const mine = memberships.find(m => m.user_id === user.user_id) ?? null
-            membership_by_group.set(group.id, mine)
-        }
+        // Own membership only — full roster + live requirement checks belong on
+        // /members (chiefs otherwise serialize every committed alt per group).
+        const [summary, membershipResults, availableResults] = await Promise.all([
+            get_characters_summary_sorted(auth_token),
+            Promise.all(
+                tribe_groups.map(async (group) => {
+                    try {
+                        const memberships = await get_memberships(
+                            auth_token as string,
+                            tribe_id,
+                            group.id,
+                            { mine: true },
+                        )
+                        return [group.id, memberships[0] ?? null] as const
+                    } catch {
+                        return [group.id, null] as const
+                    }
+                }),
+            ),
+            Promise.all(
+                tribe_groups.map(async (group) => {
+                    try {
+                        const list = await get_membership_characters_available(
+                            auth_token as string,
+                            tribe_id,
+                            group.id,
+                        )
+                        return [group.id, list] as const
+                    } catch {
+                        return [group.id, []] as const
+                    }
+                }),
+            ),
+        ])
 
-        const summary = await get_characters_summary_sorted(auth_token)
         user_characters = summary.characters ?? []
-
-        const availableResults = await Promise.all(
-            tribe_groups.map(async (group) => {
-                try {
-                    const list = await get_membership_characters_available(
-                        auth_token as string,
-                        tribe_id,
-                        group.id,
-                    )
-                    return [group.id, list] as const
-                } catch {
-                    return [group.id, []] as const
-                }
-            }),
-        )
-
+        for (const [gid, mine] of membershipResults)
+            membership_by_group.set(gid, mine)
         for (const [gid, list] of availableResults)
             available_by_group.set(gid, list as TribeAvailableCharacter[])
     }

--- a/frontend/app/src/pages/alliance/tribes/[tribe_id]/[group_id].astro
+++ b/frontend/app/src/pages/alliance/tribes/[tribe_id]/[group_id].astro
@@ -46,6 +46,8 @@ try {
     tribe = await get_tribe(tribe_id)
     tribe_group = await get_tribe_group(tribe_id, group_id)
 
+    // Member roster for the group landing (no live requirement checks — those
+    // are only needed on /members for chiefs reviewing qualify status).
     const memberships = await get_memberships(auth_token as string, tribe_id, tribe_group.id)
     const mine = memberships.find(m => m.user_id === user.user_id) ?? null
     membership_by_group.set(tribe_group.id, mine)

--- a/frontend/app/src/pages/alliance/tribes/[tribe_id]/[group_id]/members.astro
+++ b/frontend/app/src/pages/alliance/tribes/[tribe_id]/[group_id]/members.astro
@@ -45,8 +45,14 @@ try {
     if (!is_superuser && !is_chief)
         return HTTP_403_Forbidden()
 
-    approved = await get_memberships(auth_token as string, tribe_id, tribe_group.id, 'active')
-    pending = await get_memberships(auth_token as string, tribe_id, tribe_group.id, 'pending')
+    approved = await get_memberships(auth_token as string, tribe_id, tribe_group.id, {
+        status: 'active',
+        include_requirements: true,
+    })
+    pending = await get_memberships(auth_token as string, tribe_id, tribe_group.id, {
+        status: 'pending',
+        include_requirements: true,
+    })
 
     if (is_chief)
         chief_membership = [ ...approved, ...pending ].find(m => m.user_id === user.user_id) ?? null

--- a/frontend/app/src/pages/partials/tribe_component.astro
+++ b/frontend/app/src/pages/partials/tribe_component.astro
@@ -55,30 +55,44 @@ try {
     )
 
     if (auth_token && user) {
-        for (const group of tribe_groups) {
-            const memberships = await get_memberships(auth_token, tribe_id, group.id)
-            const mine = memberships.find(m => m.user_id === user.user_id) ?? null
-            membership_by_group.set(group.id, mine)
-        }
+        // Own membership only — full roster + live requirement checks belong on
+        // /members (chiefs otherwise serialize every committed alt per group).
+        const [summary, membershipResults, availableResults] = await Promise.all([
+            get_characters_summary_sorted(auth_token),
+            Promise.all(
+                tribe_groups.map(async (group) => {
+                    try {
+                        const memberships = await get_memberships(
+                            auth_token as string,
+                            tribe_id,
+                            group.id,
+                            { mine: true },
+                        )
+                        return [group.id, memberships[0] ?? null] as const
+                    } catch {
+                        return [group.id, null] as const
+                    }
+                }),
+            ),
+            Promise.all(
+                tribe_groups.map(async (group) => {
+                    try {
+                        const list = await get_membership_characters_available(
+                            auth_token as string,
+                            tribe_id,
+                            group.id,
+                        )
+                        return [group.id, list] as const
+                    } catch {
+                        return [group.id, []] as const
+                    }
+                }),
+            ),
+        ])
 
-        const summary = await get_characters_summary_sorted(auth_token)
         user_characters = summary.characters ?? []
-
-        const availableResults = await Promise.all(
-            tribe_groups.map(async (group) => {
-                try {
-                    const list = await get_membership_characters_available(
-                        auth_token as string,
-                        tribe_id,
-                        group.id,
-                    )
-                    return [group.id, list] as const
-                } catch {
-                    return [group.id, []] as const
-                }
-            }),
-        )
-        
+        for (const [gid, mine] of membershipResults)
+            membership_by_group.set(gid, mine)
         for (const [gid, list] of availableResults)
             available_by_group.set(gid, list as TribeAvailableCharacter[])
     }

--- a/frontend/app/src/pages/partials/tribe_group_memberships_component.astro
+++ b/frontend/app/src/pages/partials/tribe_group_memberships_component.astro
@@ -135,8 +135,14 @@ try {
     if (!is_superuser && !is_chief)
         return HTTP_403_Forbidden()
 
-    approved = await get_memberships(auth_token as string, tribe_id, tribe_group.id, 'active')
-    pending = await get_memberships(auth_token as string, tribe_id, tribe_group.id, 'pending')
+    approved = await get_memberships(auth_token as string, tribe_id, tribe_group.id, {
+        status: 'active',
+        include_requirements: true,
+    })
+    pending = await get_memberships(auth_token as string, tribe_id, tribe_group.id, {
+        status: 'pending',
+        include_requirements: true,
+    })
 
     if (is_chief)
         chief_membership = [ ...approved, ...pending ].find(m => m.user_id === user.user_id) ?? null

--- a/frontend/app/src/pages/partials/tribe_group_status_component.astro
+++ b/frontend/app/src/pages/partials/tribe_group_status_component.astro
@@ -119,8 +119,10 @@ let fetch_group_error: Error | false = false
 try {
     tribe_group = await get_tribe_group(tribe_id, group_id)
 
-    const memberships = await get_memberships(auth_token as string, tribe_id, tribe_group.id)
-    const mine = memberships.find(m => m.user_id === user.user_id) ?? null
+    const memberships = await get_memberships(auth_token as string, tribe_id, tribe_group.id, {
+        mine: true,
+    })
+    const mine = memberships[0] ?? null
     membership_by_group.set(tribe_group.id, mine)
 
     const summary = await get_characters_summary_sorted(auth_token)


### PR DESCRIPTION
## Summary
- Tribe landing (`/alliance/tribes/:id`) was calling `GET .../memberships` per group. For chiefs/managers that returned the **full roster** with live `check_character_meets_requirements` per committed character — minutes of work on Supply (Mining/PI alone), so the page never loaded.
- Backend: add `mine=true` (own membership only) and gate live qualify flags behind `include_requirements=true`.
- Frontend: landing + status partials use `mine=true` and parallelize membership/available/summary fetches; `/members` is the only page that requests `include_requirements`.

Mim already had the right endpoints; the landing just needed to stop using the chief full-list path.

## Test plan
- [ ] As a Supply tribe/group chief or superuser, open `/alliance/tribes/2` — page should load in a few seconds (not hang)
- [ ] Confirm apply / pending / leave / add-alt still works from tribe tiles
- [ ] As chief, open a group `/members` page — qualify ▲/▼ flags still appear
- [ ] As a regular member, landing still shows membership status correctly
- [ ] `pipenv run python manage.py test tribes.tests.test_routers.MembershipListTestCase --settings=app.settings_test`


Made with [Cursor](https://cursor.com)