### PR TITLE
Fix market expectation saves on page 2+

### DIFF
--- a/backend/market/helpers/expectations_admin.py
+++ b/backend/market/helpers/expectations_admin.py
@@ -310,7 +310,9 @@ def build_location_fitting_expectations_context(
         )
         model_admin = cl.model_admin
 
-    base_params = _fitting_expectation_query_params(request)
+    base_params = _fitting_expectation_query_params(
+        request, page=cl.page_num if cl is not None else None
+    )
     form_action = reverse(
         "admin:market_location_fitting_expectations",
         args=[location.pk],
@@ -389,7 +391,9 @@ def build_location_contract_expectations_context(
         )
         model_admin = cl.model_admin
 
-    base_params = _expectation_query_params(request)
+    base_params = _expectation_query_params(
+        request, page=cl.page_num if cl is not None else None
+    )
     form_action = reverse(
         "admin:market_location_contract_expectations",
         args=[location.pk],

--- a/backend/market/helpers/expectations_changelist.py
+++ b/backend/market/helpers/expectations_changelist.py
@@ -18,6 +18,10 @@ from market.models import (
 )
 
 EXPECTATION_PAGE_SIZE = 15
+# The non-doctrine fitting list tops out at a few hundred rows, so render it
+# unpaginated: paginating splits the save form across pages and only the
+# visible page gets saved.
+FITTING_EXPECTATION_PAGE_SIZE = 10_000
 
 
 class FittingExpectationListItem:
@@ -180,7 +184,7 @@ def _quantity_input(fitting_id: int, quantity: int | None) -> str:
 
 
 class LocationFittingExpectationsModelAdmin(admin.ModelAdmin):
-    list_per_page = EXPECTATION_PAGE_SIZE
+    list_per_page = FITTING_EXPECTATION_PAGE_SIZE
     search_fields = ("fitting_name",)
     search_help_text = _("Search by ship fit name.")
     list_filter = (FittingTagListFilter, FittingConfiguredListFilter)

--- a/backend/market/helpers/sell_orders.py
+++ b/backend/market/helpers/sell_orders.py
@@ -621,6 +621,7 @@ def build_location_sell_orders_context(location, request=None) -> dict:
         source_filter=source_filter,
         stock_filter=stock_filter,
         markup_filter=markup_filter,
+        page=cl.page_num if cl is not None else None,
     )
     form_action = reverse(
         "admin:market_location_sell_orders", args=[location.pk]

--- a/backend/market/templates/admin/market/location_expectations_changelist.html
+++ b/backend/market/templates/admin/market/location_expectations_changelist.html
@@ -77,7 +77,9 @@
 
         {% if cl.result_count %}
         <div class="submit-row">
+          {% if cl.multi_page %}
           <p class="help">{% translate "Only the rows on this page are saved when you click Save." %}</p>
+          {% endif %}
           <input type="submit" value="{{ save_button_label }}" class="default">
         </div>
         {% endif %}

--- a/backend/market/tests/test_market_vision.py
+++ b/backend/market/tests/test_market_vision.py
@@ -1258,6 +1258,22 @@ class ExpectationsAdminViewsTestCase(TestCase):
             9,
         )
 
+    def test_fitting_expectations_render_on_single_page(self):
+        for i in range(20):
+            fitting = EveFitting.objects.create(
+                name=f"[FL33T] Rifter {i:02d}",
+                eft_format=rifter_eft(f"[FL33T] Rifter {i:02d}"),
+                ship_id=587,
+            )
+            fitting.set_tag_slugs([FittingTag.NANOGANG], write_history=False)
+
+        context = build_location_fitting_expectations_context(
+            self.location, self.factory.get("/")
+        )
+        cl = context["cl"]
+        self.assertFalse(cl.multi_page)
+        self.assertEqual(len(cl.result_list), 20)
+
     def test_fitting_expectations_save_on_page_two(self):
         fittings = []
         for i in range(2):

--- a/backend/market/tests/test_market_vision.py
+++ b/backend/market/tests/test_market_vision.py
@@ -3,7 +3,10 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.contrib import admin
+from django.contrib.auth import get_user_model
+from django.contrib.messages.storage.fallback import FallbackStorage
 from django.test import RequestFactory
+from django.urls import reverse
 from django.utils import timezone
 
 from app.test import TestCase
@@ -16,6 +19,10 @@ from fittings.models import (
     EveDoctrineFitting,
     EveFitting,
     FittingTag,
+)
+from market.admin_location_views import (
+    _allowed_fitting_ids,
+    market_location_fitting_expectations_view,
 )
 from market.helpers.contract_admin import build_location_contracts_context
 from market.helpers.contract_match import (
@@ -1249,6 +1256,61 @@ class ExpectationsAdminViewsTestCase(TestCase):
                 location=self.location, fitting=self.fitting
             ).quantity,
             9,
+        )
+
+    def test_fitting_expectations_save_on_page_two(self):
+        fittings = []
+        for i in range(2):
+            fitting = EveFitting.objects.create(
+                name=f"[FL33T] Rifter {i:02d}",
+                eft_format=rifter_eft(f"[FL33T] Rifter {i:02d}"),
+                ship_id=587,
+            )
+            fitting.set_tag_slugs([FittingTag.NANOGANG], write_history=False)
+            fittings.append(fitting)
+
+        with patch(
+            "market.helpers.expectations_changelist."
+            "LocationFittingExpectationsModelAdmin.list_per_page",
+            1,
+        ):
+            get_request = self.factory.get("/", {"p": "2"})
+            context = build_location_fitting_expectations_context(
+                self.location, get_request
+            )
+            self.assertEqual(context["cl"].page_num, 2)
+            self.assertIn("p=2", context["form_action"])
+            page2_fitting_id = context["cl"].result_list[0].fitting_id
+            self.assertEqual(_allowed_fitting_ids(context), {page2_fitting_id})
+
+            user = get_user_model().objects.create_superuser(
+                username="expectations-admin",
+                email="admin@example.com",
+                password="test-pass",
+            )
+            url = reverse(
+                "admin:market_location_fitting_expectations",
+                args=[self.location.pk],
+            )
+            post_request = self.factory.post(
+                f"{url}?p=2",
+                {f"quantity_{page2_fitting_id}": "8"},
+            )
+            post_request.user = user
+            post_request.session = {}
+            setattr(post_request, "_messages", FallbackStorage(post_request))
+
+            response = market_location_fitting_expectations_view(
+                post_request, self.location.pk
+            )
+            self.assertEqual(response.status_code, 302)
+            self.assertIn("p=2", response.url)
+
+        self.assertEqual(
+            EveMarketFittingExpectation.objects.get(
+                location=self.location, fitting_id=page2_fitting_id
+            ).quantity,
+            8,
         )
 
     def test_contract_expectations_include_all_doctrine_fittings(self):


### PR DESCRIPTION
## Summary
- Render the non-doctrine fitting expectations admin page unpaginated — the list tops out at a few hundred rows, and paginating splits the save form so only the visible page gets saved
- Preserve the current page (`p`) in the form action URLs for the pages that still paginate (contract expectations, sell orders), fixing saves from page 2+ being silently ignored
- Hide the "Only the rows on this page are saved" warning when everything fits on one page
- Add regression tests: saving from page 2 persists, and the fitting list renders on a single page

## Test plan
- [x] `pipenv run python manage.py test market.tests.test_market_vision.ExpectationsAdminViewsTestCase market.tests.test_admin_permissions market.tests.test_admin_query_counts --settings=app.settings_test`
- [ ] Open `/admin/market/location/<id>/fitting-expectations/?tag=faction_warfare` — all rows on one page, no paginator links
- [ ] Change quantities anywhere in the list, click Save, confirm they persist after reload
- [ ] On doctrine contract expectations page 2, save a quantity and confirm it persists