### PR TITLE
Add Jita buy list export to Market Ops viability gaps

### DIFF
--- a/frontend/app/src/i18n/ui.ts
+++ b/frontend/app/src/i18n/ui.ts
@@ -401,6 +401,8 @@ export const ui = {
         'ops_sell_gap_listed': '{listed} listed',
         'ops_health_coverage_hint': 'Share of target quantity currently listed, regardless of price.',
         'ops_health_viability_hint': 'Share of target quantity listed within 20% of baseline (items under 1M ISK always count).',
+        'ops_copy_jita_buy_list': 'Copy Jita buy list',
+        'ops_copy_jita_buy_list_tip': 'Copies the missing quantities as a Multibuy list. Paste it into the EVE Multibuy window in Jita.',
         'freight.page_title': 'Freight Service',
         'freight.leading_text': 'Minmatar Fleet Logistics offers the best prices for logistics across the warzone, ensuring our pilots can destroy trillions in enemy vessels.',
         'freight.meta_description': 'Minmatar Fleet freight: jump freighter hauling from Jita and wormhole routes. Courier contracts, calculator, and 30-day summary for EVE Online pilots.',

--- a/frontend/app/src/pages/market/ops.astro
+++ b/frontend/app/src/pages/market/ops.astro
@@ -93,6 +93,12 @@ const contracts_tone = health_tone(summary?.contracts_health_pct)
 const sell_tone = health_tone(summary?.sell_orders_health_pct)
 const sell_viability_tone = health_tone(summary?.sell_orders_viability_pct)
 
+// EVE Multibuy format: one "Item Name quantity" per line, pasteable in Jita.
+const jita_buy_list = (monitor?.sell_gaps ?? [])
+    .filter(row => row.shortfall > 0)
+    .map(row => `${row.item_name} ${row.shortfall}`)
+    .join('\n')
+
 import Viewport from '@layouts/Viewport.astro';
 import PageWide from '@components/page/PageWide.astro';
 import PageTitle from '@components/page/PageTitle.astro';
@@ -105,6 +111,7 @@ import ComponentBlock from '@components/blocks/ComponentBlock.astro';
 import ErrorRefetch from '@components/blocks/ErrorRefetch.astro';
 import Markdown from '@components/blocks/Markdown.astro';
 import Progress from '@components/blocks/Progress.astro';
+import ClipboardButton from '@components/blocks/ClipboardButton.astro';
 import OpsUnderstockedGrid from '@components/blocks/OpsUnderstockedGrid.astro';
 import OpsSellGapsList from '@components/blocks/OpsSellGapsList.astro';
 
@@ -304,6 +311,15 @@ const admin_hub = location_id != null
                                 rows={monitor.sell_gaps}
                                 hide_location={true}
                             />
+                            {jita_buy_list.length > 0 &&
+                                <FlexInline justification="flex-end">
+                                    <ClipboardButton
+                                        id="jita-buy-list-clipboard"
+                                        text={t('ops_copy_jita_buy_list')}
+                                        data-tippy-content={t('ops_copy_jita_buy_list_tip')}
+                                    >{jita_buy_list}</ClipboardButton>
+                                </FlexInline>
+                            }
                         </Flexblock>
                     </Flexblock>
                 </>


### PR DESCRIPTION
## Summary
- Adds a "Copy Jita buy list" button below the viability gaps list on `/market/ops/`
- Copies each gap's shortfall as an EVE Multibuy line (`Item Name quantity`), ready to paste into the Multibuy window in Jita
- Button only renders when there are gaps with a shortfall

## Test plan
- [ ] Open `/market/ops/` with active viability gaps and confirm the button appears below the list
- [ ] Click it and paste into a text editor: one `Item Name quantity` line per gap
- [ ] Paste into the EVE Multibuy window in Jita and confirm items resolve
- [ ] Confirm the button is hidden when there are no gaps

Made with [Cursor](https://cursor.com)