### PR TITLE
Fix propaganda Share to copy referral links

### DIFF
--- a/frontend/app/src/pages/alliance/propaganda/[post_id].astro
+++ b/frontend/app/src/pages/alliance/propaganda/[post_id].astro
@@ -59,6 +59,9 @@ import ClipboardButton from '@components/blocks/ClipboardButton.astro'
 
 const page_title = post?.title ?? t('new_post')
 const page_description = post?.excerpt ?? page_title
+
+const share_url = new URL(Astro.url.href)
+if (user) share_url.searchParams.set('ref', user.user_id.toString())
 ---
 
 <Viewport
@@ -90,7 +93,7 @@ const page_description = post?.excerpt ?? page_title
                         copied_text={t('post_url_copied')}
                         iconed={false}
                     >
-                        {Astro.url}
+                        {share_url.href}
                     </ClipboardButton>
                     {is_user_post &&
                         <Button

--- a/frontend/app/src/pages/partials/post_component.astro
+++ b/frontend/app/src/pages/partials/post_component.astro
@@ -10,6 +10,7 @@ const user:User | false = auth_token ? jose.decodeJwt(auth_token) as User : fals
 
 import { query_string } from '@helpers/string'
 import { fetch_post } from '@helpers/fetching/posts'
+import { get_app_url } from '@helpers/env'
 import type { PostUI } from '@dtypes/layout_components'
 import { HTTP_400_Bad_Request, HTTP_404_Not_Found } from '@helpers/http_responses'
 
@@ -40,6 +41,9 @@ import { format_date } from '@helpers/date'
 const POST_PARTIAL_URL = translatePath(`/partials/post_component?id=${post_id}`)
 
 const delay = parseInt(Astro.url.searchParams.get('delay') ?? '0')
+
+const post_url = get_app_url(translatePath(`/alliance/propaganda/${post_id}`))
+const share_url = user ? `${post_url}?ref=${user.user_id}` : post_url
 
 import PageTitle from '@components/page/PageTitle.astro';
 
@@ -83,7 +87,7 @@ import DebugTag from '@components/blocks/DebugTag.astro'
                     copied_text={t('post_url_copied')}
                     iconed={false}
                 >
-                    {Astro.url}
+                    {share_url}
                 </ClipboardButton>
                 {is_user_post &&
                     <Button


### PR DESCRIPTION
## Summary
- Propaganda post Share buttons now append `?ref=<user_id>` for logged-in users, matching fittings and guides.
- The post partial copies the public `/alliance/propaganda/<id>` URL instead of the internal `/partials/post_component` path.

## Test plan
- [ ] Logged in: open a propaganda post, click Share post, confirm clipboard URL is absolute and includes `?ref=<your user id>`
- [ ] Logged out: Share post copies the absolute post URL with no `ref`
- [ ] Visit a shared URL with `?ref=` as another user and confirm a referral is recorded for propaganda
- [ ] If the post header is loaded via the partial, Share still copies the public post URL (not `/partials/...`)

Made with [Cursor](https://cursor.com)