### PR TITLE
Fix help ticket close buttons timing out after bot restarts

### DIFF
--- a/bot/app/client.py
+++ b/bot/app/client.py
@@ -9,7 +9,7 @@ from app.settings import settings
 
 from .timer_form import TimerForm
 from .tickets.sync import deploy_or_update_panel
-from .tickets.ticket_flow import register_persistent_ticket_views
+from .tickets.views import register_close_ticket_buttons
 from .voicetracking_api import (
     ACTIVITY_RECORDS_URL,
     GUILDS_SYNC_URL,
@@ -39,12 +39,12 @@ class MyClient(discord.Client):
         print(f"Logged in as {self.user} (ID: {self.user.id})")
         print("------")
         await sync_guilds_to_api()
-        await register_persistent_ticket_views(self)
         await deploy_or_update_panel(self)
         track_voice_channels.start()
         sync_help_ticket_panel.start()
 
     async def setup_hook(self) -> None:
+        register_close_ticket_buttons(self)
         for guild in GUILDS:
             print(f"Syncing commands for {guild.id}")
             await self.tree.sync(guild=guild)

--- a/bot/app/tickets/api.py
+++ b/bot/app/tickets/api.py
@@ -5,7 +5,6 @@ from app.settings import settings
 HELP_TICKETS_BASE_URL = f"{settings.API_URL}/help-tickets"
 PANEL_CONFIG_URL = f"{HELP_TICKETS_BASE_URL}/panel-config"
 PANEL_STATE_URL = f"{HELP_TICKETS_BASE_URL}/panel-state"
-OPEN_TICKETS_URL = f"{HELP_TICKETS_BASE_URL}/open"
 
 
 class HelpTicketPanelCategory(BaseModel):
@@ -54,12 +53,3 @@ class HelpTicketResponse(BaseModel):
 class CloseHelpTicketRequest(BaseModel):
     closed_by_discord_id: int
     close_reason: str = ""
-
-
-class OpenHelpTicket(BaseModel):
-    id: int
-    thread_id: int
-
-
-class OpenHelpTicketsResponse(BaseModel):
-    tickets: list[OpenHelpTicket]

--- a/bot/app/tickets/close_flow.py
+++ b/bot/app/tickets/close_flow.py
@@ -1,0 +1,137 @@
+import asyncio
+import logging
+
+import discord
+
+from .api import CloseHelpTicketRequest
+from .service import (
+    close_help_ticket,
+    fetch_help_ticket,
+    member_can_close_ticket,
+)
+
+logger = logging.getLogger(__name__)
+
+THREAD_ARCHIVE_DELAY_SECONDS = 5
+
+
+async def _can_close_ticket(
+    member: discord.Member,
+    thread: discord.Thread,
+    opener_discord_id: int,
+) -> bool:
+    """Moderators/admins, the ticket opener, and anyone participating in
+    the ticket thread (e.g. the tribe owner or mentioned team members)
+    may close the ticket."""
+    if member_can_close_ticket(member):
+        return True
+    if member.id == opener_discord_id:
+        return True
+    try:
+        await thread.fetch_member(member.id)
+    except discord.NotFound:
+        return False
+    except discord.HTTPException:
+        logger.exception(
+            "Failed to check thread membership for %s in %s",
+            member.id,
+            thread.id,
+        )
+        return False
+    return True
+
+
+async def _send_close_notice_dm(
+    client: discord.Client,
+    *,
+    opener_discord_id: int,
+    closed_by: discord.Member,
+    close_reason: str,
+) -> None:
+    reason_text = close_reason.strip() or "No reason specified"
+    try:
+        opener = await client.fetch_user(opener_discord_id)
+        await opener.send(
+            f"Your help ticket has been closed by {closed_by.display_name}.\n"
+            f"**Reason:** {reason_text}"
+        )
+    except discord.HTTPException:
+        logger.warning(
+            "Could not DM opener %s about closed help ticket",
+            opener_discord_id,
+            exc_info=True,
+        )
+
+
+async def close_ticket(
+    interaction: discord.Interaction,
+    ticket_id: int,
+    *,
+    close_reason: str = "",
+):
+    if not isinstance(interaction.user, discord.Member):
+        await interaction.response.send_message(
+            "Unable to verify your permissions.",
+            ephemeral=True,
+        )
+        return
+
+    if not isinstance(interaction.channel, discord.Thread):
+        await interaction.response.send_message(
+            "Tickets can only be closed from the ticket thread.",
+            ephemeral=True,
+        )
+        return
+
+    await interaction.response.defer(ephemeral=True)
+
+    reason_text = close_reason.strip() or "No reason specified"
+
+    try:
+        ticket = await asyncio.to_thread(fetch_help_ticket, ticket_id)
+    except Exception:
+        logger.exception("Failed to fetch help ticket %s", ticket_id)
+        await interaction.followup.send(
+            "Could not load ticket details. Try again.",
+            ephemeral=True,
+        )
+        return
+
+    if not await _can_close_ticket(
+        interaction.user,
+        interaction.channel,
+        ticket.opener_discord_id,
+    ):
+        await interaction.followup.send(
+            "Only moderators, people in this ticket, or the ticket "
+            "opener can close tickets.",
+            ephemeral=True,
+        )
+        return
+
+    await interaction.followup.send("Ticket closed.", ephemeral=True)
+    await asyncio.sleep(THREAD_ARCHIVE_DELAY_SECONDS)
+
+    try:
+        await asyncio.to_thread(
+            close_help_ticket,
+            ticket_id,
+            CloseHelpTicketRequest(
+                closed_by_discord_id=interaction.user.id,
+                close_reason=close_reason,
+            ),
+        )
+    except Exception:
+        logger.exception("Failed to close help ticket %s via API", ticket_id)
+        await interaction.followup.send(
+            "Could not archive the Discord thread. The ticket is still open.",
+            ephemeral=True,
+        )
+        return
+
+    await _send_close_notice_dm(
+        interaction.client,
+        opener_discord_id=ticket.opener_discord_id,
+        closed_by=interaction.user,
+        close_reason=reason_text,
+    )

--- a/bot/app/tickets/modals.py
+++ b/bot/app/tickets/modals.py
@@ -1,5 +1,7 @@
 import discord
 
+from .ticket_flow import create_ticket_from_modal
+
 
 class HelpRequestModal(discord.ui.Modal, title="Help request"):
     def __init__(self, category_id: int):
@@ -15,9 +17,6 @@ class HelpRequestModal(discord.ui.Modal, title="Help request"):
     )
 
     async def on_submit(self, interaction: discord.Interaction):
-        # pylint: disable=import-outside-toplevel
-        from .ticket_flow import create_ticket_from_modal
-
         await create_ticket_from_modal(
             interaction,
             category_id=self.category_id,

--- a/bot/app/tickets/panel.py
+++ b/bot/app/tickets/panel.py
@@ -1,6 +1,7 @@
 import discord
 
 from .api import HelpTicketPanelConfig
+from .modals import HelpRequestModal
 
 HELP_TICKET_SELECT_CUSTOM_ID = "help_ticket_select"
 
@@ -56,9 +57,6 @@ class HelpTicketSelect(discord.ui.Select):
                 ephemeral=True,
             )
             return
-
-        # pylint: disable=import-outside-toplevel
-        from .modals import HelpRequestModal
 
         await interaction.response.send_modal(HelpRequestModal(category_id))
 

--- a/bot/app/tickets/service.py
+++ b/bot/app/tickets/service.py
@@ -8,7 +8,6 @@ from app.settings import settings
 
 from .api import (
     HELP_TICKETS_BASE_URL,
-    OPEN_TICKETS_URL,
     PANEL_CONFIG_URL,
     PANEL_STATE_URL,
     CloseHelpTicketRequest,
@@ -17,7 +16,6 @@ from .api import (
     HelpTicketPanelState,
     HelpTicketPanelStateUpdate,
     HelpTicketResponse,
-    OpenHelpTicketsResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -79,11 +77,6 @@ def close_help_ticket(
 def fetch_help_ticket(ticket_id: int) -> HelpTicketResponse:
     response = _request("GET", f"{HELP_TICKETS_BASE_URL}/{ticket_id}/")
     return HelpTicketResponse.model_validate(response.json())
-
-
-def fetch_open_help_tickets() -> OpenHelpTicketsResponse:
-    response = _request("GET", OPEN_TICKETS_URL)
-    return OpenHelpTicketsResponse.model_validate(response.json())
 
 
 def sanitize_thread_name(group_code: str, username: str) -> str:

--- a/bot/app/tickets/ticket_flow.py
+++ b/bot/app/tickets/ticket_flow.py
@@ -4,23 +4,17 @@ import logging
 import discord
 
 from .api import (
-    CloseHelpTicketRequest,
     CreateHelpTicketRequest,
     HelpTicketPanelCategory,
 )
 from .service import (
-    close_help_ticket,
     create_help_ticket,
-    fetch_help_ticket,
     fetch_panel_config,
-    member_can_close_ticket,
     sanitize_thread_name,
 )
-from .views import CloseTicketView
+from .views import build_close_ticket_view
 
 logger = logging.getLogger(__name__)
-
-THREAD_ARCHIVE_DELAY_SECONDS = 5
 
 
 async def create_ticket_from_modal(
@@ -109,109 +103,15 @@ async def create_ticket_from_modal(
         )
         return
 
-    close_view = CloseTicketView(ticket.id)
-    interaction.client.add_view(close_view)
-
     await thread.send(
         content=mention or None,
         embeds=[welcome_embed, details_embed],
-        view=close_view,
+        view=build_close_ticket_view(ticket.id),
     )
 
     await interaction.followup.send(
         f"Your ticket was opened: {thread.mention}",
         ephemeral=True,
-    )
-
-
-async def _send_close_notice_dm(
-    client: discord.Client,
-    *,
-    opener_discord_id: int,
-    closed_by: discord.Member,
-    close_reason: str,
-) -> None:
-    reason_text = close_reason.strip() or "No reason specified"
-    try:
-        opener = await client.fetch_user(opener_discord_id)
-        await opener.send(
-            f"Your help ticket has been closed by {closed_by.display_name}.\n"
-            f"**Reason:** {reason_text}"
-        )
-    except discord.HTTPException:
-        logger.warning(
-            "Could not DM opener %s about closed help ticket",
-            opener_discord_id,
-            exc_info=True,
-        )
-
-
-async def close_ticket(
-    interaction: discord.Interaction,
-    ticket_id: int,
-    *,
-    close_reason: str = "",
-):
-    if not isinstance(interaction.user, discord.Member):
-        await interaction.response.send_message(
-            "Unable to verify your permissions.",
-            ephemeral=True,
-        )
-        return
-
-    if not member_can_close_ticket(interaction.user):
-        await interaction.response.send_message(
-            "Only moderators and administrators can close tickets.",
-            ephemeral=True,
-        )
-        return
-
-    if not isinstance(interaction.channel, discord.Thread):
-        await interaction.response.send_message(
-            "Tickets can only be closed from the ticket thread.",
-            ephemeral=True,
-        )
-        return
-
-    await interaction.response.defer(ephemeral=True)
-
-    reason_text = close_reason.strip() or "No reason specified"
-
-    try:
-        ticket = await asyncio.to_thread(fetch_help_ticket, ticket_id)
-    except Exception:
-        logger.exception("Failed to fetch help ticket %s", ticket_id)
-        await interaction.followup.send(
-            "Could not load ticket details. Try again.",
-            ephemeral=True,
-        )
-        return
-
-    await interaction.followup.send("Ticket closed.", ephemeral=True)
-    await asyncio.sleep(THREAD_ARCHIVE_DELAY_SECONDS)
-
-    try:
-        await asyncio.to_thread(
-            close_help_ticket,
-            ticket_id,
-            CloseHelpTicketRequest(
-                closed_by_discord_id=interaction.user.id,
-                close_reason=close_reason,
-            ),
-        )
-    except Exception:
-        logger.exception("Failed to close help ticket %s via API", ticket_id)
-        await interaction.followup.send(
-            "Could not archive the Discord thread. The ticket is still open.",
-            ephemeral=True,
-        )
-        return
-
-    await _send_close_notice_dm(
-        interaction.client,
-        opener_discord_id=ticket.opener_discord_id,
-        closed_by=interaction.user,
-        close_reason=reason_text,
     )
 
 
@@ -227,17 +127,3 @@ def _find_category(
 def _format_mentions(discord_ids: list[int]) -> str:
     unique_ids = list(dict.fromkeys(discord_ids))
     return " ".join(f"<@{discord_id}>" for discord_id in unique_ids)
-
-
-async def register_persistent_ticket_views(client: discord.Client):
-    # pylint: disable=import-outside-toplevel
-    from .service import fetch_open_help_tickets
-
-    try:
-        open_tickets = await asyncio.to_thread(fetch_open_help_tickets)
-    except Exception:
-        logger.exception("Failed to fetch open help tickets for view registration")
-        return
-
-    for ticket in open_tickets.tickets:
-        client.add_view(CloseTicketView(ticket.id))

--- a/bot/app/tickets/views.py
+++ b/bot/app/tickets/views.py
@@ -1,4 +1,8 @@
+import re
+
 import discord
+
+from .close_flow import close_ticket
 
 
 class CloseWithReasonModal(discord.ui.Modal, title="Close ticket"):
@@ -15,9 +19,6 @@ class CloseWithReasonModal(discord.ui.Modal, title="Close ticket"):
     )
 
     async def on_submit(self, interaction: discord.Interaction):
-        # pylint: disable=import-outside-toplevel
-        from .ticket_flow import close_ticket
-
         await close_ticket(
             interaction,
             self.ticket_id,
@@ -25,36 +26,72 @@ class CloseWithReasonModal(discord.ui.Modal, title="Close ticket"):
         )
 
 
-class CloseTicketView(discord.ui.View):
+class CloseTicketButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"help_ticket_close:(?P<ticket_id>[0-9]+)",
+):
     def __init__(self, ticket_id: int):
-        super().__init__(timeout=None)
+        super().__init__(
+            discord.ui.Button(
+                label="Close",
+                style=discord.ButtonStyle.danger,
+                emoji="🔒",
+                custom_id=f"help_ticket_close:{ticket_id}",
+            )
+        )
         self.ticket_id = ticket_id
 
-        close_button = discord.ui.Button(
-            label="Close",
-            style=discord.ButtonStyle.danger,
-            emoji="🔒",
-            custom_id=f"help_ticket_close:{ticket_id}",
-        )
-        close_button.callback = self.close_callback
-        self.add_item(close_button)
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Button,
+        match: re.Match[str],
+        /,
+    ):
+        return cls(int(match["ticket_id"]))
 
-        close_with_reason_button = discord.ui.Button(
-            label="Close With Reason",
-            style=discord.ButtonStyle.danger,
-            emoji="🔒",
-            custom_id=f"help_ticket_close_reason:{ticket_id}",
-        )
-        close_with_reason_button.callback = self.close_with_reason_callback
-        self.add_item(close_with_reason_button)
-
-    async def close_callback(self, interaction: discord.Interaction):
-        # pylint: disable=import-outside-toplevel
-        from .ticket_flow import close_ticket
-
+    async def callback(self, interaction: discord.Interaction):
         await close_ticket(interaction, self.ticket_id)
 
-    async def close_with_reason_callback(self, interaction: discord.Interaction):
+
+class CloseWithReasonButton(
+    discord.ui.DynamicItem[discord.ui.Button],
+    template=r"help_ticket_close_reason:(?P<ticket_id>[0-9]+)",
+):
+    def __init__(self, ticket_id: int):
+        super().__init__(
+            discord.ui.Button(
+                label="Close With Reason",
+                style=discord.ButtonStyle.danger,
+                emoji="🔒",
+                custom_id=f"help_ticket_close_reason:{ticket_id}",
+            )
+        )
+        self.ticket_id = ticket_id
+
+    @classmethod
+    async def from_custom_id(
+        cls,
+        interaction: discord.Interaction,
+        item: discord.ui.Button,
+        match: re.Match[str],
+        /,
+    ):
+        return cls(int(match["ticket_id"]))
+
+    async def callback(self, interaction: discord.Interaction):
         await interaction.response.send_modal(
             CloseWithReasonModal(self.ticket_id)
         )
+
+
+def build_close_ticket_view(ticket_id: int) -> discord.ui.View:
+    view = discord.ui.View(timeout=None)
+    view.add_item(CloseTicketButton(ticket_id))
+    view.add_item(CloseWithReasonButton(ticket_id))
+    return view
+
+
+def register_close_ticket_buttons(client: discord.Client) -> None:
+    client.add_dynamic_items(CloseTicketButton, CloseWithReasonButton)


### PR DESCRIPTION
## Summary
- Help ticket Close / Close With Reason buttons showed "The application didn't respond in time" after bot restarts: per-ticket views were only re-registered from a startup fetch of `/help-tickets/open`, so a failed fetch, an already-closed ticket, or a click before `on_ready` left the button with no handler.
- Replaced per-ticket view registration with `discord.ui.DynamicItem` buttons matched by `custom_id` pattern (`help_ticket_close:<id>` / `help_ticket_close_reason:<id>`), registered once in `setup_hook`. Custom IDs are unchanged, so buttons on existing ticket messages work again as soon as this deploys.
- Broadened close permissions: in addition to admins/moderators, the ticket opener and anyone in the ticket thread (tribe owner / mentioned team members) can now close the ticket. The check runs after deferring, so the thread-membership lookup can't reintroduce the interaction timeout.
- Removed the now-unused open-tickets fetch from the bot and the circular inline imports it forced (`close_ticket` moved to `close_flow.py`).

## Test plan
- [x] Bot package imports and byte-compiles cleanly; view builder produces the same custom IDs as before
- [ ] After deploy: click Close on a pre-existing ticket thread (created before the restart) and confirm it responds
- [ ] Confirm ticket opener (non-moderator) can close their own ticket and receives the close DM

Made with [Cursor](https://cursor.com)