### PR TITLE
Fix freight contract sync picking directors who left the corp

### DIFF
--- a/backend/eveonline/helpers/corporations/update.py
+++ b/backend/eveonline/helpers/corporations/update.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from decimal import Decimal
 
 import pytz
+from django.db import models
 from django.utils import timezone
 from esi.models import Token
 
@@ -102,31 +103,46 @@ def get_director_with_scope(corporation, scope_list):
 def resolve_directors_by_scope(corporation, scope_lists):
     """
     Return a dict mapping tuple(scope_list) -> EveCharacter | None for each
-    scope list, checking CEO and directors once per candidate.
+    scope list, checking the CEO first, then directors. Candidates who are no
+    longer in the corporation (stale director entries) are skipped, since ESI
+    rejects corporation endpoints for tokens of former members.
     """
-    candidate_ids = set()
+    candidate_ids = []
     if corporation.ceo_id and corporation.ceo:
-        candidate_ids.add(corporation.ceo.character_id)
+        candidate_ids.append(corporation.ceo.character_id)
     for director in corporation.directors.all():
-        candidate_ids.add(director.character_id)
+        if director.character_id not in candidate_ids:
+            candidate_ids.append(director.character_id)
 
     results = {tuple(scope_list): None for scope_list in scope_lists}
     if not candidate_ids:
         return results
 
+    # Only keep candidates still in the corporation; a character with an
+    # unknown affiliation (corporation_id not yet synced) is given the
+    # benefit of the doubt.
     characters_by_id = {
         character.character_id: character
         for character in EveCharacter.objects.filter(
-            character_id__in=candidate_ids
+            models.Q(corporation_id=corporation.corporation_id)
+            | models.Q(corporation_id__isnull=True),
+            character_id__in=candidate_ids,
         )
     }
     for character_id in candidate_ids:
+        if character_id not in characters_by_id:
+            logger.debug(
+                "Skipping candidate %s for corporation %s: no longer a member",
+                character_id,
+                corporation.corporation_id,
+            )
+            continue
         for scope_list in scope_lists:
             key = tuple(scope_list)
             if results[key] is not None:
                 continue
             if Token.get_token(character_id, scope_list):
-                results[key] = characters_by_id.get(character_id)
+                results[key] = characters_by_id[character_id]
     return results
 
 

--- a/backend/eveonline/tests/helpers/test_resolve_directors.py
+++ b/backend/eveonline/tests/helpers/test_resolve_directors.py
@@ -1,0 +1,76 @@
+"""Tests for director/CEO token resolution used by corporation ESI syncs."""
+
+import factory
+from django.db.models import signals
+from esi.models import Scope, Token
+
+from app.test import TestCase
+from eveonline.helpers.corporations.update import (
+    SCOPE_CORPORATION_CONTRACTS,
+    resolve_directors_by_scope,
+)
+from eveonline.models import EveCharacter, EveCorporation
+
+CORP_ID = 98705678
+OTHER_CORP_ID = 98838663
+
+
+def _character_with_scopes(character_id, corporation_id, scopes):
+    token = Token.objects.create(character_id=character_id)
+    for scope_name in scopes:
+        scope, _ = Scope.objects.get_or_create(name=scope_name)
+        token.scopes.add(scope)
+    return EveCharacter.objects.create(
+        character_id=character_id,
+        corporation_id=corporation_id,
+        token=token,
+    )
+
+
+class ResolveDirectorsByScopeTestCase(TestCase):
+    @factory.django.mute_signals(signals.pre_save, signals.post_save)
+    def test_skips_directors_no_longer_in_corporation(self):
+        corporation = EveCorporation.objects.create(corporation_id=CORP_ID)
+        stale_director = _character_with_scopes(
+            96129158, OTHER_CORP_ID, SCOPE_CORPORATION_CONTRACTS
+        )
+        ceo = _character_with_scopes(
+            149027055, CORP_ID, SCOPE_CORPORATION_CONTRACTS
+        )
+        corporation.ceo = ceo
+        corporation.save()
+        corporation.directors.add(stale_director)
+
+        results = resolve_directors_by_scope(
+            corporation, [SCOPE_CORPORATION_CONTRACTS]
+        )
+
+        self.assertEqual(ceo, results[tuple(SCOPE_CORPORATION_CONTRACTS)])
+
+    @factory.django.mute_signals(signals.pre_save, signals.post_save)
+    def test_returns_none_when_only_candidates_left_corporation(self):
+        corporation = EveCorporation.objects.create(corporation_id=CORP_ID)
+        stale_director = _character_with_scopes(
+            96129158, OTHER_CORP_ID, SCOPE_CORPORATION_CONTRACTS
+        )
+        corporation.directors.add(stale_director)
+
+        results = resolve_directors_by_scope(
+            corporation, [SCOPE_CORPORATION_CONTRACTS]
+        )
+
+        self.assertIsNone(results[tuple(SCOPE_CORPORATION_CONTRACTS)])
+
+    @factory.django.mute_signals(signals.pre_save, signals.post_save)
+    def test_allows_candidate_with_unknown_affiliation(self):
+        corporation = EveCorporation.objects.create(corporation_id=CORP_ID)
+        director = _character_with_scopes(
+            90000001, None, SCOPE_CORPORATION_CONTRACTS
+        )
+        corporation.directors.add(director)
+
+        results = resolve_directors_by_scope(
+            corporation, [SCOPE_CORPORATION_CONTRACTS]
+        )
+
+        self.assertEqual(director, results[tuple(SCOPE_CORPORATION_CONTRACTS)])


### PR DESCRIPTION
## Summary

- Freight contracts for Minmatar Fleet Logistics (98705678) stopped syncing on July 19: the hourly corporation sync was authenticating with tokens from directors still listed in our DB but no longer in the corporation (they moved to Minmatar Extraction Company), and ESI rejects corporation endpoints for former members.
- `resolve_directors_by_scope` now checks the CEO first, then directors, in deterministic order (previously an unordered set), and skips any candidate whose current `corporation_id` no longer matches the corporation being synced. Characters with unknown affiliation are still allowed.
- This also benefits the other syncs using the same resolver (members/roles, industry jobs, blueprints, wallet journal); the members/roles sync will clean out the stale director entries on its next successful run.

## Test plan

- [x] New regression tests in `backend/eveonline/tests/helpers/test_resolve_directors.py`: stale director skipped in favor of CEO, all-stale candidates return None, unknown affiliation still allowed.
- [x] `pipenv run python manage.py test eveonline.tests.helpers.test_resolve_directors eveonline.tests.test_tasks --settings=app.settings_test` — 13 tests pass.
- [ ] After deploy, confirm the hourly `update_corporations` run resolves Bargelina's token and freight contracts update.

Made with [Cursor](https://cursor.com)