### PR TITLE
Fix compressed ore planner shorting minerals on partial portions

### DIFF
--- a/backend/industry/helpers/compressed_ore.py
+++ b/backend/industry/helpers/compressed_ore.py
@@ -420,18 +420,21 @@ def reprocess_output(
     refine_rate: float = DEFAULT_REFINE_RATE,
 ) -> Dict[str, int]:
     """
-    Portion-aware refine output: floor(qty / 100 * base * refine_rate).
+    Portion-aware refine output: floor(floor(qty / 100) * base * refine_rate).
 
-    Matches in-game batch reprocessing for Compressed / uncompressed ore.
+    Matches in-game batch reprocessing for Compressed / uncompressed ore:
+    only whole 100-unit portions refine; a trailing partial stack yields
+    nothing (Discord report: crediting partial portions shorted Pye/Mex).
     """
     if quantity <= 0 or refine_rate <= 0:
+        return {}
+    portions = quantity // ORE_BATCH_SIZE
+    if portions <= 0:
         return {}
     per_portion = ore_materials_per_portion(ore_name)
     out: Dict[str, int] = {}
     for name, base_qty in per_portion.items():
-        produced = math.floor(
-            quantity / ORE_BATCH_SIZE * base_qty * refine_rate
-        )
+        produced = math.floor(portions * base_qty * refine_rate)
         if produced > 0:
             out[name] = produced
     return out
@@ -755,18 +758,27 @@ def compute_practical_belt_blend(
 
 def to_compressed_units(
     uncompressed_units: Dict[str, float],
+    *,
+    batch_size: int = 1,
 ) -> Dict[str, int]:
     """
     Convert ore units to Compressed stacks.
 
     Modern compression is 1:1 quantity (volume shrinks ~100×).
+
+    ``batch_size`` rounds each stack up to whole reprocessing portions
+    (100 for ore, 1 for ice). Units beyond the last whole portion refine
+    to nothing in-game, so partial stacks are pure dead weight.
     """
     compressed: Dict[str, int] = {}
     for ore_name, units in uncompressed_units.items():
         if units <= 0:
             continue
         name = compressed_type_name(ore_name)
-        compressed[name] = compressed.get(name, 0) + int(math.ceil(units))
+        qty = int(math.ceil(units))
+        if batch_size > 1:
+            qty = math.ceil(qty / batch_size) * batch_size
+        compressed[name] = compressed.get(name, 0) + qty
     return compressed
 
 
@@ -834,11 +846,14 @@ def _top_up_floor_coverage(
             return
         name = compressed_type_name(ore)
         base_qty = ore_materials_per_portion(ore).get(shortfall, 0.0)
-        yield_per = (base_qty / ORE_BATCH_SIZE) * coverage_rate
-        if yield_per <= 0:
+        yield_per_portion = base_qty * coverage_rate
+        if yield_per_portion <= 0:
             return
-        add = max(1, math.ceil(shortfall_qty / yield_per))
-        belt_compressed[name] = belt_compressed.get(name, 0) + add
+        # Whole portions only — partial stacks refine to nothing in-game.
+        add_portions = max(1, math.ceil(shortfall_qty / yield_per_portion))
+        belt_compressed[name] = (
+            belt_compressed.get(name, 0) + add_portions * ORE_BATCH_SIZE
+        )
 
 
 def ice_materials_per_unit(ice_name: str) -> Dict[str, float]:
@@ -1121,7 +1136,8 @@ def build_compressed_ore_plan(
             require_market=require_market,
         )
         plan.moon_ore_compressed = to_compressed_units(
-            {k: float(v) for k, v in moon_units.items()}
+            {k: float(v) for k, v in moon_units.items()},
+            batch_size=ORE_BATCH_SIZE,
         )
         plan.moon_mineral_byproducts = moon_byproducts
         # Uncovered PI P0 (not allowlisted / no marketable moon ore) stays import.
@@ -1143,7 +1159,9 @@ def build_compressed_ore_plan(
     belt_units, mineral_imports = compute_practical_belt_blend(
         mineral_needs, moon_byproducts, ore_yields
     )
-    plan.belt_ore_compressed = to_compressed_units(belt_units)
+    plan.belt_ore_compressed = to_compressed_units(
+        belt_units, batch_size=ORE_BATCH_SIZE
+    )
     _top_up_floor_coverage(
         plan.belt_ore_compressed,
         mineral_needs,

--- a/backend/industry/tests/test_compressed_ore.py
+++ b/backend/industry/tests/test_compressed_ore.py
@@ -448,6 +448,37 @@ class CompressedOrePlanTestCase(TestCase):
         out = reprocess_output("Veldspar", 100, refine_rate=0.84)
         self.assertEqual(out["Tritanium"], 336)
 
+    def test_reprocess_output_ignores_partial_portions(self):
+        """In-game, only whole 100-unit portions refine; remainders yield 0."""
+        # 150 units = 1 whole portion; the trailing 50 refine to nothing.
+        out = reprocess_output("Veldspar", 150, refine_rate=0.84)
+        self.assertEqual(out["Tritanium"], 336)
+        # Below one portion → no output at all.
+        self.assertEqual(
+            reprocess_output("Veldspar", 99, refine_rate=0.84), {}
+        )
+
+    def test_to_compressed_units_rounds_up_to_whole_portions(self):
+        compressed = to_compressed_units({"Zeolites": 59_524}, batch_size=100)
+        self.assertEqual(compressed["Compressed Zeolites"], 59_600)
+        # Default (ice) keeps 1:1 ceil.
+        self.assertEqual(
+            to_compressed_units({"Glare Crust": 10.2})[
+                "Compressed Glare Crust"
+            ],
+            11,
+        )
+
+    def test_plan_belt_stacks_are_whole_portions(self):
+        plan = build_compressed_ore_plan(
+            {"Tritanium": 8_000_001, "Pyerite": 4_000_000},
+            refine_rate=0.84,
+            use_moon_ore=False,
+            require_market=False,
+        )
+        for name, qty in plan.belt_ore_compressed.items():
+            self.assertEqual(qty % 100, 0, msg=f"{name}: {qty}")
+
     def test_floor_top_up_eliminates_covered_mineral_shortfall(self):
         """Continuous blend can undershoot Trit by 1; top-up closes the gap."""
         plan = build_compressed_ore_plan(


### PR DESCRIPTION
## Summary
- In-game reprocessing only consumes whole 100-unit ore portions; units past the last whole portion yield nothing. The planner credited those partial portions (`floor(qty / 100 * base * rate)`), so shopping lists with non-multiple-of-100 stacks came up short when refined in-game. Reproduces the Discord report exactly: −5,249 Pyerite / −25 Mexallon (and +1,703 Tritanium surplus) on a Typhoon Fleet Issue ×40 order refined at Amamake 85.77%.
- `reprocess_output` now floors to whole portions before applying yield, matching in-game batch reprocessing.
- Belt/moon ore stacks round up to multiples of 100 (`to_compressed_units(batch_size=100)`) since partial stacks are dead freight; ice keeps 1:1 (portion size 1).
- The floor-coverage top-up adds ore in whole 100-unit portions.

With the fix, the same order covers Trit/Pye/Mex at both the UI display rate (+137 / +1,612 / +378) and the full facility rate — slight surplus, never a shortfall.

## Test plan
- [x] New regression tests: partial portions yield zero, plan stacks are multiples of 100, portion rounding in `to_compressed_units`
- [x] Existing `test_top_up_covers_at_display_refine_rate` now validates true in-game whole-portion math via the fixed `reprocess_output`
- [x] Full `industry` suite: 217 tests, OK

Made with [Cursor](https://cursor.com)