### PR TITLE
Fill Sniper Omen and Blaster Vexor FW cruiser guide fits

### DIFF
--- a/frontend/app/src/data/faction-warfare-cruiser-guide/fittings.ts
+++ b/frontend/app/src/data/faction-warfare-cruiser-guide/fittings.ts
@@ -342,7 +342,36 @@ Nanite Repair Paste x90`,
         name: 'Sniper Omen',
         description:
             'Heavy beam long-point plex protector with MAAR.',
-        eftFormat: `[Omen, Sniper Omen]`,
+        eftFormat: `[Omen, Sniper Omen]
+
+Medium Ancillary Armor Repairer
+Multispectrum Energized Membrane II
+Damage Control II
+Heat Sink II
+Extruded Compact Heat Sink
+Reactor Control Unit II
+
+50MN Y-T8 Compact Microwarpdrive
+Warp Disruptor II
+Medium F-RX Compact Capacitor Booster
+
+Heavy Beam Laser II
+Heavy Beam Laser II
+Heavy Beam Laser II
+Heavy Beam Laser II
+Heavy Beam Laser II
+
+Medium Ionic Field Projector II
+Medium Ancillary Current Router I
+Medium Energy Locus Coordinator II
+
+
+Warrior II x5
+
+Aurora M x5
+Navy Cap Booster 800 x1
+Imperial Navy Xray M x5
+Nanite Repair Paste x32`,
     },
     {
         id: 'omenni-mid-kite',
@@ -424,16 +453,6 @@ Hornet EC-300 x5
 
 Navy Cap Booster 800 x15
 Nanite Repair Paste x214`,
-    },
-    {
-        id: 'omenni-pulse',
-        fittingId: 0,
-        shipId: 17709,
-        shipGuideId: 'omenni',
-        name: 'Pulse Omen Navy Issue',
-        description:
-            'Closer-range pulse variant of the mid-range kite line.',
-        eftFormat: `[Omen Navy Issue, Pulse Omen Navy Issue]`,
     },
     {
         id: 'caracalni-ham',
@@ -741,8 +760,35 @@ Navy Cap Booster 400 x1`,
         shipGuideId: 'vexor',
         name: 'Blaster Vexor',
         description:
-            'Neutron + dual magnetic stab scram brawler with bulkhead rigs.',
-        eftFormat: `[Vexor, Blaster Vexor]`,
+            'Hull-tank Neutrons with dual webs, medium neut, and transverse bulkhead rigs.',
+        eftFormat: `[Vexor, Blaster Vexor]
+
+Drone Damage Amplifier II
+Drone Damage Amplifier II
+Damage Control II
+Mark I Compact Reinforced Bulkheads
+Reinforced Bulkheads II
+
+50MN Quad LiF Restrained Microwarpdrive
+Faint Epsilon Scoped Warp Scrambler
+Fleeting Compact Stasis Webifier
+Fleeting Compact Stasis Webifier
+
+Medium Energy Neutralizer II
+Heavy Neutron Blaster II
+Heavy Neutron Blaster II
+Heavy Neutron Blaster II
+
+Medium Transverse Bulkhead I
+Medium Transverse Bulkhead I
+Medium Transverse Bulkhead I
+
+
+Hobgoblin II x1
+Hammerhead II x2
+Ogre II x2
+
+Void M x480`,
     },
     {
         id: 'vni-dual-rep',

--- a/frontend/app/src/data/faction-warfare-cruiser-guide/opponent-ships.ts
+++ b/frontend/app/src/data/faction-warfare-cruiser-guide/opponent-ships.ts
@@ -33,7 +33,6 @@ const fitNameToShip: Record<string, ResolvedOpponentShip> = {
     'Sniper Omen': cruiserGuideShips.omen,
     'Kite Omen Navy Issue': cruiserGuideShips.omenni,
     'Beam Omen Navy Issue': cruiserGuideShips.omenni,
-    'Pulse Omen Navy Issue': cruiserGuideShips.omenni,
     'HAM Caracal Navy Issue': cruiserGuideShips.caracalni,
     '2X Neut HAM Osprey Navy Issue': cruiserGuideShips.ospreyni,
     'RLML Osprey Navy Issue': cruiserGuideShips.ospreyni,

--- a/frontend/app/src/data/faction-warfare-cruiser-guide/ships.ts
+++ b/frontend/app/src/data/faction-warfare-cruiser-guide/ships.ts
@@ -270,7 +270,7 @@ export const omenniGuide: ShipGuide = {
     shortName: 'OmenNI',
     faction: 'Amarr',
     shipId: 17709,
-    tagline: 'Mid-range kite is top tier; sniper and pulse fill the gaps.',
+    tagline: 'Mid-range kite is top tier; beam sniper covers plex denial.',
     bonuses: [
         { label: 'Medium Energy Turret damage', value: '5%' },
         { label: 'Medium Energy Turret tracking', value: '7.5%' },
@@ -282,7 +282,7 @@ export const omenniGuide: ShipGuide = {
             id: 'overview',
             title: 'Overview',
             paragraphs: [
-                'If you are flying Omen Navy, you are usually kiting at mid range. That line is the hull\'s job. Sniper and pulse exist for plex pressure and frigates respectively.',
+                'If you are flying Omen Navy, you are usually kiting at mid range. That pulse kite line is the hull\'s job and the gold standard — no closer-range pulse variant. Beam sniper covers plex denial and gang projection.',
             ],
         },
         {
@@ -297,13 +297,6 @@ export const omenniGuide: ShipGuide = {
             title: 'Beam Omen Navy Issue',
             paragraphs: [
                 'Longer band for plex denial and gang projection.',
-            ],
-        },
-        {
-            id: 'pulse',
-            title: 'Pulse Omen Navy Issue',
-            paragraphs: [
-                'Tracking and frigate work when the mid-range kite is the wrong tool.',
             ],
         },
     ],
@@ -332,16 +325,6 @@ export const omenniGuide: ShipGuide = {
                 { opponent: 'XLASB HAM Bellicose', load: 'Aurora', verdict: 'favoured', advice: 'Same idea — do not let them scramble free.' },
                 { opponent: 'Blaster Exequror Navy Issue', load: 'Aurora', verdict: 'bail', advice: 'Once Neutrons land you are dead. Warp.' },
                 { opponent: 'Armor RLML Scythe Fleet Issue', load: 'Aurora', verdict: 'unfavoured', advice: 'They out-range-threat and outspeed. Leave early.' },
-            ],
-        },
-        {
-            title: 'Pulse Omen Navy Issue',
-            fitContext: 'Closer-range pulse for tracking and frigate work.',
-            entries: [
-                { opponent: 'AB XLASB Stabber', load: 'Conflag', verdict: 'favoured', advice: 'Closer band where tracking helps.' },
-                { opponent: 'Brawl Arbitrator', load: 'Conflag', verdict: 'skill', advice: 'Possible if you open clean. Watch neuts.' },
-                { opponent: 'Blaster Exequror Navy Issue', load: 'Conflag', verdict: 'unfavoured', advice: 'Neutron race is not your fight.' },
-                { opponent: 'Dual Rep Vexor Navy Issue', load: 'Conflag', verdict: 'bail', advice: 'Do not take the reactive wall at pulse range.' },
             ],
         },
     ],
@@ -599,7 +582,7 @@ export const vexorGuide: ShipGuide = {
         },
         {
             title: 'Blaster Vexor',
-            fitContext: 'Neutron + dual mag stab scram brawler with bulkhead rigs.',
+            fitContext: 'Hull-tank Neutrons with dual webs, medium neut, and bulkhead rigs.',
             entries: [
                 { opponent: 'AB XLASB Stabber', load: 'Void', verdict: 'favoured', advice: 'Wins most T1 mirror work.' },
                 { opponent: 'XLASB HAM Bellicose', load: 'Void', verdict: 'favoured', advice: 'Scram race into a T1 missile boat.' },


### PR DESCRIPTION
## Summary
- Fill Sniper Omen and Blaster Vexor EFTs from Dato Koppla in the Faction Warfare Cruiser Guide
- Remove the closer-range Pulse Omen Navy Issue placeholder (mid-range kite stays the pulse gold standard)
- Align Blaster Vexor copy with the hull-tank bulkhead fit (not mag stabs)

## Test plan
- [ ] Open `/ships/faction-warfare-cruiser-guide/` and confirm Sniper Omen / Blaster Vexor cards show full copyable EFTs
- [ ] Confirm Omen Navy Issue section no longer lists a separate Pulse ONI fit or matchup group
- [ ] Spot-check that earlier Dato-filled fits (e.g. Polarized AugNI, TD Support Arby) are unchanged


Made with [Cursor](https://cursor.com)