### PR TITLE
Isolate primary-character 401 from order claim UI

### DIFF
--- a/frontend/app/src/components/blocks/OrderBreakdown.astro
+++ b/frontend/app/src/components/blocks/OrderBreakdown.astro
@@ -7,6 +7,7 @@ import type { RootSingleItem } from '@dtypes/api.minmatar.org'
 interface Props {
     order_id:                   number;
     primary_character_id?:      number | null;
+    claim_disabled_reason?:     string | null;
     order_breakdown:            RootSingleItem[];
     location_name:              string | undefined;
     init_tooltips?:             boolean;
@@ -15,6 +16,7 @@ interface Props {
 const {
     order_id,
     primary_character_id,
+    claim_disabled_reason = null,
     order_breakdown,
     location_name,
     init_tooltips = false,
@@ -161,14 +163,31 @@ import RefreshIcon from '@components/icons/buttons/RefreshIcon.astro';
 
                     <FlexInline class="[ grow ]">
                         {(item.unassigned_quantity > 0 || user_assignment) &&
-                            <ButtonClaimOrder
-                                target_id={`order-item-${order_id}`}
-                                reclaim={Boolean(user_assignment)}
-                                order_id={order_id}
-                                claimed={user_assignment?.quantity ?? 0}
-                                item={item}
-                                character_id={primary_character_id as number}
-                            />
+                            <>{claim_disabled_reason ?
+                                <span
+                                    class="[ inline-flex ]"
+                                    data-tippy-content={claim_disabled_reason}
+                                    x-init={init_tooltips ? 'tippy($el, tippy_options)' : undefined}
+                                >
+                                    <Button
+                                        size='sm'
+                                        color='green'
+                                        disabled
+                                        off_disable={true}
+                                    >
+                                        {t('claim')}
+                                    </Button>
+                                </span>
+                                :
+                                <ButtonClaimOrder
+                                    target_id={`order-item-${order_id}`}
+                                    reclaim={Boolean(user_assignment)}
+                                    order_id={order_id}
+                                    claimed={user_assignment?.quantity ?? 0}
+                                    item={item}
+                                    character_id={primary_character_id as number}
+                                />
+                            }</>
                         }
 
                         {user_assignment &&

--- a/frontend/app/src/components/blocks/OrderItem.astro
+++ b/frontend/app/src/components/blocks/OrderItem.astro
@@ -9,6 +9,7 @@ interface Props {
     order:                  IndustryOrderUI;
     order_breakdown?:       RootSingleItem[];
     primary_character_id?:  number | null;
+    claim_disabled_reason?: string | null;
     location_name:          string | undefined;
     init_tooltips:          boolean;
 }
@@ -17,6 +18,7 @@ const {
     order,
     order_breakdown,
     primary_character_id,
+    claim_disabled_reason = null,
     location_name,
     init_tooltips,
 } = Astro.props
@@ -148,6 +150,7 @@ import TippyOrderItem from './TippyOrderItem.astro';
             <OrderBreakdown
                 order_id={order.id}
                 primary_character_id={primary_character_id}
+                claim_disabled_reason={claim_disabled_reason}
                 order_breakdown={order_breakdown}
                 location_name={location_name}
                 init_tooltips={true}

--- a/frontend/app/src/helpers/api.minmatar.org/characters.ts
+++ b/frontend/app/src/helpers/api.minmatar.org/characters.ts
@@ -139,6 +139,30 @@ export async function get_primary_characters(access_token:string) {
     }
 }
 
+/** Resolve main pilot for claim UI without failing the parent page load. */
+export type PrimaryClaimAvailability = 'ok' | 'login' | 'auth' | 'no_primary'
+
+export async function resolve_primary_for_claim(
+    access_token: string | false
+): Promise<{ character_id: number; availability: PrimaryClaimAvailability }> {
+    if (!access_token) {
+        return { character_id: 0, availability: 'login' }
+    }
+
+    try {
+        const primary_pilot = await get_primary_characters(access_token)
+        const character_id = primary_pilot?.character_id ?? 0
+
+        if (!character_id) {
+            return { character_id: 0, availability: 'no_primary' }
+        }
+
+        return { character_id, availability: 'ok' }
+    } catch {
+        return { character_id: 0, availability: 'auth' }
+    }
+}
+
 export async function get_character_skillsets(access_token:string, character_id:number) {
     const headers = {
         'Content-Type': 'application/json',

--- a/frontend/app/src/i18n/ui.ts
+++ b/frontend/app/src/i18n/ui.ts
@@ -443,6 +443,8 @@ export const ui = {
         'industry.orders.assign_unassigned_suffix': 'unassigned',
         'industry.orders.assign_invalid_form': 'Invalid item, character, or quantity.',
         'industry.orders.assign_error': 'Could not create assignment.',
+        'industry.orders.claim_session_required': 'Your session expired. Log in again to claim.',
+        'industry.orders.claim_main_pilot_required': 'Set a main pilot on your account to claim.',
         'page_finder.orders.description': 'Manufacturing orders and assignments breakdowns.',
         'page_finder.orders.history.description': 'Manufacturing orders history.',
 

--- a/frontend/app/src/pages/partials/order_breakdown_component.astro
+++ b/frontend/app/src/pages/partials/order_breakdown_component.astro
@@ -2,33 +2,45 @@
 import { i18n } from '@helpers/i18n'
 const { t, translatePath } = i18n(Astro.url)
 
-import type { User } from '@dtypes/jwt'
-import * as jose from 'jose'
-
 const order_id = parseInt(Astro.url.searchParams.get('order_id') ?? '0')
 const location_name = Astro.url.searchParams.get('location_name')
 
 import type { RootSingleItem } from '@dtypes/api.minmatar.org'
 import { fetch_order_breakdown_grouped } from '@helpers/fetching/industry'
-import { get_primary_characters } from '@helpers/api.minmatar.org/characters'
+import {
+    resolve_primary_for_claim,
+    type PrimaryClaimAvailability,
+} from '@helpers/api.minmatar.org/characters'
 
 const auth_token = Astro.cookies.has('auth_token') ? (Astro.cookies.get('auth_token')?.value as string) : false
-const user:User | false = auth_token ? jose.decodeJwt(auth_token) as User : false
 
 let order_breakdown: RootSingleItem[] = []
 let primary_character_id = 0
+let claim_availability: PrimaryClaimAvailability = 'login'
 let fetching_error: Error | false = false
+
+const claim_disabled_reason_by_availability: Record<Exclude<PrimaryClaimAvailability, 'ok'>, string> = {
+    login: t('industry.orders.assign_login_required'),
+    auth: t('industry.orders.claim_session_required'),
+    no_primary: t('industry.orders.claim_main_pilot_required'),
+}
 
 try {
     if (isNaN(order_id))
         throw new Error(t('invalid_order_id'), { cause: 400 })
 
     order_breakdown = await fetch_order_breakdown_grouped(order_id)
-    const primary_pilot = await get_primary_characters(auth_token as string)
-    primary_character_id = primary_pilot?.character_id ?? 0
+
+    const primary = await resolve_primary_for_claim(auth_token)
+    primary_character_id = primary.character_id
+    claim_availability = primary.availability
 } catch (error) {
     fetching_error = error
 }
+
+const claim_disabled_reason = claim_availability === 'ok'
+    ? null
+    : claim_disabled_reason_by_availability[claim_availability]
 
 import { query_string } from '@helpers/string';
 const ORDER_BREAKDOWN_PARTIAL_URL = `${translatePath('/partials/order_breakdown_component')}?${query_string({
@@ -55,6 +67,7 @@ import ErrorRefetch from '@components/blocks/ErrorRefetch.astro'
         <OrderBreakdown
             order_id={order_id}
             primary_character_id={primary_character_id}
+            claim_disabled_reason={claim_disabled_reason}
             order_breakdown={order_breakdown}
             location_name={location_name ?? undefined}
             init_tooltips={true}

--- a/frontend/app/src/pages/partials/order_item_component.astro
+++ b/frontend/app/src/pages/partials/order_item_component.astro
@@ -90,7 +90,10 @@ if (Astro.request.method === "PATCH") {
 }
 
 import { fetch_order_by_id } from '@helpers/fetching/industry'
-import { get_primary_characters } from '@helpers/api.minmatar.org/characters'
+import {
+    resolve_primary_for_claim,
+    type PrimaryClaimAvailability,
+} from '@helpers/api.minmatar.org/characters'
 import type { RootSingleItem } from '@dtypes/api.minmatar.org'
 import { fetch_order_breakdown_grouped } from '@helpers/fetching/industry'
 
@@ -98,6 +101,13 @@ let fetching_error: Error | false = false
 let order:IndustryOrderUI | null = null
 let order_breakdown: RootSingleItem[] = []
 let primary_character_id = 0
+let claim_availability: PrimaryClaimAvailability = 'login'
+
+const claim_disabled_reason_by_availability: Record<Exclude<PrimaryClaimAvailability, 'ok'>, string> = {
+    login: t('industry.orders.assign_login_required'),
+    auth: t('industry.orders.claim_session_required'),
+    no_primary: t('industry.orders.claim_main_pilot_required'),
+}
 
 try {
     order = await fetch_order_by_id(order_id)
@@ -107,12 +117,17 @@ try {
 
     if (fetch_breakdown) {
         order_breakdown = await fetch_order_breakdown_grouped(order_id)
-        const primary_pilot = await get_primary_characters(auth_token as string)
-        primary_character_id = primary_pilot?.character_id ?? 0
+        const primary = await resolve_primary_for_claim(auth_token)
+        primary_character_id = primary.character_id
+        claim_availability = primary.availability
     }
 } catch (error) {
     fetching_error = error
 }
+
+const claim_disabled_reason = !fetch_breakdown || claim_availability === 'ok'
+    ? null
+    : claim_disabled_reason_by_availability[claim_availability]
 
 import { query_string } from '@helpers/string';
 const ORDER_ITEM_PARTIAL_URL = translatePath(`/partials/order_item_component?${query_string({
@@ -141,5 +156,6 @@ import ShowAlert from '@components/blocks/ShowAlert.astro'
         order_breakdown={fetch_breakdown ? order_breakdown : undefined}
         location_name={order?.location.location_name}
         primary_character_id={fetch_breakdown ? primary_character_id : undefined}
+        claim_disabled_reason={fetch_breakdown ? claim_disabled_reason : undefined}
     />
 }


### PR DESCRIPTION
## Summary
- Expanding contractor cards no longer fails the whole breakdown when `GET /api/eveonline/characters/primary` returns 401 (or auth is missing).
- Claim stays available as a disabled button with a clear hover explaining login / session / main-pilot requirements; assignments remain visible.

## Test plan
- [ ] Open industry orders while logged out: expand a contractor card — breakdown loads; Claim is disabled with “Log in…” hover
- [ ] Log in with an expired/invalid session cookie (or otherwise force primary 401): expand card — breakdown loads; Claim disabled with session-expired hover
- [ ] Logged in with a main pilot: Claim works as before
- [ ] Logged in without a main pilot: Claim disabled with main-pilot hover

Made with [Cursor](https://cursor.com)