### PR TITLE
Require fleet boss for start and quick-start

### DIFF
--- a/backend/fleets/endpoints/active/post_start_fleet_now.py
+++ b/backend/fleets/endpoints/active/post_start_fleet_now.py
@@ -24,7 +24,11 @@ ROUTE_SPEC = {
         403: ErrorResponse,
         400: ErrorResponse,
     },
-    "description": "Create a fleet with defaults, link to your current in-game fleet, and activate (no Discord). Must be in a fleet and have fleets.add_evefleet.",
+    "description": (
+        "Create a fleet with defaults, link to your current in-game fleet, "
+        "and activate (no Discord). Must be the fleet commander (boss) of "
+        "your in-game fleet and have fleets.create / fleets.add_evefleet."
+    ),
 }
 
 
@@ -68,6 +72,10 @@ def start_fleet_now(request, payload: Optional[StartFleetNowRequest] = None):
         fleet.delete()
         if "not in a fleet" in str(e):
             return 400, {"detail": "Not currently in a fleet"}
+        if "not the fleet commander" in str(e):
+            return 400, {
+                "detail": ("Must be the fleet commander of your in-game fleet")
+            }
         logger.exception(
             "Quick start fleet failed for user %s", request.user.username
         )

--- a/backend/fleets/endpoints/fleet/post_fleet_tracking.py
+++ b/backend/fleets/endpoints/fleet/post_fleet_tracking.py
@@ -38,6 +38,10 @@ def start_fleet(
     except Exception as e:
         if "not in a fleet" in str(e):
             return 400, ErrorResponse.log("Not currently in a fleet", e)
+        if "not the fleet commander" in str(e):
+            return 400, ErrorResponse.log(
+                "Must be the fleet commander of your in-game fleet", e
+            )
         else:
             return 400, ErrorResponse.log(
                 f"Error starting fleet {fleet.id}", e

--- a/backend/fleets/models.py
+++ b/backend/fleets/models.py
@@ -129,6 +129,14 @@ class EveFleet(models.Model):
 
         response = esi_response.data
 
+        # Only the in-game fleet boss (fleet commander) may link/start tracking.
+        # Otherwise a member can "steal" an existing EveFleetInstance.
+        if response.get("fleet_boss_id") != eve_character.character_id:
+            raise RuntimeError(
+                f"Character {eve_character.character_name} is not the fleet "
+                f"commander (starting fleet {self.id})"
+            )
+
         if EveFleetInstance.objects.filter(id=response["fleet_id"]).exists():
             fleet_instance = EveFleetInstance.objects.get(
                 id=response["fleet_id"]

--- a/backend/fleets/tests.py
+++ b/backend/fleets/tests.py
@@ -56,6 +56,10 @@ def disconnect_fleet_signals():
         sender=EveFleet,
         dispatch_uid="update_fleet_schedule_on_save",
     )
+    signals.post_delete.disconnect(
+        update_fleet_schedule_on_delete,
+        sender=EveFleet,
+    )
     signals.post_save.disconnect(
         sender=EveCharacter,
         dispatch_uid="populate_eve_character_public_data",
@@ -625,6 +629,121 @@ class FleetRouterTestCase(TestCase):
         self.assertEqual(400, response.status_code)
         error = response.json()
         self.assertEqual("Not currently in a fleet", error["detail"])
+
+    @patch("fleets.models.EsiClient")
+    @patch("fleets.models.discord")
+    def test_start_fleet_rejects_non_commander(self, discord_mock, esi_mock):
+        char_id = setup_fc(self.user)
+        fleet = make_test_fleet("Test", self.user)
+        fleet.disable_motd = True
+        fleet.save()
+
+        owner = User.objects.create(username="real_fc")
+        owner_fleet = make_test_fleet("Owner fleet", owner)
+        existing = EveFleetInstance.objects.create(
+            id=987654,
+            eve_fleet=owner_fleet,
+            boss_id=9999,
+        )
+
+        esi_mock_instance = esi_mock.return_value
+        esi_mock_instance.get_active_fleet.return_value = EsiResponse(
+            response_code=200,
+            data={
+                "fleet_id": existing.id,
+                "fleet_boss_id": 9999,
+                "role": "squad_member",
+            },
+        )
+
+        response = self.client.post(
+            f"{BASE_URL}/{fleet.id}/tracking",
+            data=None,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(
+            "Must be the fleet commander of your in-game fleet",
+            response.json()["detail"],
+        )
+
+        existing.refresh_from_db()
+        self.assertEqual(owner_fleet.id, existing.eve_fleet_id)
+        self.assertEqual(9999, existing.boss_id)
+        self.assertNotEqual(char_id, existing.boss_id)
+
+    @patch("fleets.models.EsiClient")
+    @patch("fleets.models.discord")
+    def test_start_fleet_now_as_commander(self, discord_mock, esi_mock):
+        char_id = setup_fc(self.user)
+
+        esi_mock_instance = esi_mock.return_value
+        esi_mock_instance.get_active_fleet.return_value = EsiResponse(
+            response_code=200,
+            data={
+                "fleet_id": 555666,
+                "fleet_boss_id": char_id,
+                "role": "fleet_commander",
+            },
+        )
+        esi_mock_instance.update_fleet_details.return_value = EsiResponse(
+            response_code=204, data={}
+        )
+
+        response = self.client.post(
+            f"{BASE_URL}/start-now",
+            {},
+            "application/json",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        self.assertEqual(200, response.status_code)
+        fleet_id = response.json()["id"]
+        instance = EveFleetInstance.objects.get(id=555666)
+        self.assertEqual(fleet_id, instance.eve_fleet_id)
+        self.assertEqual(char_id, instance.boss_id)
+
+    @patch("fleets.models.EsiClient")
+    @patch("fleets.models.discord")
+    def test_start_fleet_now_rejects_non_commander(
+        self, discord_mock, esi_mock
+    ):
+        setup_fc(self.user)
+
+        owner = User.objects.create(username="real_fc")
+        owner_fleet = make_test_fleet("Owner fleet", owner)
+        existing = EveFleetInstance.objects.create(
+            id=555666,
+            eve_fleet=owner_fleet,
+            boss_id=9999,
+        )
+
+        esi_mock_instance = esi_mock.return_value
+        esi_mock_instance.get_active_fleet.return_value = EsiResponse(
+            response_code=200,
+            data={
+                "fleet_id": existing.id,
+                "fleet_boss_id": 9999,
+                "role": "squad_member",
+            },
+        )
+
+        fleets_before = EveFleet.objects.count()
+        response = self.client.post(
+            f"{BASE_URL}/start-now",
+            {},
+            "application/json",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(
+            "Must be the fleet commander of your in-game fleet",
+            response.json()["detail"],
+        )
+        self.assertEqual(fleets_before, EveFleet.objects.count())
+
+        existing.refresh_from_db()
+        self.assertEqual(owner_fleet.id, existing.eve_fleet_id)
 
     @patch("fleets.models.EsiClient")
     @patch("fleets.models.discord")


### PR DESCRIPTION
## Summary
- Block fleet start / quick-start unless the selected character is the in-game fleet boss, so members can’t reassign and steal an existing `EveFleetInstance`.
- Surface a clear 400 (`Must be the fleet commander of your in-game fleet`) on both `/start-now` and `/{id}/tracking`.
- Add regression tests for commander success, non-commander rejection, and no instance reassignment.

## Test plan
- [ ] As fleet boss, quick-start still works and links the ESI fleet
- [ ] As a squad member in someone else’s fleet, quick-start returns 400 and does not move their `EveFleetInstance`
- [ ] Same checks for starting tracking on an existing fleet card
- [ ] `pipenv run python manage.py test fleets.tests.FleetRouterTestCase --settings=app.settings_test`


Made with [Cursor](https://cursor.com)