### PR TITLE
Add industry LP stockpile accounts and priced ledger

### DIFF
--- a/backend/industry/admin.py
+++ b/backend/industry/admin.py
@@ -18,9 +18,18 @@ from industry.forms import (
 )
 from industry.helpers.admin_permissions import industry_orders_index_link_perms
 from industry.helpers.type_breakdown import get_breakdown_for_industry_product
+from industry.helpers.lp_ledger import (
+    LpLedgerError,
+    account_balance,
+    post_ledger_entry,
+    resolve_offer_isk_per_lp,
+    weighted_average_cost_isk_per_lp,
+)
 from industry.models import (
     IndustryLoyaltyPoint,
+    IndustryLoyaltyPointAccount,
     IndustryLoyaltyPointContact,
+    IndustryLoyaltyPointLedgerEntry,
     IndustryLpStoreOffer,
     IndustryOrder,
     IndustryOrderItem,
@@ -46,6 +55,27 @@ class IndustryLoyaltyPointContactInline(admin.TabularInline):
     )
 
 
+class IndustryLoyaltyPointLedgerEntryInline(admin.TabularInline):
+    model = IndustryLoyaltyPointLedgerEntry
+    extra = 1
+    fields = (
+        "amount",
+        "isk_per_lp",
+        "notes",
+        "balance_after",
+        "created_by",
+        "created_at",
+    )
+    readonly_fields = ("balance_after", "created_by", "created_at")
+    ordering = ("-created_at", "-id")
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
 @admin.register(IndustryLoyaltyPoint)
 class IndustryLoyaltyPointAdmin(admin.ModelAdmin):
     list_display = (
@@ -53,32 +83,128 @@ class IndustryLoyaltyPointAdmin(admin.ModelAdmin):
         "corporation_id",
         "default_isk_per_lp",
         "is_active",
-        "contact_count",
+        "account_count",
     )
     list_filter = ("is_active",)
     search_fields = ("name", "corporation_id")
-    inlines = (IndustryLoyaltyPointContactInline,)
 
-    @admin.display(description="contacts")
-    def contact_count(self, obj):
-        return obj.contacts.count()
+    @admin.display(description="accounts")
+    def account_count(self, obj):
+        return obj.accounts.count()
+
+
+@admin.register(IndustryLoyaltyPointAccount)
+class IndustryLoyaltyPointAccountAdmin(admin.ModelAdmin):
+    list_display = (
+        "name",
+        "loyalty_point",
+        "role",
+        "balance_display",
+        "offer_isk_per_lp_display",
+        "avg_cost_display",
+        "is_active",
+    )
+    list_filter = ("role", "is_active", "loyalty_point")
+    search_fields = (
+        "name",
+        "corporation_name",
+        "loyalty_point__name",
+        "contacts__character_name",
+        "contacts__discord_username",
+    )
+    raw_id_fields = ("loyalty_point", "eve_character", "user")
+    inlines = (
+        IndustryLoyaltyPointContactInline,
+        IndustryLoyaltyPointLedgerEntryInline,
+    )
+
+    @admin.display(description="balance")
+    def balance_display(self, obj):
+        return account_balance(obj)
+
+    @admin.display(description="offer ISK/LP")
+    def offer_isk_per_lp_display(self, obj):
+        return resolve_offer_isk_per_lp(obj)
+
+    @admin.display(description="avg cost")
+    def avg_cost_display(self, obj):
+        avg = weighted_average_cost_isk_per_lp(obj)
+        if avg is None:
+            return "—"
+        return f"{avg:.1f}"
+
+    def save_formset(self, request, form, formset, change):
+        if formset.model is not IndustryLoyaltyPointLedgerEntry:
+            super().save_formset(request, form, formset, change)
+            return
+        instances = formset.save(commit=False)
+        for obj in formset.deleted_objects:
+            obj.delete()
+        account = form.instance
+        for obj in instances:
+            if obj.pk:
+                continue
+            if obj.amount is None or obj.isk_per_lp is None:
+                continue
+            try:
+                post_ledger_entry(
+                    account,
+                    obj.amount,
+                    obj.isk_per_lp,
+                    notes=obj.notes or "",
+                    user=request.user,
+                )
+            except LpLedgerError as exc:
+                messages.error(request, str(exc))
+        formset.save_m2m()
 
 
 @admin.register(IndustryLoyaltyPointContact)
 class IndustryLoyaltyPointContactAdmin(admin.ModelAdmin):
     list_display = (
         "character_name",
-        "loyalty_point",
+        "account",
         "discord_username",
         "is_active",
     )
-    list_filter = ("is_active", "loyalty_point")
+    list_filter = ("is_active", "account__loyalty_point", "account__role")
     search_fields = (
         "character_name",
         "discord_username",
-        "loyalty_point__name",
+        "account__name",
+        "account__loyalty_point__name",
     )
-    raw_id_fields = ("loyalty_point", "eve_character", "user")
+    raw_id_fields = ("account", "eve_character", "user")
+
+
+@admin.register(IndustryLoyaltyPointLedgerEntry)
+class IndustryLoyaltyPointLedgerEntryAdmin(admin.ModelAdmin):
+    list_display = (
+        "account",
+        "amount",
+        "isk_per_lp",
+        "balance_after",
+        "created_by",
+        "created_at",
+    )
+    list_filter = ("account__loyalty_point", "account__role")
+    search_fields = ("account__name", "notes")
+    raw_id_fields = ("account", "created_by")
+    readonly_fields = (
+        "account",
+        "amount",
+        "isk_per_lp",
+        "notes",
+        "balance_after",
+        "created_by",
+        "created_at",
+    )
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
 
 
 @admin.register(IndustryLpStoreOffer)

--- a/backend/industry/admin.py
+++ b/backend/industry/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 from django.contrib import messages
+from django import forms
+from django.db.models import Q, Sum
 from django.http import HttpResponseRedirect
 from django.urls import path, reverse
 from django.utils import timezone
@@ -13,15 +15,16 @@ from industry.admin_views import (
     industry_orders_home_view,
 )
 from industry.forms import (
+    IndustryLoyaltyPointAccountAdminForm,
+    IndustryLoyaltyPointLedgerEntryAdminForm,
     IndustryOrderAdminForm,
     MiningUpgradeCompletionAdminForm,
 )
 from industry.helpers.admin_permissions import industry_orders_index_link_perms
 from industry.helpers.type_breakdown import get_breakdown_for_industry_product
 from industry.helpers.lp_ledger import (
-    LpLedgerError,
     account_balance,
-    post_ledger_entry,
+    remaining_lots,
     resolve_offer_isk_per_lp,
     weighted_average_cost_isk_per_lp,
 )
@@ -40,10 +43,35 @@ from industry.models import (
 from tribes.models import TribeGroup
 
 
+class IndustryLoyaltyPointAccountInline(admin.TabularInline):
+    """Edit seller/stockpile holders directly from a loyalty currency."""
+
+    model = IndustryLoyaltyPointAccount
+    extra = 0
+    show_change_link = True
+    fields = (
+        "name",
+        "role",
+        "isk_per_lp",
+        "corporation_name",
+        "is_active",
+        "balance_display",
+    )
+    readonly_fields = ("balance_display",)
+    autocomplete_fields = ("eve_character", "user")
+
+    @admin.display(description="balance")
+    def balance_display(self, obj):
+        if not obj.pk:
+            return "—"
+        return f"{account_balance(obj):,}"
+
+
 class IndustryLoyaltyPointContactInline(admin.TabularInline):
     model = IndustryLoyaltyPointContact
-    extra = 0
-    raw_id_fields = ("eve_character", "user")
+    extra = 1
+    show_change_link = True
+    autocomplete_fields = ("eve_character", "user")
     fields = (
         "character_name",
         "eve_character",
@@ -55,25 +83,59 @@ class IndustryLoyaltyPointContactInline(admin.TabularInline):
     )
 
 
-class IndustryLoyaltyPointLedgerEntryInline(admin.TabularInline):
+class IndustryLoyaltyPointLedgerHistoryInline(admin.TabularInline):
+    """Read-only lot history. New rows are posted via the account form."""
+
     model = IndustryLoyaltyPointLedgerEntry
-    extra = 1
+    extra = 0
+    can_delete = False
+    show_change_link = True
     fields = (
-        "amount",
-        "isk_per_lp",
-        "notes",
-        "balance_after",
-        "created_by",
         "created_at",
+        "amount_display",
+        "isk_per_lp",
+        "balance_after",
+        "notes",
+        "created_by",
     )
-    readonly_fields = ("balance_after", "created_by", "created_at")
+    readonly_fields = fields
     ordering = ("-created_at", "-id")
+
+    @admin.display(description="amount")
+    def amount_display(self, obj):
+        if obj.amount is None:
+            return "—"
+        sign = "+" if obj.amount > 0 else ""
+        return f"{sign}{obj.amount:,}"
+
+    def has_add_permission(self, request, obj=None):
+        return False
 
     def has_change_permission(self, request, obj=None):
         return False
 
-    def has_delete_permission(self, request, obj=None):
-        return False
+
+class PositiveLpBalanceFilter(admin.SimpleListFilter):
+    title = "balance"
+    parameter_name = "has_balance"
+
+    def lookups(self, request, model_admin):
+        return (
+            ("positive", "Positive balance"),
+            ("zero", "Zero balance"),
+        )
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value == "positive":
+            return queryset.annotate(
+                _bal=Sum("ledger_entries__amount")
+            ).filter(_bal__gt=0)
+        if value == "zero":
+            return queryset.annotate(
+                _bal=Sum("ledger_entries__amount")
+            ).filter(Q(_bal__isnull=True) | Q(_bal=0))
+        return queryset
 
 
 @admin.register(IndustryLoyaltyPoint)
@@ -84,17 +146,56 @@ class IndustryLoyaltyPointAdmin(admin.ModelAdmin):
         "default_isk_per_lp",
         "is_active",
         "account_count",
+        "accounts_link",
     )
+    list_editable = ("default_isk_per_lp", "is_active")
     list_filter = ("is_active",)
     search_fields = ("name", "corporation_id")
+    inlines = (IndustryLoyaltyPointAccountInline,)
+    fieldsets = (
+        (
+            None,
+            {
+                "fields": (
+                    "name",
+                    "corporation_id",
+                    "default_isk_per_lp",
+                    "is_active",
+                    "notes",
+                ),
+                "description": (
+                    "Currency catalog for militia / navy LP. Default ISK/LP is "
+                    "used by the planner and as the offer fallback for accounts."
+                ),
+            },
+        ),
+        (
+            "Timestamps",
+            {
+                "classes": ("collapse",),
+                "fields": ("created_at", "updated_at"),
+            },
+        ),
+    )
+    readonly_fields = ("created_at", "updated_at")
 
     @admin.display(description="accounts")
     def account_count(self, obj):
         return obj.accounts.count()
 
+    @admin.display(description="open accounts")
+    def accounts_link(self, obj):
+        url = reverse("admin:industry_industryloyaltypointaccount_changelist")
+        return format_html(
+            '<a href="{}?loyalty_point__id__exact={}">View accounts</a>',
+            url,
+            obj.pk,
+        )
+
 
 @admin.register(IndustryLoyaltyPointAccount)
 class IndustryLoyaltyPointAccountAdmin(admin.ModelAdmin):
+    form = IndustryLoyaltyPointAccountAdminForm
     list_display = (
         "name",
         "loyalty_point",
@@ -102,9 +203,16 @@ class IndustryLoyaltyPointAccountAdmin(admin.ModelAdmin):
         "balance_display",
         "offer_isk_per_lp_display",
         "avg_cost_display",
+        "contact_summary",
         "is_active",
     )
-    list_filter = ("role", "is_active", "loyalty_point")
+    list_filter = (
+        "role",
+        "is_active",
+        "loyalty_point",
+        PositiveLpBalanceFilter,
+    )
+    list_editable = ("role", "is_active")
     search_fields = (
         "name",
         "corporation_name",
@@ -112,51 +220,160 @@ class IndustryLoyaltyPointAccountAdmin(admin.ModelAdmin):
         "contacts__character_name",
         "contacts__discord_username",
     )
-    raw_id_fields = ("loyalty_point", "eve_character", "user")
+    autocomplete_fields = ("loyalty_point", "eve_character", "user")
     inlines = (
         IndustryLoyaltyPointContactInline,
-        IndustryLoyaltyPointLedgerEntryInline,
+        IndustryLoyaltyPointLedgerHistoryInline,
     )
+    fieldsets = (
+        (
+            None,
+            {
+                "fields": (
+                    "loyalty_point",
+                    "name",
+                    "role",
+                    "corporation_name",
+                    "eve_character",
+                    "user",
+                    "is_active",
+                    "notes",
+                ),
+            },
+        ),
+        (
+            "Pricing",
+            {
+                "fields": ("isk_per_lp",),
+                "description": (
+                    "Current offer ISK/LP for industrialists (or known seller ask). "
+                    "Lot history can still mix 825 / 850 / etc. on the ledger."
+                ),
+            },
+        ),
+        (
+            "Balance",
+            {
+                "fields": (
+                    "balance_display",
+                    "offer_isk_per_lp_display",
+                    "avg_cost_display",
+                    "lots_display",
+                ),
+            },
+        ),
+        (
+            "Post ledger entry",
+            {
+                "fields": (
+                    "ledger_direction",
+                    "ledger_quantity",
+                    "ledger_isk_per_lp",
+                    "ledger_notes",
+                ),
+                "description": (
+                    "Leave quantity blank to only update the account. "
+                    "To post: choose credit/debit, enter LP quantity and ISK/LP "
+                    "for that lot, then Save."
+                ),
+            },
+        ),
+        (
+            "Timestamps",
+            {
+                "classes": ("collapse",),
+                "fields": ("created_at", "updated_at"),
+            },
+        ),
+    )
+    readonly_fields = (
+        "balance_display",
+        "offer_isk_per_lp_display",
+        "avg_cost_display",
+        "lots_display",
+        "created_at",
+        "updated_at",
+    )
+
+    def get_fieldsets(self, request, obj=None):
+        fieldsets = list(super().get_fieldsets(request, obj))
+        if obj is None:
+            # Balance + ledger post only make sense after the account exists.
+            return [
+                fs
+                for fs in fieldsets
+                if fs[0] not in ("Balance", "Post ledger entry")
+            ]
+        return fieldsets
+
+    def get_inlines(self, request, obj):
+        if obj is None:
+            return (IndustryLoyaltyPointContactInline,)
+        return self.inlines
 
     @admin.display(description="balance")
     def balance_display(self, obj):
-        return account_balance(obj)
+        if not obj or not obj.pk:
+            return "—"
+        return f"{account_balance(obj):,}"
 
     @admin.display(description="offer ISK/LP")
     def offer_isk_per_lp_display(self, obj):
+        if not obj or not obj.pk:
+            return "—"
         return resolve_offer_isk_per_lp(obj)
 
     @admin.display(description="avg cost")
     def avg_cost_display(self, obj):
+        if not obj or not obj.pk:
+            return "—"
         avg = weighted_average_cost_isk_per_lp(obj)
         if avg is None:
             return "—"
         return f"{avg:.1f}"
 
-    def save_formset(self, request, form, formset, change):
-        if formset.model is not IndustryLoyaltyPointLedgerEntry:
-            super().save_formset(request, form, formset, change)
+    @admin.display(description="remaining lots")
+    def lots_display(self, obj):
+        if not obj or not obj.pk:
+            return "—"
+        lots = remaining_lots(obj)
+        if not lots:
+            return "—"
+        return mark_safe(
+            "<br>".join(
+                f"{lot.quantity:,} LP @ {lot.isk_per_lp} ISK/LP"
+                for lot in lots
+            )
+        )
+
+    @admin.display(description="contacts")
+    def contact_summary(self, obj):
+        names = list(
+            obj.contacts.filter(is_active=True).values_list(
+                "character_name", flat=True
+            )[:3]
+        )
+        if not names:
+            return "—"
+        suffix = "…" if obj.contacts.filter(is_active=True).count() > 3 else ""
+        return ", ".join(names) + suffix
+
+    def save_model(self, request, obj, form, change):
+        super().save_model(request, obj, form, change)
+        if not isinstance(form, IndustryLoyaltyPointAccountAdminForm):
             return
-        instances = formset.save(commit=False)
-        for obj in formset.deleted_objects:
-            obj.delete()
-        account = form.instance
-        for obj in instances:
-            if obj.pk:
-                continue
-            if obj.amount is None or obj.isk_per_lp is None:
-                continue
-            try:
-                post_ledger_entry(
-                    account,
-                    obj.amount,
-                    obj.isk_per_lp,
-                    notes=obj.notes or "",
-                    user=request.user,
-                )
-            except LpLedgerError as exc:
-                messages.error(request, str(exc))
-        formset.save_m2m()
+        try:
+            entry = form.post_ledger_if_requested(user=request.user)
+        except forms.ValidationError as exc:
+            messages.error(request, "; ".join(exc.messages))
+            return
+        if entry is not None:
+            sign = "+" if entry.amount > 0 else ""
+            messages.success(
+                request,
+                f"Posted ledger entry: {sign}{entry.amount:,} LP "
+                f"@ {entry.isk_per_lp} ISK/LP (balance {entry.balance_after:,}).",
+            )
 
 
 @admin.register(IndustryLoyaltyPointContact)
@@ -164,9 +381,12 @@ class IndustryLoyaltyPointContactAdmin(admin.ModelAdmin):
     list_display = (
         "character_name",
         "account",
+        "account_role",
+        "loyalty_point_name",
         "discord_username",
         "is_active",
     )
+    list_editable = ("is_active",)
     list_filter = ("is_active", "account__loyalty_point", "account__role")
     search_fields = (
         "character_name",
@@ -174,37 +394,116 @@ class IndustryLoyaltyPointContactAdmin(admin.ModelAdmin):
         "account__name",
         "account__loyalty_point__name",
     )
-    raw_id_fields = ("account", "eve_character", "user")
+    autocomplete_fields = ("account", "eve_character", "user")
+
+    @admin.display(description="role", ordering="account__role")
+    def account_role(self, obj):
+        return obj.account.get_role_display()
+
+    @admin.display(
+        description="loyalty point", ordering="account__loyalty_point__name"
+    )
+    def loyalty_point_name(self, obj):
+        return obj.account.loyalty_point.name
 
 
 @admin.register(IndustryLoyaltyPointLedgerEntry)
 class IndustryLoyaltyPointLedgerEntryAdmin(admin.ModelAdmin):
+    form = IndustryLoyaltyPointLedgerEntryAdminForm
     list_display = (
+        "created_at",
         "account",
-        "amount",
+        "amount_display",
         "isk_per_lp",
         "balance_after",
+        "notes_short",
         "created_by",
-        "created_at",
     )
-    list_filter = ("account__loyalty_point", "account__role")
+    list_filter = ("account__loyalty_point", "account__role", "account")
     search_fields = ("account__name", "notes")
-    raw_id_fields = ("account", "created_by")
-    readonly_fields = (
-        "account",
-        "amount",
-        "isk_per_lp",
-        "notes",
-        "balance_after",
-        "created_by",
-        "created_at",
-    )
+    autocomplete_fields = ("account",)
+    date_hierarchy = "created_at"
+    ordering = ("-created_at", "-id")
 
-    def has_add_permission(self, request):
+    def get_readonly_fields(self, request, obj=None):
+        if obj:
+            return (
+                "account",
+                "amount_display",
+                "isk_per_lp",
+                "balance_after",
+                "created_by",
+                "created_at",
+            )
+        return ("balance_after", "created_by", "created_at", "amount_display")
+
+    def get_fieldsets(self, request, obj=None):
+        if obj:
+            return (
+                (
+                    None,
+                    {
+                        "fields": (
+                            "account",
+                            "amount_display",
+                            "isk_per_lp",
+                            "balance_after",
+                            "notes",
+                            "created_by",
+                            "created_at",
+                        ),
+                        "description": (
+                            "Amount and ISK/LP are immutable. Edit notes if needed, "
+                            "or post a reversing entry from the account page."
+                        ),
+                    },
+                ),
+            )
+        return (
+            (
+                None,
+                {
+                    "fields": (
+                        "account",
+                        "direction",
+                        "quantity",
+                        "isk_per_lp",
+                        "notes",
+                    ),
+                    "description": (
+                        "Post a credit (LP in) or debit (LP out) against an account. "
+                        "Use a distinct ISK/LP per lot when prices differ."
+                    ),
+                },
+            ),
+        )
+
+    def get_form(self, request, obj=None, change=False, **kwargs):
+        form = super().get_form(request, obj, change=change, **kwargs)
+
+        class RequestLedgerForm(form):
+            def __init__(self, *args, **inner_kwargs):
+                super().__init__(*args, **inner_kwargs)
+                self._request_user = request.user
+
+        return RequestLedgerForm
+
+    def has_delete_permission(self, request, obj=None):
         return False
 
-    def has_change_permission(self, request, obj=None):
-        return False
+    @admin.display(description="amount", ordering="amount")
+    def amount_display(self, obj):
+        if not obj or obj.amount is None:
+            return "—"
+        sign = "+" if obj.amount > 0 else ""
+        return f"{sign}{obj.amount:,}"
+
+    @admin.display(description="notes")
+    def notes_short(self, obj):
+        notes = (obj.notes or "").strip()
+        if len(notes) <= 48:
+            return notes or "—"
+        return notes[:45] + "…"
 
 
 @admin.register(IndustryLpStoreOffer)

--- a/backend/industry/forms.py
+++ b/backend/industry/forms.py
@@ -3,12 +3,22 @@
 from django import forms
 from django.utils import timezone
 
+from industry.helpers.lp_ledger import (
+    LpLedgerError,
+    account_balance,
+    post_ledger_entry,
+)
 from industry.helpers.public_short_code import (
     is_valid_public_short_code,
     pick_unique_public_short_code_among_actives,
     public_short_code_taken_by_active,
 )
-from industry.models import IndustryOrder, MiningUpgradeCompletion
+from industry.models import (
+    IndustryLoyaltyPointAccount,
+    IndustryLoyaltyPointLedgerEntry,
+    IndustryOrder,
+    MiningUpgradeCompletion,
+)
 from sovereignty.anomalies import get_all_mining_anomaly_names
 
 
@@ -87,3 +97,167 @@ class IndustryOrderAdminForm(forms.ModelForm):
         ):
             return raw
         return pick_unique_public_short_code_among_actives()
+
+
+class IndustryLoyaltyPointAccountAdminForm(forms.ModelForm):
+    """
+    Account edit form with an explicit credit/debit poster.
+
+    Leave the ledger fields blank to save account/contact changes only.
+    """
+
+    class Meta:
+        model = IndustryLoyaltyPointAccount
+        fields = "__all__"
+
+    LEDGER_CREDIT = "credit"
+    LEDGER_DEBIT = "debit"
+    LEDGER_DIRECTION_CHOICES = (
+        (LEDGER_CREDIT, "Credit (LP in)"),
+        (LEDGER_DEBIT, "Debit (LP out)"),
+    )
+
+    ledger_direction = forms.ChoiceField(
+        choices=LEDGER_DIRECTION_CHOICES,
+        required=False,
+        initial=LEDGER_CREDIT,
+        label="Direction",
+        help_text="Optional. Fill quantity below to post one credit or debit on save.",
+    )
+    ledger_quantity = forms.IntegerField(
+        required=False,
+        min_value=1,
+        label="LP quantity",
+        help_text="Positive LP amount to credit or debit. Leave blank to skip.",
+    )
+    ledger_isk_per_lp = forms.IntegerField(
+        required=False,
+        min_value=1,
+        label="ISK per LP (this lot)",
+        help_text=(
+            "Price for this intake/draw only (e.g. 825 or 850). "
+            "Defaults to the account offer or currency default when blank."
+        ),
+    )
+    ledger_notes = forms.CharField(
+        required=False,
+        widget=forms.Textarea(attrs={"rows": 2}),
+        label="Ledger notes",
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        offer = None
+        inst = self.instance
+        if inst and inst.pk:
+            if inst.isk_per_lp:
+                offer = inst.isk_per_lp
+            elif inst.loyalty_point_id:
+                offer = inst.loyalty_point.default_isk_per_lp
+        if offer:
+            self.fields["ledger_isk_per_lp"].initial = offer
+
+    def clean(self):
+        cleaned = super().clean()
+        quantity = cleaned.get("ledger_quantity")
+        direction = cleaned.get("ledger_direction") or self.LEDGER_CREDIT
+        isk_per_lp = cleaned.get("ledger_isk_per_lp")
+        if quantity is None:
+            return cleaned
+        if not direction:
+            self.add_error(
+                "ledger_direction",
+                "Choose credit or debit when posting a quantity.",
+            )
+        if isk_per_lp is None:
+            inst = self.instance
+            if inst and inst.isk_per_lp:
+                isk_per_lp = inst.isk_per_lp
+            elif inst and inst.loyalty_point_id:
+                isk_per_lp = inst.loyalty_point.default_isk_per_lp
+            cleaned["ledger_isk_per_lp"] = isk_per_lp
+        if cleaned.get("ledger_isk_per_lp") is None:
+            self.add_error(
+                "ledger_isk_per_lp",
+                "Enter ISK/LP for this lot (or set an account/currency default).",
+            )
+        if (
+            direction == self.LEDGER_DEBIT
+            and self.instance
+            and self.instance.pk
+            and not self.errors
+        ):
+            balance = account_balance(self.instance)
+            if quantity > balance:
+                self.add_error(
+                    "ledger_quantity",
+                    f"Insufficient LP balance: have {balance:,}, debit {quantity:,}.",
+                )
+        return cleaned
+
+    def post_ledger_if_requested(self, *, user=None):
+        """Post the optional ledger row after the account is saved. Returns entry or None."""
+        quantity = self.cleaned_data.get("ledger_quantity")
+        if quantity is None:
+            return None
+        direction = (
+            self.cleaned_data.get("ledger_direction") or self.LEDGER_CREDIT
+        )
+        amount = int(quantity)
+        if direction == self.LEDGER_DEBIT:
+            amount = -amount
+        try:
+            return post_ledger_entry(
+                self.instance,
+                amount,
+                int(self.cleaned_data["ledger_isk_per_lp"]),
+                notes=self.cleaned_data.get("ledger_notes") or "",
+                user=user,
+            )
+        except LpLedgerError as exc:
+            raise forms.ValidationError(str(exc)) from exc
+
+
+class IndustryLoyaltyPointLedgerEntryAdminForm(forms.ModelForm):
+    """Add ledger rows via the standalone ledger admin using credit/debit fields."""
+
+    class Meta:
+        model = IndustryLoyaltyPointLedgerEntry
+        fields = ("account", "notes")
+
+    direction = forms.ChoiceField(
+        choices=IndustryLoyaltyPointAccountAdminForm.LEDGER_DIRECTION_CHOICES,
+        initial=IndustryLoyaltyPointAccountAdminForm.LEDGER_CREDIT,
+        label="Direction",
+    )
+    quantity = forms.IntegerField(min_value=1, label="LP quantity")
+    isk_per_lp = forms.IntegerField(min_value=1, label="ISK per LP")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance and self.instance.pk:
+            for name in ("direction", "quantity", "isk_per_lp"):
+                self.fields[name].disabled = True
+                self.fields[name].required = False
+
+    def save(self, commit=True):
+        existing = self.instance
+        if existing.pk:
+            existing.notes = self.cleaned_data.get("notes") or ""
+            if commit:
+                existing.save(update_fields=["notes"])
+            return existing
+        direction = self.cleaned_data["direction"]
+        quantity = int(self.cleaned_data["quantity"])
+        amount = (
+            -quantity
+            if direction == IndustryLoyaltyPointAccountAdminForm.LEDGER_DEBIT
+            else quantity
+        )
+        return post_ledger_entry(
+            self.cleaned_data["account"],
+            amount,
+            int(self.cleaned_data["isk_per_lp"]),
+            notes=self.cleaned_data.get("notes") or "",
+            user=getattr(self, "_request_user", None),
+        )

--- a/backend/industry/helpers/lp_ledger.py
+++ b/backend/industry/helpers/lp_ledger.py
@@ -1,0 +1,132 @@
+"""Credit/debit helpers for industry LP accounts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from django.db import transaction
+from django.db.models import Sum
+
+from industry.models import (
+    IndustryLoyaltyPointAccount,
+    IndustryLoyaltyPointLedgerEntry,
+)
+
+
+class LpLedgerError(ValueError):
+    """Invalid LP ledger post."""
+
+
+def account_balance(account: IndustryLoyaltyPointAccount) -> int:
+    """Current LP balance for an account (sum of ledger amounts)."""
+    total = account.ledger_entries.aggregate(total=Sum("amount"))["total"]
+    return int(total or 0)
+
+
+def resolve_offer_isk_per_lp(account: IndustryLoyaltyPointAccount) -> int:
+    """
+    Current offer ISK/LP for a holder.
+
+    Prefers account.isk_per_lp; falls back to the currency default.
+    """
+    if account.isk_per_lp is not None and account.isk_per_lp > 0:
+        return int(account.isk_per_lp)
+    return int(account.loyalty_point.default_isk_per_lp)
+
+
+@dataclass(frozen=True)
+class RemainingLot:
+    """Remaining quantity at a single intake price after FIFO consumption."""
+
+    isk_per_lp: int
+    quantity: int
+
+
+def remaining_lots(account: IndustryLoyaltyPointAccount) -> list[RemainingLot]:
+    """
+    FIFO remaining inventory by lot price.
+
+    Walks credits then consumes them with later debits in chronological order.
+    """
+    lots: list[list[int]] = []  # [isk_per_lp, remaining_qty]
+    entries = account.ledger_entries.order_by("created_at", "id").values_list(
+        "amount", "isk_per_lp"
+    )
+    for amount, isk_per_lp in entries:
+        if amount > 0:
+            lots.append([int(isk_per_lp), int(amount)])
+            continue
+        need = -int(amount)
+        while need > 0 and lots:
+            price, qty = lots[0]
+            take = min(qty, need)
+            qty -= take
+            need -= take
+            if qty == 0:
+                lots.pop(0)
+            else:
+                lots[0][1] = qty
+        if need > 0:
+            # Should not happen if posts enforce no overdraft; ignore remainder.
+            break
+    return [
+        RemainingLot(isk_per_lp=price, quantity=qty)
+        for price, qty in lots
+        if qty > 0
+    ]
+
+
+def weighted_average_cost_isk_per_lp(
+    account: IndustryLoyaltyPointAccount,
+) -> Optional[float]:
+    """Weighted average ISK/LP of remaining FIFO lots, or None if empty."""
+    lots = remaining_lots(account)
+    if not lots:
+        return None
+    total_qty = sum(lot.quantity for lot in lots)
+    if total_qty <= 0:
+        return None
+    cost = sum(lot.quantity * lot.isk_per_lp for lot in lots)
+    return cost / total_qty
+
+
+@transaction.atomic
+def post_ledger_entry(
+    account: IndustryLoyaltyPointAccount,
+    amount: int,
+    isk_per_lp: int,
+    *,
+    notes: str = "",
+    user=None,
+) -> IndustryLoyaltyPointLedgerEntry:
+    """
+    Append a credit/debit lot and return the new entry.
+
+    ``isk_per_lp`` is required (lot price). Rejects zero amounts, non-positive
+    prices, and debits that would overdraw the account.
+    """
+    amount = int(amount)
+    isk_per_lp = int(isk_per_lp)
+    if amount == 0:
+        raise LpLedgerError("Ledger amount must be non-zero.")
+    if isk_per_lp <= 0:
+        raise LpLedgerError("isk_per_lp must be a positive integer.")
+
+    locked = IndustryLoyaltyPointAccount.objects.select_for_update().get(
+        pk=account.pk
+    )
+    balance = account_balance(locked)
+    if amount < 0 and balance + amount < 0:
+        raise LpLedgerError(
+            f"Insufficient LP balance: have {balance}, debit {-amount}."
+        )
+    balance_after = balance + amount
+    return IndustryLoyaltyPointLedgerEntry.objects.create(
+        account=locked,
+        amount=amount,
+        isk_per_lp=isk_per_lp,
+        notes=notes or "",
+        balance_after=balance_after,
+        created_by=user,
+    )

--- a/backend/industry/migrations/0029_lp_accounts_and_ledger.py
+++ b/backend/industry/migrations/0029_lp_accounts_and_ledger.py
@@ -1,0 +1,228 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+def migrate_contacts_to_accounts(apps, schema_editor):
+    IndustryLoyaltyPointAccount = apps.get_model(
+        "industry", "IndustryLoyaltyPointAccount"
+    )
+    IndustryLoyaltyPointContact = apps.get_model(
+        "industry", "IndustryLoyaltyPointContact"
+    )
+    for contact in IndustryLoyaltyPointContact.objects.all():
+        account = IndustryLoyaltyPointAccount.objects.create(
+            loyalty_point_id=contact.loyalty_point_id,
+            name=contact.character_name,
+            role="seller",
+            eve_character_id=contact.eve_character_id,
+            user_id=contact.user_id,
+            is_active=contact.is_active,
+            notes=contact.notes or "",
+        )
+        contact.account = account
+        contact.save(update_fields=["account"])
+
+
+def noop_reverse(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("eveonline", "0097_industry_job_status_blueprint_id_idx"),
+        ("industry", "0028_seed_militia_loyalty_points"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="IndustryLoyaltyPointAccount",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=128)),
+                (
+                    "role",
+                    models.CharField(
+                        choices=[
+                            ("seller", "Seller"),
+                            ("stockpile", "Stockpile"),
+                        ],
+                        db_index=True,
+                        default="seller",
+                        max_length=16,
+                    ),
+                ),
+                (
+                    "isk_per_lp",
+                    models.PositiveIntegerField(
+                        blank=True,
+                        help_text=(
+                            "Current offer ISK/LP for this holder. Falls back "
+                            "to the currency default when empty. Lot history "
+                            "uses each ledger entry's price."
+                        ),
+                        null=True,
+                    ),
+                ),
+                (
+                    "corporation_name",
+                    models.CharField(blank=True, max_length=128),
+                ),
+                ("is_active", models.BooleanField(default=True)),
+                ("notes", models.TextField(blank=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "eve_character",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="loyalty_point_accounts",
+                        to="eveonline.evecharacter",
+                    ),
+                ),
+                (
+                    "loyalty_point",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="accounts",
+                        to="industry.industryloyaltypoint",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="loyalty_point_accounts",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Industry loyalty point account",
+                "verbose_name_plural": "Industry loyalty point accounts",
+                "ordering": ["loyalty_point__name", "name"],
+            },
+        ),
+        migrations.CreateModel(
+            name="IndustryLoyaltyPointLedgerEntry",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "amount",
+                    models.BigIntegerField(
+                        help_text=(
+                            "Signed LP change: positive credit, negative debit."
+                        ),
+                    ),
+                ),
+                (
+                    "isk_per_lp",
+                    models.PositiveIntegerField(
+                        help_text=(
+                            "ISK/LP for this lot (required; e.g. 825 or 850)."
+                        ),
+                    ),
+                ),
+                ("notes", models.TextField(blank=True)),
+                (
+                    "balance_after",
+                    models.BigIntegerField(
+                        help_text=(
+                            "Account balance after this entry was posted."
+                        ),
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "account",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="ledger_entries",
+                        to="industry.industryloyaltypointaccount",
+                    ),
+                ),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="loyalty_point_ledger_entries",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Industry loyalty point ledger entry",
+                "verbose_name_plural": (
+                    "Industry loyalty point ledger entries"
+                ),
+                "ordering": ["-created_at", "-id"],
+            },
+        ),
+        migrations.AddField(
+            model_name="industryloyaltypointcontact",
+            name="account",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="contacts",
+                to="industry.industryloyaltypointaccount",
+            ),
+        ),
+        migrations.RunPython(migrate_contacts_to_accounts, noop_reverse),
+        migrations.RemoveField(
+            model_name="industryloyaltypointcontact",
+            name="loyalty_point",
+        ),
+        migrations.AlterField(
+            model_name="industryloyaltypointcontact",
+            name="account",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="contacts",
+                to="industry.industryloyaltypointaccount",
+            ),
+        ),
+        migrations.AlterModelOptions(
+            name="industryloyaltypointcontact",
+            options={
+                "ordering": [
+                    "account__loyalty_point__name",
+                    "character_name",
+                ],
+                "verbose_name": "Industry loyalty point contact",
+                "verbose_name_plural": "Industry loyalty point contacts",
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="industryloyaltypointaccount",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("is_active", True)),
+                fields=("loyalty_point", "name"),
+                name="uniq_active_lp_account_name_per_currency",
+            ),
+        ),
+    ]

--- a/backend/industry/models/__init__.py
+++ b/backend/industry/models/__init__.py
@@ -5,7 +5,9 @@
 from industry.models.cost_index import IndustrySystemCostIndex
 from industry.models.lp_store import (
     IndustryLoyaltyPoint,
+    IndustryLoyaltyPointAccount,
     IndustryLoyaltyPointContact,
+    IndustryLoyaltyPointLedgerEntry,
     IndustryLpStoreOffer,
 )
 from industry.models.mining import MiningUpgradeCompletion
@@ -21,7 +23,9 @@ from industry.models.product import (
 
 __all__ = [
     "IndustryLoyaltyPoint",
+    "IndustryLoyaltyPointAccount",
     "IndustryLoyaltyPointContact",
+    "IndustryLoyaltyPointLedgerEntry",
     "IndustryLpStoreOffer",
     "IndustryOrder",
     "IndustryOrderItem",

--- a/backend/industry/models/lp_store.py
+++ b/backend/industry/models/lp_store.py
@@ -7,8 +7,8 @@ class IndustryLoyaltyPoint(models.Model):
     """
     A loyalty-point currency we care about (e.g. Tribal Liberation Force).
 
-    Holds default ISK/LP pricing for the industry planner. Contacts who can
-    supply this LP are linked via IndustryLoyaltyPointContact.
+    Holds default ISK/LP pricing for the industry planner. Holders (sellers /
+    stockpiles) and contacts are linked via IndustryLoyaltyPointAccount.
     """
 
     name = models.CharField(max_length=128)
@@ -34,11 +34,79 @@ class IndustryLoyaltyPoint(models.Model):
         return f"{self.name} ({self.default_isk_per_lp} ISK/LP)"
 
 
-class IndustryLoyaltyPointContact(models.Model):
-    """Someone to contact for a given loyalty-point currency."""
+class IndustryLoyaltyPointAccount(models.Model):
+    """
+    A holder of one LP currency: external seller or in-alliance stockpile.
+
+    Balance is derived from ledger entries (SUM of amounts). Offer price is
+    the current ask; each ledger row carries its own lot price (825, 850, …).
+    """
+
+    class Role(models.TextChoices):
+        SELLER = "seller", "Seller"
+        STOCKPILE = "stockpile", "Stockpile"
 
     loyalty_point = models.ForeignKey(
         IndustryLoyaltyPoint,
+        on_delete=models.CASCADE,
+        related_name="accounts",
+    )
+    name = models.CharField(max_length=128)
+    role = models.CharField(
+        max_length=16,
+        choices=Role.choices,
+        default=Role.SELLER,
+        db_index=True,
+    )
+    isk_per_lp = models.PositiveIntegerField(
+        null=True,
+        blank=True,
+        help_text=(
+            "Current offer ISK/LP for this holder. Falls back to the currency "
+            "default when empty. Lot history uses each ledger entry's price."
+        ),
+    )
+    eve_character = models.ForeignKey(
+        "eveonline.EveCharacter",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="loyalty_point_accounts",
+    )
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="loyalty_point_accounts",
+    )
+    corporation_name = models.CharField(max_length=128, blank=True)
+    is_active = models.BooleanField(default=True)
+    notes = models.TextField(blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ["loyalty_point__name", "name"]
+        verbose_name = "Industry loyalty point account"
+        verbose_name_plural = "Industry loyalty point accounts"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["loyalty_point", "name"],
+                condition=models.Q(is_active=True),
+                name="uniq_active_lp_account_name_per_currency",
+            ),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.name} ({self.loyalty_point.name}, {self.role})"
+
+
+class IndustryLoyaltyPointContact(models.Model):
+    """Someone to contact for a given LP account (seller or stockpile)."""
+
+    account = models.ForeignKey(
+        IndustryLoyaltyPointAccount,
         on_delete=models.CASCADE,
         related_name="contacts",
     )
@@ -65,12 +133,57 @@ class IndustryLoyaltyPointContact(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
     class Meta:
-        ordering = ["loyalty_point__name", "character_name"]
+        ordering = ["account__loyalty_point__name", "character_name"]
         verbose_name = "Industry loyalty point contact"
         verbose_name_plural = "Industry loyalty point contacts"
 
     def __str__(self) -> str:
-        return f"{self.character_name} ({self.loyalty_point.name})"
+        return f"{self.character_name} ({self.account.name})"
+
+
+class IndustryLoyaltyPointLedgerEntry(models.Model):
+    """
+    One credit/debit lot against an LP account.
+
+    Credits are intakes at a specific ISK/LP (e.g. +200k @ 825). Debits are
+    draws. Mixed prices on the same account are expected.
+    """
+
+    account = models.ForeignKey(
+        IndustryLoyaltyPointAccount,
+        on_delete=models.CASCADE,
+        related_name="ledger_entries",
+    )
+    amount = models.BigIntegerField(
+        help_text="Signed LP change: positive credit, negative debit.",
+    )
+    isk_per_lp = models.PositiveIntegerField(
+        help_text="ISK/LP for this lot (required; e.g. 825 or 850).",
+    )
+    notes = models.TextField(blank=True)
+    balance_after = models.BigIntegerField(
+        help_text="Account balance after this entry was posted.",
+    )
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="loyalty_point_ledger_entries",
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["-created_at", "-id"]
+        verbose_name = "Industry loyalty point ledger entry"
+        verbose_name_plural = "Industry loyalty point ledger entries"
+
+    def __str__(self) -> str:
+        sign = "+" if self.amount >= 0 else ""
+        return (
+            f"{self.account.name}: {sign}{self.amount} LP "
+            f"@ {self.isk_per_lp} ISK/LP"
+        )
 
 
 class IndustryLpStoreOffer(models.Model):

--- a/backend/industry/tests/test_lp_admin.py
+++ b/backend/industry/tests/test_lp_admin.py
@@ -1,0 +1,168 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from industry.forms import IndustryLoyaltyPointAccountAdminForm
+from industry.helpers.lp_ledger import account_balance, post_ledger_entry
+from industry.models import (
+    IndustryLoyaltyPoint,
+    IndustryLoyaltyPointAccount,
+    IndustryLoyaltyPointLedgerEntry,
+)
+
+User = get_user_model()
+TLIB_CORP_ID = 1000182
+
+
+class LpAccountAdminFormTestCase(TestCase):
+    def setUp(self):
+        self.currency, _ = IndustryLoyaltyPoint.objects.update_or_create(
+            corporation_id=TLIB_CORP_ID,
+            defaults={
+                "name": "Tribal Liberation Force",
+                "default_isk_per_lp": 800,
+                "is_active": True,
+            },
+        )
+        self.account = IndustryLoyaltyPointAccount.objects.create(
+            loyalty_point=self.currency,
+            name="Alliance pot",
+            role=IndustryLoyaltyPointAccount.Role.STOCKPILE,
+            isk_per_lp=840,
+        )
+
+    def test_post_credit_via_form(self):
+        form = IndustryLoyaltyPointAccountAdminForm(
+            data={
+                "loyalty_point": self.currency.pk,
+                "name": self.account.name,
+                "role": self.account.role,
+                "isk_per_lp": 840,
+                "corporation_name": "",
+                "is_active": True,
+                "notes": "",
+                "ledger_direction": "credit",
+                "ledger_quantity": 200000,
+                "ledger_isk_per_lp": 825,
+                "ledger_notes": "order A",
+            },
+            instance=self.account,
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+        entry = form.post_ledger_if_requested()
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry.amount, 200000)
+        self.assertEqual(entry.isk_per_lp, 825)
+        self.assertEqual(account_balance(self.account), 200000)
+
+    def test_debit_overdraft_fails_clean(self):
+        post_ledger_entry(self.account, 10_000, 825)
+        form = IndustryLoyaltyPointAccountAdminForm(
+            data={
+                "loyalty_point": self.currency.pk,
+                "name": self.account.name,
+                "role": self.account.role,
+                "isk_per_lp": 840,
+                "corporation_name": "",
+                "is_active": True,
+                "notes": "",
+                "ledger_direction": "debit",
+                "ledger_quantity": 50_000,
+                "ledger_isk_per_lp": 840,
+                "ledger_notes": "",
+            },
+            instance=self.account,
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("ledger_quantity", form.errors)
+
+
+class LpAdminViewsTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_superuser(
+            username="lp_admin",
+            email="lp_admin@example.com",
+            password="test",
+        )
+        self.client.force_login(self.user)
+        self.currency, _ = IndustryLoyaltyPoint.objects.update_or_create(
+            corporation_id=TLIB_CORP_ID,
+            defaults={
+                "name": "Tribal Liberation Force",
+                "default_isk_per_lp": 800,
+                "is_active": True,
+            },
+        )
+        self.account = IndustryLoyaltyPointAccount.objects.create(
+            loyalty_point=self.currency,
+            name="Alliance pot",
+            role=IndustryLoyaltyPointAccount.Role.STOCKPILE,
+            isk_per_lp=840,
+        )
+
+    def test_loyalty_point_change_page_loads(self):
+        url = reverse(
+            "admin:industry_industryloyaltypoint_change",
+            args=[self.currency.pk],
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Alliance pot")
+        self.assertContains(response, "default_isk_per_lp")
+
+    def test_account_change_page_has_post_ledger_fields(self):
+        url = reverse(
+            "admin:industry_industryloyaltypointaccount_change",
+            args=[self.account.pk],
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Post ledger entry")
+        self.assertContains(response, "ledger_quantity")
+        self.assertContains(response, "Remaining lots")
+
+    def test_account_post_credit_from_change_view(self):
+        url = reverse(
+            "admin:industry_industryloyaltypointaccount_change",
+            args=[self.account.pk],
+        )
+        response = self.client.post(
+            url,
+            {
+                "loyalty_point": self.currency.pk,
+                "name": self.account.name,
+                "role": self.account.role,
+                "isk_per_lp": 840,
+                "corporation_name": "",
+                "is_active": "on",
+                "notes": "",
+                "ledger_direction": "credit",
+                "ledger_quantity": "100000",
+                "ledger_isk_per_lp": "850",
+                "ledger_notes": "buy order",
+                "contacts-TOTAL_FORMS": "0",
+                "contacts-INITIAL_FORMS": "0",
+                "contacts-MIN_NUM_FORMS": "0",
+                "contacts-MAX_NUM_FORMS": "1000",
+                "ledger_entries-TOTAL_FORMS": "0",
+                "ledger_entries-INITIAL_FORMS": "0",
+                "ledger_entries-MIN_NUM_FORMS": "0",
+                "ledger_entries-MAX_NUM_FORMS": "1000",
+                "_continue": "Save and continue editing",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(account_balance(self.account), 100000)
+        entry = IndustryLoyaltyPointLedgerEntry.objects.get(
+            account=self.account
+        )
+        self.assertEqual(entry.amount, 100000)
+        self.assertEqual(entry.isk_per_lp, 850)
+
+    def test_ledger_add_page_loads(self):
+        url = reverse("admin:industry_industryloyaltypointledgerentry_add")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Direction")
+        self.assertContains(response, "LP quantity")

--- a/backend/industry/tests/test_lp_ledger.py
+++ b/backend/industry/tests/test_lp_ledger.py
@@ -1,0 +1,103 @@
+from django.test import TestCase
+
+from industry.helpers.lp_ledger import (
+    LpLedgerError,
+    account_balance,
+    post_ledger_entry,
+    remaining_lots,
+    resolve_offer_isk_per_lp,
+    weighted_average_cost_isk_per_lp,
+)
+from industry.models import (
+    IndustryLoyaltyPoint,
+    IndustryLoyaltyPointAccount,
+    IndustryLoyaltyPointContact,
+)
+
+TLIB_CORP_ID = 1000182
+
+
+class LpLedgerHelperTestCase(TestCase):
+    def setUp(self):
+        self.currency, _ = IndustryLoyaltyPoint.objects.update_or_create(
+            corporation_id=TLIB_CORP_ID,
+            defaults={
+                "name": "Tribal Liberation Force",
+                "default_isk_per_lp": 800,
+                "is_active": True,
+            },
+        )
+        self.stockpile = IndustryLoyaltyPointAccount.objects.create(
+            loyalty_point=self.currency,
+            name="FL33T TLIB pot",
+            role=IndustryLoyaltyPointAccount.Role.STOCKPILE,
+            isk_per_lp=840,
+        )
+
+    def test_resolve_offer_falls_back_to_currency_default(self):
+        account = IndustryLoyaltyPointAccount.objects.create(
+            loyalty_point=self.currency,
+            name="No offer set",
+            role=IndustryLoyaltyPointAccount.Role.SELLER,
+        )
+        self.assertEqual(resolve_offer_isk_per_lp(account), 800)
+        self.assertEqual(resolve_offer_isk_per_lp(self.stockpile), 840)
+
+    def test_multi_price_credits_and_fifo_average(self):
+        post_ledger_entry(self.stockpile, 200_000, 825, notes="order A")
+        post_ledger_entry(self.stockpile, 100_000, 850, notes="order B")
+        self.assertEqual(account_balance(self.stockpile), 300_000)
+
+        lots = remaining_lots(self.stockpile)
+        self.assertEqual(
+            [(lot.isk_per_lp, lot.quantity) for lot in lots],
+            [(825, 200_000), (850, 100_000)],
+        )
+        self.assertAlmostEqual(
+            weighted_average_cost_isk_per_lp(self.stockpile),
+            (200_000 * 825 + 100_000 * 850) / 300_000,
+        )
+
+        post_ledger_entry(self.stockpile, -50_000, 840, notes="draw")
+        self.assertEqual(account_balance(self.stockpile), 250_000)
+        lots = remaining_lots(self.stockpile)
+        self.assertEqual(
+            [(lot.isk_per_lp, lot.quantity) for lot in lots],
+            [(825, 150_000), (850, 100_000)],
+        )
+        self.assertAlmostEqual(
+            weighted_average_cost_isk_per_lp(self.stockpile),
+            (150_000 * 825 + 100_000 * 850) / 250_000,
+        )
+
+    def test_overdraft_rejected(self):
+        post_ledger_entry(self.stockpile, 10_000, 825)
+        with self.assertRaises(LpLedgerError):
+            post_ledger_entry(self.stockpile, -20_000, 840)
+        self.assertEqual(account_balance(self.stockpile), 10_000)
+
+    def test_zero_amount_and_invalid_price_rejected(self):
+        with self.assertRaises(LpLedgerError):
+            post_ledger_entry(self.stockpile, 0, 825)
+        with self.assertRaises(LpLedgerError):
+            post_ledger_entry(self.stockpile, 1_000, 0)
+
+    def test_seller_contact_directory_without_balance(self):
+        seller = IndustryLoyaltyPointAccount.objects.create(
+            loyalty_point=self.currency,
+            name="Other militia contact",
+            role=IndustryLoyaltyPointAccount.Role.SELLER,
+        )
+        IndustryLoyaltyPointContact.objects.create(
+            account=seller,
+            character_name="Amarr Seller",
+            discord_username="amarr#0001",
+        )
+        self.assertEqual(account_balance(seller), 0)
+        self.assertEqual(seller.contacts.count(), 1)
+        sellers = IndustryLoyaltyPointAccount.objects.filter(
+            role=IndustryLoyaltyPointAccount.Role.SELLER,
+            loyalty_point=self.currency,
+            is_active=True,
+        )
+        self.assertIn(seller, sellers)


### PR DESCRIPTION
## Summary
- Add `IndustryLoyaltyPointAccount` (`seller` / `stockpile`) with optional offer ISK/LP, and move contacts onto accounts (existing contacts migrate to seller accounts).
- Add append-only `IndustryLoyaltyPointLedgerEntry` lots with required per-row `isk_per_lp` so multiple intakes at different prices (825, 850, …) are first-class; balance is `SUM(amount)`.
- Admin lists balance, offer price, and FIFO weighted average cost; ledger posts go through `post_ledger_entry` (no overdraft).

## Test plan
- [ ] `pipenv run python manage.py test industry.tests.test_lp_ledger industry.tests.test_loyalty_store --settings=app.settings_test`
- [ ] In admin: create a stockpile account, post credits at 825 and 850, confirm balance and avg cost
- [ ] Confirm seller accounts with contacts show up at zero balance
- [ ] Confirm debit past balance is rejected


Made with [Cursor](https://cursor.com)