### PR TITLE
Add soft industry order ↔ ESI contract associations

### DIFF
--- a/backend/app/settings_celery.py
+++ b/backend/app/settings_celery.py
@@ -145,6 +145,13 @@ CELERYBEAT_INDUSTRY = [
             "schedule": crontab(minute=20),
         },
     ),
+    (
+        "[Industry] Reconcile Contract Associations",
+        {
+            "task": "industry.tasks.reconcile_industry_contract_associations_task",
+            "schedule": crontab(minute=35, hour="*/2"),
+        },
+    ),
 ]
 
 # Groups

--- a/backend/eveonline/tasks/characters.py
+++ b/backend/eveonline/tasks/characters.py
@@ -71,6 +71,10 @@ def update_character(eve_character_id):
         refresh_character_killmails(eve_character_id)
     if Token.get_token(eve_character_id, SCOPE_CONTRACTS):
         refresh_character_contracts(eve_character_id)
+        app.send_task(
+            "industry.tasks.reconcile_industry_contract_associations_for_character_task",
+            args=[eve_character_id],
+        )
     if Token.get_token(eve_character_id, SCOPE_INDUSTRY_JOBS):
         refresh_character_industry_jobs(eve_character_id)
     if Token.get_token(eve_character_id, SCOPE_MINING):

--- a/backend/industry/admin.py
+++ b/backend/industry/admin.py
@@ -19,6 +19,7 @@ from industry.forms import (
 from industry.helpers.admin_permissions import industry_orders_index_link_perms
 from industry.helpers.type_breakdown import get_breakdown_for_industry_product
 from industry.models import (
+    IndustryContractAssociation,
     IndustryLoyaltyPoint,
     IndustryLoyaltyPointContact,
     IndustryLpStoreOffer,
@@ -386,6 +387,23 @@ class IndustryOrderItemAssignmentAdmin(admin.ModelAdmin):
         if order_item_id:
             initial["order_item"] = order_item_id
         return initial
+
+
+@admin.register(IndustryContractAssociation)
+class IndustryContractAssociationAdmin(admin.ModelAdmin):
+    list_display = (
+        "contract_id",
+        "order",
+        "assignment",
+        "score",
+        "contract_status",
+        "updated_at",
+    )
+    list_filter = ("contract_status",)
+    search_fields = ("contract_id", "order__id", "order__public_short_code")
+    raw_id_fields = ("order", "assignment")
+    readonly_fields = ("created_at", "updated_at", "signals")
+    ordering = ("-score", "-updated_at")
 
 
 @admin.register(IndustryProduct)

--- a/backend/industry/helpers/contract_associations.py
+++ b/backend/industry/helpers/contract_associations.py
@@ -1,0 +1,479 @@
+"""Loose scored matching of ESI character contracts to industry orders."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime as dt_datetime, time as dt_time
+from typing import Iterable
+
+from django.db.models import Prefetch
+from django.utils import timezone
+
+from eveonline.client import EsiClient
+from eveonline.models import (
+    EveAlliance,
+    EveCharacter,
+    EveCharacterContract,
+    EveCorporation,
+)
+from market.helpers.contract_match import normalize_contract_items
+
+from industry.models import (
+    IndustryContractAssociation,
+    IndustryOrder,
+    IndustryOrderItemAssignment,
+)
+
+logger = logging.getLogger(__name__)
+
+MATCH_THRESHOLD = 0.4
+
+WEIGHT_ASSIGNEE_OWNER = 0.40
+WEIGHT_ASSIGNEE_CONTRACT_TO = 0.20
+WEIGHT_ISSUER_ASSIGNEE = 0.30
+WEIGHT_TYPE_QTY = 0.30
+WEIGHT_TYPE_QTY_OVER = 0.15
+WEIGHT_LOCATION = 0.15
+WEIGHT_SHORT_CODE = 0.15
+WEIGHT_STATUS = 0.05
+WEIGHT_TIME_WINDOW = 0.05
+
+
+@dataclass(frozen=True)
+class MatchCandidate:
+    order: IndustryOrder
+    assignment: IndustryOrderItemAssignment | None
+    contract: EveCharacterContract
+    score: float
+    signals: dict
+
+
+def order_period_bounds(order: IndustryOrder) -> tuple:
+    """Return (period_start, period_end) aware datetimes for an order."""
+    period_start = order.created_at
+    if order.fulfilled_at is not None:
+        period_end = order.fulfilled_at
+    else:
+        period_end = timezone.make_aware(
+            dt_datetime.combine(order.needed_by, dt_time.max)
+        )
+    return period_start, period_end
+
+
+def owner_entity_ids(character: EveCharacter) -> set[int]:
+    ids: set[int] = set()
+    if character.character_id:
+        ids.add(int(character.character_id))
+    if character.corporation_id:
+        ids.add(int(character.corporation_id))
+    if character.alliance_id:
+        ids.add(int(character.alliance_id))
+    return ids
+
+
+def contract_to_name_matches(
+    assignee_id: int | None, contract_to: str
+) -> bool:
+    """Weak fallback: resolve free-text contract_to against known entity names."""
+    if not assignee_id or not (contract_to or "").strip():
+        return False
+    name = contract_to.strip()
+    if EveCharacter.objects.filter(
+        character_id=assignee_id, character_name__iexact=name
+    ).exists():
+        return True
+    if EveCorporation.objects.filter(
+        corporation_id=assignee_id, name__iexact=name
+    ).exists():
+        return True
+    if EveAlliance.objects.filter(
+        alliance_id=assignee_id, name__iexact=name
+    ).exists():
+        return True
+    return False
+
+
+def contract_in_order_window(
+    contract: EveCharacterContract, period_start, period_end
+) -> bool:
+    """True if issued or completed time overlaps the order period."""
+    for stamp in (contract.date_issued, contract.date_completed):
+        if stamp is None:
+            continue
+        if period_start <= stamp <= period_end:
+            return True
+    # Outstanding contracts issued before the window but still open during it
+    if (
+        contract.date_issued is not None
+        and contract.date_issued <= period_end
+        and (
+            contract.date_completed is None
+            or contract.date_completed >= period_start
+        )
+        and contract.status in ("outstanding", "in_progress")
+    ):
+        return True
+    return False
+
+
+def aggregate_contract_items(raw_items: list[dict] | None) -> dict[int, int]:
+    if not raw_items:
+        return {}
+    return normalize_contract_items(raw_items)
+
+
+def fetch_character_contract_items(
+    owner: EveCharacter, contract_id: int
+) -> dict[int, int]:
+    """Fetch and aggregate ESI contract items for the order owner's token."""
+    response = EsiClient(owner).get_character_contract_items(contract_id)
+    if not response.success():
+        logger.debug(
+            "Could not fetch items for contract %s (owner %s): %s",
+            contract_id,
+            owner.character_id,
+            response.response_code,
+        )
+        return {}
+    return aggregate_contract_items(response.results() or [])
+
+
+def score_contract_for_assignment(
+    *,
+    order: IndustryOrder,
+    assignment: IndustryOrderItemAssignment,
+    contract: EveCharacterContract,
+    owner_ids: set[int],
+    item_quantities: dict[int, int] | None,
+) -> MatchCandidate | None:
+    signals: dict = {}
+    score = 0.0
+
+    assignee_id = contract.assignee_id
+    if assignee_id and int(assignee_id) in owner_ids:
+        score += WEIGHT_ASSIGNEE_OWNER
+        signals["assignee_owner"] = True
+    elif contract_to_name_matches(assignee_id, order.contract_to):
+        score += WEIGHT_ASSIGNEE_CONTRACT_TO
+        signals["assignee_contract_to"] = True
+    else:
+        return None
+
+    score += WEIGHT_TIME_WINDOW
+    signals["time_window"] = True
+
+    issuer_id = contract.issuer_id
+    if issuer_id and int(issuer_id) == int(assignment.character.character_id):
+        score += WEIGHT_ISSUER_ASSIGNEE
+        signals["issuer_assignee"] = True
+
+    type_id = assignment.order_item.eve_type_id
+    qty = assignment.quantity
+    if item_quantities is not None and type_id in item_quantities:
+        contract_qty = item_quantities[type_id]
+        if 1 <= contract_qty <= qty:
+            score += WEIGHT_TYPE_QTY
+            signals["type_qty"] = contract_qty
+        elif contract_qty > qty:
+            score += WEIGHT_TYPE_QTY_OVER
+            signals["type_qty_over"] = contract_qty
+
+    location_id = order.location_id
+    if location_id in (
+        contract.start_location_id,
+        contract.end_location_id,
+    ):
+        score += WEIGHT_LOCATION
+        signals["location"] = True
+
+    short_code = (order.public_short_code or "").strip()
+    title = contract.title or ""
+    if short_code and short_code.lower() in title.lower():
+        score += WEIGHT_SHORT_CODE
+        signals["short_code"] = True
+
+    if contract.status in ("finished", "outstanding"):
+        score += WEIGHT_STATUS
+        signals["status"] = contract.status
+
+    score = min(score, 1.0)
+    if score < MATCH_THRESHOLD:
+        return None
+
+    return MatchCandidate(
+        order=order,
+        assignment=assignment,
+        contract=contract,
+        score=score,
+        signals=signals,
+    )
+
+
+def score_contract_for_order(
+    *,
+    order: IndustryOrder,
+    contract: EveCharacterContract,
+    owner_ids: set[int],
+) -> MatchCandidate | None:
+    """Order-level association when assignee matches but no assignment pins."""
+    signals: dict = {}
+    score = 0.0
+
+    assignee_id = contract.assignee_id
+    if assignee_id and int(assignee_id) in owner_ids:
+        score += WEIGHT_ASSIGNEE_OWNER
+        signals["assignee_owner"] = True
+    elif contract_to_name_matches(assignee_id, order.contract_to):
+        score += WEIGHT_ASSIGNEE_CONTRACT_TO
+        signals["assignee_contract_to"] = True
+    else:
+        return None
+
+    score += WEIGHT_TIME_WINDOW
+    signals["time_window"] = True
+
+    location_id = order.location_id
+    if location_id in (
+        contract.start_location_id,
+        contract.end_location_id,
+    ):
+        score += WEIGHT_LOCATION
+        signals["location"] = True
+
+    short_code = (order.public_short_code or "").strip()
+    title = contract.title or ""
+    if short_code and short_code.lower() in title.lower():
+        score += WEIGHT_SHORT_CODE
+        signals["short_code"] = True
+
+    if contract.status in ("finished", "outstanding"):
+        score += WEIGHT_STATUS
+        signals["status"] = contract.status
+
+    score = min(score, 1.0)
+    if score < MATCH_THRESHOLD:
+        return None
+
+    return MatchCandidate(
+        order=order,
+        assignment=None,
+        contract=contract,
+        score=score,
+        signals=signals,
+    )
+
+
+def candidate_contracts_for_order(
+    order: IndustryOrder,
+) -> list[EveCharacterContract]:
+    owner = order.character
+    period_start, period_end = order_period_bounds(order)
+    owner_ids = owner_entity_ids(owner)
+
+    qs = EveCharacterContract.objects.filter(
+        character=owner,
+        type="item_exchange",
+    )
+    contracts = []
+    for contract in qs:
+        if not contract_in_order_window(contract, period_start, period_end):
+            continue
+        assignee_id = contract.assignee_id
+        if assignee_id and int(assignee_id) in owner_ids:
+            contracts.append(contract)
+            continue
+        if contract_to_name_matches(assignee_id, order.contract_to):
+            contracts.append(contract)
+    return contracts
+
+
+def match_order_contracts(
+    order: IndustryOrder,
+    *,
+    item_quantities_by_contract: dict[int, dict[int, int]] | None = None,
+    fetch_items: bool = True,
+) -> list[MatchCandidate]:
+    """
+    Score contracts synced for the order owner against assignments.
+
+    Prefer assignment-level matches. If a contract matches the order assignee
+    filter but no assignment scores above threshold, keep an order-level row.
+    """
+    owner = order.character
+    owner_ids = owner_entity_ids(owner)
+    contracts = candidate_contracts_for_order(order)
+    if not contracts:
+        return []
+
+    assignments = list(
+        IndustryOrderItemAssignment.objects.filter(
+            order_item__order=order
+        ).select_related("character", "order_item")
+    )
+
+    items_cache = dict(item_quantities_by_contract or {})
+    results: list[MatchCandidate] = []
+
+    for contract in contracts:
+        contract_id = int(contract.contract_id)
+        if contract_id not in items_cache and fetch_items:
+            items_cache[contract_id] = fetch_character_contract_items(
+                owner, contract_id
+            )
+        item_quantities = items_cache.get(contract_id)
+
+        assignment_matches: list[MatchCandidate] = []
+        for assignment in assignments:
+            candidate = score_contract_for_assignment(
+                order=order,
+                assignment=assignment,
+                contract=contract,
+                owner_ids=owner_ids,
+                item_quantities=item_quantities,
+            )
+            if candidate is not None:
+                assignment_matches.append(candidate)
+
+        if assignment_matches:
+            results.extend(assignment_matches)
+            continue
+
+        order_match = score_contract_for_order(
+            order=order,
+            contract=contract,
+            owner_ids=owner_ids,
+        )
+        if order_match is not None:
+            results.append(order_match)
+
+    return results
+
+
+def upsert_associations(candidates: Iterable[MatchCandidate]) -> int:
+    """Create or update association rows; returns number of rows written."""
+    written = 0
+    for candidate in candidates:
+        shared = {
+            "score": candidate.score,
+            "signals": candidate.signals,
+            "contract_status": candidate.contract.status or "",
+        }
+        if candidate.assignment is not None:
+            IndustryContractAssociation.objects.update_or_create(
+                assignment=candidate.assignment,
+                contract_id=candidate.contract.contract_id,
+                defaults={**shared, "order": candidate.order},
+            )
+        else:
+            IndustryContractAssociation.objects.update_or_create(
+                order=candidate.order,
+                contract_id=candidate.contract.contract_id,
+                assignment=None,
+                defaults=shared,
+            )
+        written += 1
+    return written
+
+
+def prune_stale_associations(
+    order: IndustryOrder, keep: Iterable[MatchCandidate]
+) -> int:
+    """Delete associations for this order not present in the latest match set."""
+    keep_keys = set()
+    for candidate in keep:
+        if candidate.assignment is not None:
+            keep_keys.add(
+                (
+                    "a",
+                    candidate.assignment.pk,
+                    candidate.contract.contract_id,
+                )
+            )
+        else:
+            keep_keys.add(
+                ("o", candidate.order.pk, candidate.contract.contract_id)
+            )
+
+    deleted = 0
+    for assoc in IndustryContractAssociation.objects.filter(order=order):
+        if assoc.assignment_id:
+            key = ("a", assoc.assignment_id, assoc.contract_id)
+        else:
+            key = ("o", assoc.order_id, assoc.contract_id)
+        if key not in keep_keys:
+            assoc.delete()
+            deleted += 1
+    return deleted
+
+
+def reconcile_order_contract_associations(
+    order: IndustryOrder,
+    *,
+    fetch_items: bool = True,
+    item_quantities_by_contract: dict[int, dict[int, int]] | None = None,
+) -> int:
+    """Match and upsert associations for one order; prune stale rows."""
+    candidates = match_order_contracts(
+        order,
+        fetch_items=fetch_items,
+        item_quantities_by_contract=item_quantities_by_contract,
+    )
+    written = upsert_associations(candidates)
+    pruned = prune_stale_associations(order, candidates)
+    logger.info(
+        "Reconciled contract associations for order %s: wrote=%s pruned=%s",
+        order.pk,
+        written,
+        pruned,
+    )
+    return written
+
+
+def open_orders_queryset():
+    """Unfulfilled industry orders with owner and assignments prefetched."""
+    return (
+        IndustryOrder.objects.filter(fulfilled_at__isnull=True)
+        .select_related("character", "location")
+        .prefetch_related(
+            Prefetch(
+                "items__assignments",
+                queryset=IndustryOrderItemAssignment.objects.select_related(
+                    "character", "order_item"
+                ),
+            )
+        )
+    )
+
+
+def reconcile_open_order_contract_associations(
+    *,
+    fetch_items: bool = True,
+) -> int:
+    """Reconcile associations for all open industry orders."""
+    total = 0
+    for order in open_orders_queryset():
+        total += reconcile_order_contract_associations(
+            order, fetch_items=fetch_items
+        )
+    return total
+
+
+def reconcile_associations_for_character(
+    character_id: int,
+    *,
+    fetch_items: bool = True,
+) -> int:
+    """
+    Reconcile open orders owned by the given ESI character_id
+    (after their contracts were refreshed).
+    """
+    total = 0
+    orders = open_orders_queryset().filter(
+        character__character_id=character_id
+    )
+    for order in orders:
+        total += reconcile_order_contract_associations(
+            order, fetch_items=fetch_items
+        )
+    return total

--- a/backend/industry/migrations/0029_industrycontractassociation.py
+++ b/backend/industry/migrations/0029_industrycontractassociation.py
@@ -1,0 +1,111 @@
+# Generated manually for IndustryContractAssociation
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("industry", "0028_seed_militia_loyalty_points"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="IndustryContractAssociation",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "contract_id",
+                    models.BigIntegerField(
+                        db_index=True,
+                        help_text="ESI contract_id (no FK; survives character-contract re-sync).",
+                    ),
+                ),
+                (
+                    "score",
+                    models.FloatField(
+                        help_text="Loose match confidence from 0 to 1.",
+                    ),
+                ),
+                (
+                    "signals",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        help_text="Which signals contributed to the score.",
+                    ),
+                ),
+                (
+                    "contract_status",
+                    models.CharField(
+                        blank=True,
+                        help_text="ESI contract status snapshot at match time.",
+                        max_length=32,
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "assignment",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text="Set when issuer/items pin the contract to one assignment.",
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="contract_associations",
+                        to="industry.industryorderitemassignment",
+                    ),
+                ),
+                (
+                    "order",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="contract_associations",
+                        to="industry.industryorder",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-score", "-updated_at"],
+            },
+        ),
+        migrations.AddIndex(
+            model_name="industrycontractassociation",
+            index=models.Index(
+                fields=["order", "contract_id"],
+                name="industry_in_order_i_7c2a1b_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="industrycontractassociation",
+            index=models.Index(
+                fields=["contract_id", "score"],
+                name="industry_in_contrac_9f4e2d_idx",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="industrycontractassociation",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("assignment__isnull", False)),
+                fields=("assignment", "contract_id"),
+                name="uniq_industry_contract_assoc_assignment_contract",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="industrycontractassociation",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("assignment__isnull", True)),
+                fields=("order", "contract_id"),
+                name="uniq_industry_contract_assoc_order_contract",
+            ),
+        ),
+    ]

--- a/backend/industry/models/__init__.py
+++ b/backend/industry/models/__init__.py
@@ -2,6 +2,7 @@
 #   from industry.models import SomeModel
 # continues to work when models are split across files in this package.
 
+from industry.models.contract_association import IndustryContractAssociation
 from industry.models.cost_index import IndustrySystemCostIndex
 from industry.models.lp_store import (
     IndustryLoyaltyPoint,
@@ -20,6 +21,7 @@ from industry.models.product import (
 )
 
 __all__ = [
+    "IndustryContractAssociation",
     "IndustryLoyaltyPoint",
     "IndustryLoyaltyPointContact",
     "IndustryLpStoreOffer",

--- a/backend/industry/models/contract_association.py
+++ b/backend/industry/models/contract_association.py
@@ -1,0 +1,71 @@
+from django.db import models
+
+
+class IndustryContractAssociation(models.Model):
+    """
+    Soft-scored link between an ESI private contract and an industry order
+    (optionally a specific assignment). Does not drive delivery behavior.
+    """
+
+    order = models.ForeignKey(
+        "industry.IndustryOrder",
+        on_delete=models.CASCADE,
+        related_name="contract_associations",
+    )
+    assignment = models.ForeignKey(
+        "industry.IndustryOrderItemAssignment",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="contract_associations",
+        help_text="Set when issuer/items pin the contract to one assignment.",
+    )
+    contract_id = models.BigIntegerField(
+        db_index=True,
+        help_text="ESI contract_id (no FK; survives character-contract re-sync).",
+    )
+    score = models.FloatField(
+        help_text="Loose match confidence from 0 to 1.",
+    )
+    signals = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text="Which signals contributed to the score.",
+    )
+    contract_status = models.CharField(
+        max_length=32,
+        blank=True,
+        help_text="ESI contract status snapshot at match time.",
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ["-score", "-updated_at"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["assignment", "contract_id"],
+                condition=models.Q(assignment__isnull=False),
+                name="uniq_industry_contract_assoc_assignment_contract",
+            ),
+            models.UniqueConstraint(
+                fields=["order", "contract_id"],
+                condition=models.Q(assignment__isnull=True),
+                name="uniq_industry_contract_assoc_order_contract",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["order", "contract_id"]),
+            models.Index(fields=["contract_id", "score"]),
+        ]
+
+    def __str__(self):
+        target = (
+            f"assignment {self.assignment_id}"
+            if self.assignment_id
+            else f"order {self.order_id}"
+        )
+        return (
+            f"Contract {self.contract_id} → {target} "
+            f"(score={self.score:.2f})"
+        )

--- a/backend/industry/tasks.py
+++ b/backend/industry/tasks.py
@@ -6,6 +6,10 @@ from app.celery import app
 from eveonline.helpers.characters.update import update_character_industry_jobs
 from eveonline.models import EveCharacter
 
+from industry.helpers.contract_associations import (
+    reconcile_associations_for_character,
+    reconcile_open_order_contract_associations,
+)
 from industry.helpers.cost_indices import sync_industry_system_cost_indices
 from industry.helpers.loyalty_store import (
     ensure_loyalty_store_offers_for_product,
@@ -105,5 +109,36 @@ def ensure_loyalty_store_offers_for_product_task(product_id: int) -> int:
         logger.exception(
             "Failed to ensure loyalty store offers for product %s",
             product_id,
+        )
+        raise
+
+
+@app.task()
+def reconcile_industry_contract_associations_task() -> int:
+    """
+    Score and upsert soft links between open industry orders and ESI contracts.
+
+    Periodic via Celery beat. Does not mark assignments delivered.
+    """
+    try:
+        return reconcile_open_order_contract_associations(fetch_items=True)
+    except Exception:
+        logger.exception("Failed to reconcile industry contract associations")
+        raise
+
+
+@app.task()
+def reconcile_industry_contract_associations_for_character_task(
+    character_id: int,
+) -> int:
+    """Reconcile associations for open orders owned by this ESI character_id."""
+    try:
+        return reconcile_associations_for_character(
+            int(character_id), fetch_items=True
+        )
+    except Exception:
+        logger.exception(
+            "Failed to reconcile industry contract associations for character %s",
+            character_id,
         )
         raise

--- a/backend/industry/tests/test_contract_associations.py
+++ b/backend/industry/tests/test_contract_associations.py
@@ -1,0 +1,248 @@
+"""Tests for loose industry order ↔ ESI contract associations."""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.utils import timezone
+
+from app.test import TestCase
+from eveonline.models import EveCharacter, EveCharacterContract, EveLocation
+from eveuniverse.models import EveCategory, EveGroup, EveType
+
+from industry.helpers.contract_associations import (
+    MATCH_THRESHOLD,
+    match_order_contracts,
+    reconcile_order_contract_associations,
+)
+from industry.models import (
+    IndustryContractAssociation,
+    IndustryOrderItem,
+    IndustryOrderItemAssignment,
+)
+from industry.tasks import (
+    reconcile_industry_contract_associations_for_character_task,
+    reconcile_industry_contract_associations_task,
+)
+from industry.test_utils import create_industry_order
+
+
+class ContractAssociationTestCase(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.category, _ = EveCategory.objects.get_or_create(
+            id=9201,
+            defaults={"name": "Assoc Category", "published": True},
+        )
+        cls.group, _ = EveGroup.objects.get_or_create(
+            id=9201,
+            defaults={
+                "name": "Assoc Group",
+                "published": True,
+                "eve_category": cls.category,
+            },
+        )
+        cls.eve_type, _ = EveType.objects.get_or_create(
+            id=9201,
+            defaults={
+                "name": "Assoc Widget",
+                "published": True,
+                "eve_group": cls.group,
+            },
+        )
+        cls.eve_type_b, _ = EveType.objects.get_or_create(
+            id=9202,
+            defaults={
+                "name": "Assoc Widget B",
+                "published": True,
+                "eve_group": cls.group,
+            },
+        )
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="assoc_owner")
+        self.location = EveLocation.objects.create(
+            location_id=92001,
+            location_name="Assoc Hub",
+            solar_system_id=1,
+            solar_system_name="Test",
+        )
+        self.owner = EveCharacter.objects.create(
+            character_id=92001,
+            character_name="Order Owner",
+            corporation_id=98000001,
+            alliance_id=99000001,
+            user=self.user,
+        )
+        self.builder = EveCharacter.objects.create(
+            character_id=92002,
+            character_name="Builder Pilot",
+            user=self.user,
+        )
+        self.needed_by = (timezone.now() + timedelta(days=7)).date()
+        self.order = create_industry_order(
+            needed_by=self.needed_by,
+            character=self.owner,
+            location=self.location,
+            public_short_code="aB3",
+            contract_to="Order Owner",
+        )
+        self.order_item = IndustryOrderItem.objects.create(
+            order=self.order,
+            eve_type=self.eve_type,
+            quantity=10,
+        )
+        self.assignment = IndustryOrderItemAssignment.objects.create(
+            order_item=self.order_item,
+            character=self.builder,
+            quantity=5,
+        )
+
+    def _make_contract(self, **overrides):
+        defaults = {
+            "contract_id": 700001,
+            "character": self.owner,
+            "type": "item_exchange",
+            "status": "outstanding",
+            "issuer_id": self.builder.character_id,
+            "assignee_id": self.owner.character_id,
+            "date_issued": timezone.now(),
+            "start_location_id": self.location.location_id,
+            "end_location_id": self.location.location_id,
+            "title": "Delivery aB3",
+        }
+        defaults.update(overrides)
+        return EveCharacterContract.objects.create(**defaults)
+
+    def test_no_association_when_assignee_does_not_match(self):
+        self._make_contract(assignee_id=11111111, title="")
+        candidates = match_order_contracts(
+            self.order,
+            fetch_items=False,
+            item_quantities_by_contract={},
+        )
+        self.assertEqual(candidates, [])
+
+    def test_assignee_and_issuer_and_type_score_assignment(self):
+        contract = self._make_contract()
+        candidates = match_order_contracts(
+            self.order,
+            fetch_items=False,
+            item_quantities_by_contract={
+                contract.contract_id: {self.eve_type.id: 5},
+            },
+        )
+        self.assertEqual(len(candidates), 1)
+        match = candidates[0]
+        self.assertEqual(match.assignment.pk, self.assignment.pk)
+        self.assertGreaterEqual(match.score, MATCH_THRESHOLD)
+        self.assertTrue(match.signals.get("assignee_owner"))
+        self.assertTrue(match.signals.get("issuer_assignee"))
+        self.assertEqual(match.signals.get("type_qty"), 5)
+        self.assertTrue(match.signals.get("location"))
+        self.assertTrue(match.signals.get("short_code"))
+
+    def test_order_level_when_no_assignment_pins(self):
+        # Different issuer, no items → assignment score may still pass via
+        # assignee+location+short_code+status; remove short code/location to
+        # force order-level-only path without issuer/type.
+        IndustryOrderItemAssignment.objects.all().delete()
+        contract = self._make_contract(
+            issuer_id=99999999,
+            title="",
+            start_location_id=None,
+            end_location_id=None,
+        )
+        candidates = match_order_contracts(
+            self.order,
+            fetch_items=False,
+            item_quantities_by_contract={contract.contract_id: {}},
+        )
+        self.assertEqual(len(candidates), 1)
+        self.assertIsNone(candidates[0].assignment)
+        self.assertTrue(candidates[0].signals.get("assignee_owner"))
+
+    def test_multi_assignment_single_contract(self):
+        item_b = IndustryOrderItem.objects.create(
+            order=self.order,
+            eve_type=self.eve_type_b,
+            quantity=3,
+        )
+        assignment_b = IndustryOrderItemAssignment.objects.create(
+            order_item=item_b,
+            character=self.builder,
+            quantity=3,
+        )
+        contract = self._make_contract()
+        candidates = match_order_contracts(
+            self.order,
+            fetch_items=False,
+            item_quantities_by_contract={
+                contract.contract_id: {
+                    self.eve_type.id: 5,
+                    self.eve_type_b.id: 3,
+                },
+            },
+        )
+        assignment_ids = {c.assignment.pk for c in candidates}
+        self.assertEqual(assignment_ids, {self.assignment.pk, assignment_b.pk})
+
+    def test_reconcile_idempotent_upsert_and_prune(self):
+        contract = self._make_contract()
+        items = {contract.contract_id: {self.eve_type.id: 5}}
+        written = reconcile_order_contract_associations(
+            self.order,
+            fetch_items=False,
+            item_quantities_by_contract=items,
+        )
+        self.assertEqual(written, 1)
+        self.assertEqual(IndustryContractAssociation.objects.count(), 1)
+
+        written_again = reconcile_order_contract_associations(
+            self.order,
+            fetch_items=False,
+            item_quantities_by_contract=items,
+        )
+        self.assertEqual(written_again, 1)
+        self.assertEqual(IndustryContractAssociation.objects.count(), 1)
+
+        # Change assignee so match disappears → prune
+        contract.assignee_id = 11111111
+        contract.save(update_fields=["assignee_id"])
+        reconcile_order_contract_associations(
+            self.order,
+            fetch_items=False,
+            item_quantities_by_contract=items,
+        )
+        self.assertEqual(IndustryContractAssociation.objects.count(), 0)
+
+    def test_corp_assignee_matches_owner_corporation(self):
+        contract = self._make_contract(
+            assignee_id=self.owner.corporation_id,
+            title="",
+        )
+        candidates = match_order_contracts(
+            self.order,
+            fetch_items=False,
+            item_quantities_by_contract={
+                contract.contract_id: {self.eve_type.id: 2},
+            },
+        )
+        self.assertEqual(len(candidates), 1)
+        self.assertTrue(candidates[0].signals.get("assignee_owner"))
+
+    @patch("industry.tasks.reconcile_open_order_contract_associations")
+    def test_reconcile_task_delegates(self, reconcile_mock):
+        reconcile_mock.return_value = 3
+        self.assertEqual(reconcile_industry_contract_associations_task(), 3)
+        reconcile_mock.assert_called_once_with(fetch_items=True)
+
+    @patch("industry.tasks.reconcile_associations_for_character")
+    def test_reconcile_for_character_task(self, reconcile_mock):
+        reconcile_mock.return_value = 1
+        self.assertEqual(
+            reconcile_industry_contract_associations_for_character_task(92001),
+            1,
+        )
+        reconcile_mock.assert_called_once_with(92001, fetch_items=True)


### PR DESCRIPTION
## Summary
- Persist scored `IndustryContractAssociation` rows linking private ESI contracts (synced for order owners) to industry orders/assignments
- Match on assignee (character/corp/alliance IDs), issuer, contract items, location, short code in title, and order time window — without auto-setting `delivered_at`
- Reconcile via Celery beat (every 2h) and after character contract refresh so later UI/auto-delivery can consume the links

## Test plan
- [ ] `pipenv run python manage.py test industry.tests.test_contract_associations --settings=app.settings_test`
- [ ] Confirm admin list for `IndustryContractAssociation` loads
- [ ] With a Market-token order owner and a private item-exchange contract from an assignee, run `reconcile_industry_contract_associations_task` and verify association rows appear with expected signals/score
- [ ] Confirm marking delivery still requires the existing PATCH `delivered` path (no auto-mark)


Made with [Cursor](https://cursor.com)