### PR TITLE
Add interactive industry order profit summary

### DIFF
--- a/backend/industry/endpoints/orders/__init__.py
+++ b/backend/industry/endpoints/orders/__init__.py
@@ -20,6 +20,12 @@ from industry.endpoints.orders.get_orders import (
     get_orders,
     METHOD as get_orders_method,
 )
+from industry.endpoints.orders.get_orders_profit_summary import (
+    PATH as get_orders_profit_summary_path,
+    ROUTE_SPEC as get_orders_profit_summary_spec,
+    get_orders_profit_summary,
+    METHOD as get_orders_profit_summary_method,
+)
 from industry.endpoints.orders.get_order_orderitems import (
     PATH as get_order_orderitems_path,
     ROUTE_SPEC as get_order_orderitems_spec,
@@ -49,6 +55,12 @@ router = Router(tags=["Industry - Orders"])
 
 _ROUTES = (
     (get_orders_method, get_orders_path, get_orders_spec, get_orders),
+    (
+        get_orders_profit_summary_method,
+        get_orders_profit_summary_path,
+        get_orders_profit_summary_spec,
+        get_orders_profit_summary,
+    ),
     (post_order_method, post_order_path, post_order_spec, post_order),
     (get_order_method, get_order_path, get_order_spec, get_order),
     (delete_order_method, delete_order_path, delete_order_spec, delete_order),

--- a/backend/industry/endpoints/orders/get_orders_profit_summary.py
+++ b/backend/industry/endpoints/orders/get_orders_profit_summary.py
@@ -1,0 +1,97 @@
+"""GET /profit-summary — canvas-style profit rollup for filtered orders (public)."""
+
+from datetime import date
+from typing import Optional
+
+from app.errors import ErrorResponse
+from ninja import Query
+
+from industry.endpoints.orders.schemas import (
+    OrdersProfitSummaryResponse,
+    ProfitSummaryOrderResponse,
+    ProfitSummaryRowResponse,
+    ProfitSummaryTotalsResponse,
+)
+from industry.helpers.orders_profit_summary import build_orders_profit_summary
+
+PATH = "profit-summary"
+METHOD = "get"
+ROUTE_SPEC = {
+    "summary": (
+        "Profit summary for industry orders "
+        "(Amamake cost vs Jita sell, filterable by needed_by / order ids)"
+    ),
+    "response": {
+        200: OrdersProfitSummaryResponse,
+        400: ErrorResponse,
+    },
+}
+
+
+def get_orders_profit_summary(
+    request,
+    needed_by_from: Optional[date] = Query(None),
+    needed_by_to: Optional[date] = Query(None),
+    open_only: bool = Query(True),
+    order_ids: Optional[str] = Query(
+        None, description="Comma-separated order IDs to include"
+    ),
+    facility_key: str = Query("amamake"),
+    compressed: bool = Query(True),
+):
+    try:
+        summary = build_orders_profit_summary(
+            needed_by_from=needed_by_from,
+            needed_by_to=needed_by_to,
+            open_only=open_only,
+            order_ids=order_ids,
+            facility_key=facility_key,
+            compressed=compressed,
+        )
+    except ValueError as exc:
+        return 400, ErrorResponse(detail=str(exc))
+
+    return OrdersProfitSummaryResponse(
+        orders=[
+            ProfitSummaryOrderResponse(
+                id=o.id,
+                public_short_code=o.public_short_code,
+                needed_by=o.needed_by,
+                location_label=o.location_label,
+                fulfilled_at=o.fulfilled_at,
+                item_count=o.item_count,
+                item_type_ids=o.item_type_ids,
+                included=o.included,
+            )
+            for o in summary.orders
+        ],
+        rows=[
+            ProfitSummaryRowResponse(
+                name=r.name,
+                type_id=r.type_id,
+                kind=r.kind,
+                qty=r.qty,
+                isk_per_lp=r.isk_per_lp,
+                cost_per=r.cost_per,
+                unit_price=r.unit_price,
+                price_source=r.price_source,
+                profit_per=r.profit_per,
+                order_profit=r.order_profit,
+                note=r.note,
+            )
+            for r in summary.rows
+        ],
+        totals=ProfitSummaryTotalsResponse(
+            total_order_amount=summary.totals.total_order_amount,
+            total_profit=summary.totals.total_profit,
+            line_count=summary.totals.line_count,
+            total_qty=summary.totals.total_qty,
+            best_name=summary.totals.best_name,
+            best_profit=summary.totals.best_profit,
+            worst_name=summary.totals.worst_name,
+            worst_profit=summary.totals.worst_profit,
+        ),
+        assumptions=summary.assumptions,
+        facility_key=summary.facility_key,
+        compressed=summary.compressed,
+    )

--- a/backend/industry/endpoints/orders/schemas.py
+++ b/backend/industry/endpoints/orders/schemas.py
@@ -126,3 +126,54 @@ class PatchOrderItemAssignmentRequest(BaseModel):
     """Mark assignment delivery state."""
 
     delivered: bool
+
+
+class ProfitSummaryOrderResponse(BaseModel):
+    """One order candidate for the profit-summary filter UI."""
+
+    id: int
+    public_short_code: str
+    needed_by: date
+    location_label: str
+    fulfilled_at: date | None
+    item_count: int
+    item_type_ids: List[int]
+    included: bool
+
+
+class ProfitSummaryRowResponse(BaseModel):
+    """Aggregated product line with Amamake cost vs order ask (or Jita fallback)."""
+
+    name: str
+    type_id: int
+    kind: str
+    qty: int
+    isk_per_lp: float | None
+    cost_per: int
+    unit_price: int
+    price_source: str
+    profit_per: int
+    order_profit: int
+    note: str | None = None
+
+
+class ProfitSummaryTotalsResponse(BaseModel):
+    total_order_amount: int
+    total_profit: int
+    line_count: int
+    total_qty: int
+    best_name: str | None
+    best_profit: int | None
+    worst_name: str | None
+    worst_profit: int | None
+
+
+class OrdersProfitSummaryResponse(BaseModel):
+    """Canvas-style profit rollup for filtered industry orders."""
+
+    orders: List[ProfitSummaryOrderResponse]
+    rows: List[ProfitSummaryRowResponse]
+    totals: ProfitSummaryTotalsResponse
+    assumptions: List[str]
+    facility_key: str
+    compressed: bool

--- a/backend/industry/helpers/guide_order_summary_export.py
+++ b/backend/industry/helpers/guide_order_summary_export.py
@@ -1,0 +1,694 @@
+"""
+Build and serialize guide-hull order summary rows for the frontend data module.
+
+Used by ``export_guide_order_summary`` so refreshes are not manual shell work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from django.conf import settings
+from eveuniverse.models import EveType
+
+from industry.helpers.blueprint_efficiency import (
+    default_blueprint_me_te_percent,
+    is_faction_navy_hull,
+)
+from industry.helpers.build_planner import plan_build
+from industry.helpers.compressed_ore import build_compressed_ore_plan
+from industry.helpers.cost_breakdown import (
+    build_plan_cost_breakdown,
+    jita_sell_prices_by_type_id,
+)
+from industry.helpers.facility_profiles import get_facility_reprocessing_tax
+from industry.helpers.loyalty_store import (
+    get_offer_for_blueprint_type,
+    navy_bpc_cost_for_plan,
+    resolve_isk_per_lp,
+)
+from industry.helpers.reprocessing_skills import resolve_refine_rate
+from industry.helpers.type_breakdown import get_blueprint_or_reaction_type_id
+
+ORDER_QTY = 100
+MIN_ORDER_PROFIT_ISK = 25_000_000
+FACILITY_KEY = "amamake"
+
+# Snapshot LP assumptions (matches baked frontend defaults).
+DEFAULT_LP_RATES = {
+    "Minmatar": 850.0,
+    "Caldari": 925.0,
+    "Amarr": 1000.0,
+    "Gallente": 1000.0,
+}
+
+CUTS_APPLIED = (
+    "Removed Dragoon, Thrasher, Omen, Maller, Breacher. Also cut any line "
+    "under 25M on the x100: Tristan, Algos, Catalyst NI, Exequror NI, "
+    "Vexor, Vexor NI."
+)
+
+# Talwar FI: local SDE may lack BP; BOM matches other navy destroyers.
+TALWAR_FI_TYPE_ID = 91858
+TALWAR_FI_BPC_TYPE_ID = 91862
+TALWAR_FI_BOM_PROXY_TYPE_ID = 73796  # Catalyst Navy Issue
+
+# Full guide catalog (pre-filter). Kept rows are those with orderProfit >= min.
+GUIDE_HULL_CANDIDATES: Tuple[Dict[str, Any], ...] = (
+    {
+        "name": "Caldari Navy Hookbill",
+        "type_id": 17619,
+        "kind": "Navy",
+        "faction": "Caldari",
+    },
+    {
+        "name": "Federation Navy Comet",
+        "type_id": 17841,
+        "kind": "Navy",
+        "faction": "Gallente",
+    },
+    {
+        "name": "Imperial Navy Slicer",
+        "type_id": 17703,
+        "kind": "Navy",
+        "faction": "Amarr",
+    },
+    {
+        "name": "Republic Fleet Firetail",
+        "type_id": 17812,
+        "kind": "Navy",
+        "faction": "Minmatar",
+    },
+    {
+        "name": "Vigil Fleet Issue",
+        "type_id": 37454,
+        "kind": "Navy",
+        "faction": "Minmatar",
+    },
+    {
+        "name": "Tristan",
+        "type_id": 593,
+        "kind": "T1",
+        "faction": "T1",
+    },
+    {
+        "name": "Breacher",
+        "type_id": 598,
+        "kind": "T1",
+        "faction": "T1",
+    },
+    {
+        "name": "Catalyst Navy Issue",
+        "type_id": 73796,
+        "kind": "Navy",
+        "faction": "Gallente",
+    },
+    {
+        "name": "Coercer Navy Issue",
+        "type_id": 73789,
+        "kind": "Navy",
+        "faction": "Amarr",
+    },
+    {
+        "name": "Thrasher Fleet Issue",
+        "type_id": 73794,
+        "kind": "Navy",
+        "faction": "Minmatar",
+    },
+    {
+        "name": "Cormorant Navy Issue",
+        "type_id": 73795,
+        "kind": "Navy",
+        "faction": "Caldari",
+    },
+    {
+        "name": "Talwar Fleet Issue",
+        "type_id": TALWAR_FI_TYPE_ID,
+        "kind": "Navy",
+        "faction": "Minmatar",
+        "bom_proxy_type_id": TALWAR_FI_BOM_PROXY_TYPE_ID,
+        "bpc_type_id": TALWAR_FI_BPC_TYPE_ID,
+        "note": "BOM proxied (identical navy destroyer recipe)",
+    },
+    {
+        "name": "Algos",
+        "type_id": 32872,
+        "kind": "T1",
+        "faction": "T1",
+    },
+    {
+        "name": "Thrasher",
+        "type_id": 16242,
+        "kind": "T1",
+        "faction": "T1",
+    },
+    {
+        "name": "Coercer",
+        "type_id": 16236,
+        "kind": "T1",
+        "faction": "T1",
+    },
+    {
+        "name": "Dragoon",
+        "type_id": 32874,
+        "kind": "T1",
+        "faction": "T1",
+    },
+    {
+        "name": "Arbitrator",
+        "type_id": 628,
+        "kind": "T1",
+        "faction": "T1",
+    },
+    {
+        "name": "Augoror Navy Issue",
+        "type_id": 29337,
+        "kind": "Navy",
+        "faction": "Amarr",
+    },
+    {
+        "name": "Maller",
+        "type_id": 624,
+        "kind": "T1",
+        "faction": "T1",
+    },
+    {
+        "name": "Omen",
+        "type_id": 2006,
+        "kind": "T1",
+        "faction": "T1",
+    },
+    {
+        "name": "Omen Navy Issue",
+        "type_id": 17709,
+        "kind": "Navy",
+        "faction": "Amarr",
+    },
+    {
+        "name": "Caracal Navy Issue",
+        "type_id": 17634,
+        "kind": "Navy",
+        "faction": "Caldari",
+    },
+    {
+        "name": "Osprey Navy Issue",
+        "type_id": 29340,
+        "kind": "Navy",
+        "faction": "Caldari",
+    },
+    {
+        "name": "Exequror Navy Issue",
+        "type_id": 29344,
+        "kind": "Navy",
+        "faction": "Gallente",
+    },
+    {
+        "name": "Vexor",
+        "type_id": 627,
+        "kind": "T1",
+        "faction": "T1",
+    },
+    {
+        "name": "Vexor Navy Issue",
+        "type_id": 17843,
+        "kind": "Navy",
+        "faction": "Gallente",
+    },
+    {
+        "name": "Bellicose",
+        "type_id": 630,
+        "kind": "T1",
+        "faction": "T1",
+    },
+    {
+        "name": "Scythe Fleet Issue",
+        "type_id": 29336,
+        "kind": "Navy",
+        "faction": "Minmatar",
+    },
+    {
+        "name": "Stabber",
+        "type_id": 622,
+        "kind": "T1",
+        "faction": "T1",
+    },
+    {
+        "name": "Stabber Fleet Issue",
+        "type_id": 17713,
+        "kind": "Navy",
+        "faction": "Minmatar",
+    },
+)
+
+# Explicitly cut even if they would pass the profit filter.
+EXPLICIT_CUT_TYPE_IDS = frozenset(
+    {
+        32874,  # Dragoon
+        16242,  # Thrasher
+        2006,  # Omen
+        624,  # Maller
+        598,  # Breacher
+    }
+)
+
+
+@dataclass
+class GuideOrderRow:
+    name: str
+    type_id: int
+    kind: str
+    faction: str
+    isk_per_lp: Optional[float]
+    cost_per: int
+    jita_sell: int
+    profit_per: int
+    order_profit: int
+    note: Optional[str] = None
+
+
+def default_frontend_module_path() -> Path:
+    root = Path(settings.BASE_DIR).resolve().parent
+    return (
+        root
+        / "frontend"
+        / "app"
+        / "src"
+        / "data"
+        / "industry"
+        / "guide-order-summary.ts"
+    )
+
+
+def _isk_per_lp_for_faction(
+    faction: str,
+    *,
+    lp_rates: Dict[str, float],
+    use_production_lp: bool,
+    corporation_id: Optional[int],
+) -> Optional[float]:
+    if faction == "T1":
+        return None
+    if use_production_lp:
+        return resolve_isk_per_lp(
+            requested=None, corporation_id=corporation_id
+        )
+    return float(lp_rates.get(faction, 1000.0))
+
+
+def _plan_product(
+    product_type_id: int,
+    *,
+    quantity: int,
+    facility: str,
+) -> Any:
+    eve_type = EveType.objects.filter(id=product_type_id).first()
+    if eve_type is None:
+        raise ValueError(f"Unknown product_type_id {product_type_id}")
+    me_pct, te_pct = default_blueprint_me_te_percent(eve_type)
+    return plan_build(
+        eve_type,
+        quantity=quantity,
+        blueprint_me=me_pct / 100.0,
+        blueprint_te=te_pct / 100.0,
+        facility=facility,
+    )
+
+
+def _compressed_cost(
+    plan,
+    *,
+    facility: str,
+    navy_bpc_isk: int,
+) -> int:
+    refine = resolve_refine_rate(
+        facility,
+        character=None,
+        use_reprocessing_implants=False,
+    )[0]
+    materials = {name: qty for _, (name, qty) in plan.leaf_materials.items()}
+    ore_plan = build_compressed_ore_plan(
+        materials,
+        refine_rate=refine,
+        reprocessing_tax=get_facility_reprocessing_tax(facility),
+    )
+    breakdown = build_plan_cost_breakdown(
+        plan,
+        compressed_ore=ore_plan,
+        navy_bpc_isk=navy_bpc_isk,
+    )
+    return int(breakdown.grand_total_isk)
+
+
+def _navy_bpc_isk(
+    *,
+    product_type_id: int,
+    bpc_type_id: Optional[int],
+    quantity: int,
+    isk_per_lp: Optional[float],
+) -> Tuple[int, Optional[float], Optional[int]]:
+    """Return (navy_bpc_isk, effective_isk_per_lp, corporation_id)."""
+    if isk_per_lp is None or float(isk_per_lp) <= 0:
+        return 0, None, None
+
+    blueprint_type_id = bpc_type_id
+    if blueprint_type_id is None:
+        eve_type = EveType.objects.filter(id=product_type_id).first()
+        if eve_type is None or not is_faction_navy_hull(eve_type):
+            return 0, None, None
+        blueprint_type_id = get_blueprint_or_reaction_type_id(eve_type)
+
+    if blueprint_type_id is None:
+        return 0, None, None
+
+    offer = get_offer_for_blueprint_type(int(blueprint_type_id))
+    corp_id = offer.corporation_id if offer is not None else None
+    rate = resolve_isk_per_lp(requested=isk_per_lp, corporation_id=corp_id)
+    if rate is None:
+        return 0, None, corp_id
+
+    cost = navy_bpc_cost_for_plan(
+        int(blueprint_type_id), quantity, float(rate)
+    )
+    if cost is None:
+        return 0, float(rate), corp_id
+    return int(cost.total_isk), float(rate), corp_id
+
+
+def _resolve_requested_isk_per_lp(
+    candidate: Dict[str, Any],
+    *,
+    lp_rates: Dict[str, float],
+    use_production_lp: bool,
+) -> Optional[float]:
+    faction = candidate["faction"]
+    if faction == "T1":
+        return None
+    if not use_production_lp:
+        return float(lp_rates.get(faction, 1000.0))
+
+    type_id = int(candidate["type_id"])
+    bpc_type_id = candidate.get("bpc_type_id")
+    blueprint_type_id = int(bpc_type_id) if bpc_type_id else None
+    if blueprint_type_id is None:
+        eve_type = EveType.objects.filter(id=type_id).first()
+        if eve_type is not None:
+            blueprint_type_id = get_blueprint_or_reaction_type_id(eve_type)
+    corp_id = None
+    if blueprint_type_id is not None:
+        offer = get_offer_for_blueprint_type(int(blueprint_type_id))
+        corp_id = offer.corporation_id if offer is not None else None
+    return _isk_per_lp_for_faction(
+        faction,
+        lp_rates=lp_rates,
+        use_production_lp=True,
+        corporation_id=corp_id,
+    )
+
+
+def compute_row(
+    candidate: Dict[str, Any],
+    *,
+    quantity: int = ORDER_QTY,
+    facility: str = FACILITY_KEY,
+    lp_rates: Optional[Dict[str, float]] = None,
+    use_production_lp: bool = False,
+    sell_prices: Optional[Dict[int, int]] = None,
+) -> GuideOrderRow:
+    rates = lp_rates or DEFAULT_LP_RATES
+    type_id = int(candidate["type_id"])
+    bom_type_id = int(candidate.get("bom_proxy_type_id") or type_id)
+    bpc_type_id = candidate.get("bpc_type_id")
+    faction = candidate["faction"]
+
+    requested_lp = _resolve_requested_isk_per_lp(
+        candidate,
+        lp_rates=rates,
+        use_production_lp=use_production_lp,
+    )
+    navy_isk, effective_lp = _navy_bpc_isk(
+        product_type_id=type_id,
+        bpc_type_id=int(bpc_type_id) if bpc_type_id else None,
+        quantity=1,
+        isk_per_lp=requested_lp,
+    )[:2]
+
+    plan = _plan_product(bom_type_id, quantity=1, facility=facility)
+    cost_per = _compressed_cost(plan, facility=facility, navy_bpc_isk=navy_isk)
+
+    prices = sell_prices or jita_sell_prices_by_type_id([type_id])
+    jita_sell = int(prices.get(type_id) or 0)
+    profit_per = jita_sell - cost_per
+    order_profit = profit_per * quantity
+
+    return GuideOrderRow(
+        name=str(candidate["name"]),
+        type_id=type_id,
+        kind=str(candidate["kind"]),
+        faction=str(faction),
+        isk_per_lp=float(effective_lp) if effective_lp is not None else None,
+        cost_per=cost_per,
+        jita_sell=jita_sell,
+        profit_per=profit_per,
+        order_profit=order_profit,
+        note=candidate.get("note"),
+    )
+
+
+def compute_kept_rows(
+    *,
+    quantity: int = ORDER_QTY,
+    facility: str = FACILITY_KEY,
+    min_order_profit: int = MIN_ORDER_PROFIT_ISK,
+    lp_rates: Optional[Dict[str, float]] = None,
+    use_production_lp: bool = False,
+    candidates: Sequence[Dict[str, Any]] = GUIDE_HULL_CANDIDATES,
+) -> List[GuideOrderRow]:
+    type_ids = [int(c["type_id"]) for c in candidates]
+    sell_prices = jita_sell_prices_by_type_id(type_ids)
+    kept: List[GuideOrderRow] = []
+    for candidate in candidates:
+        type_id = int(candidate["type_id"])
+        if type_id in EXPLICIT_CUT_TYPE_IDS:
+            continue
+        row = compute_row(
+            candidate,
+            quantity=quantity,
+            facility=facility,
+            lp_rates=lp_rates,
+            use_production_lp=use_production_lp,
+            sell_prices=sell_prices,
+        )
+        if row.order_profit >= min_order_profit:
+            kept.append(row)
+    return kept
+
+
+def _ts_number(n: int) -> str:
+    return f"{n:_}"
+
+
+def _format_as_of(d: date) -> str:
+    # e.g. 22 Jul 2026
+    return d.strftime("%-d %b %Y")
+
+
+def render_typescript_module(
+    rows: Sequence[GuideOrderRow],
+    *,
+    as_of: Optional[date] = None,
+    quantity: int = ORDER_QTY,
+    min_order_profit: int = MIN_ORDER_PROFIT_ISK,
+    lp_rates: Optional[Dict[str, float]] = None,
+) -> str:
+    rates = lp_rates or DEFAULT_LP_RATES
+    as_of = as_of or date.today()
+    as_of_str = _format_as_of(as_of)
+
+    row_blocks = []
+    for r in rows:
+        note_line = f",\n        note: {r.note!r}," if r.note else ","
+        isk_lp = "null" if r.isk_per_lp is None else str(int(r.isk_per_lp))
+        row_blocks.append(f"""    {{
+        name: {r.name!r},
+        typeId: {r.type_id},
+        kind: {r.kind!r},
+        faction: {r.faction!r},
+        iskPerLp: {isk_lp},
+        costPer: {_ts_number(r.cost_per)},
+        jitaSell: {_ts_number(r.jita_sell)},
+        profitPer: {_ts_number(r.profit_per)},
+        orderProfit: {_ts_number(r.order_profit)}{note_line}
+    }}""")
+    rows_joined = ",\n".join(row_blocks)
+
+    assumptions = (
+        "Qty ${ORDER_QTY} per hull. Navy BPCs ME0/TE0 from FW LP store "
+        "(Minmatar ${LP_RATES.Minmatar}, Caldari ${LP_RATES.Caldari}, "
+        "Amarr ${LP_RATES.Amarr}, Gallente ${LP_RATES.Gallente} ISK/LP). "
+        "T1 assumes researched ME10/TE20 BPO (no LP). Amamake Sotiyo + Tatara "
+        "compressed-ore shopping, Jita to Amamake freight, revenue = Jita sell "
+        "x ${ORDER_QTY} (no broker/sales tax). Talwar FI uses the same navy "
+        "destroyer BOM."
+    )
+
+    return f"""/**
+ * Guide hull manufacturing order summary (static report).
+ *
+ * Baked from Amamake compressed-ore planner + Jita sell · qty {quantity} · {min_order_profit // 1_000_000}M+ x{quantity} filter.
+ * Refresh: `pipenv run python manage.py export_guide_order_summary`
+ *
+ * As-of: {as_of_str}
+ */
+
+export const AS_OF_DATE = {as_of_str!r}
+export const ORDER_QTY = {quantity}
+export const MIN_ORDER_PROFIT_ISK = {_ts_number(min_order_profit)}
+export const FACILITY_KEY = {FACILITY_KEY!r}
+
+/** ISK/LP used when this snapshot was baked (not necessarily live production defaults). */
+export const LP_RATES = {{
+    Minmatar: {int(rates["Minmatar"])},
+    Caldari: {int(rates["Caldari"])},
+    Amarr: {int(rates["Amarr"])},
+    Gallente: {int(rates["Gallente"])},
+}} as const
+
+export type GuideOrderHullKind = 'Navy' | 'T1'
+export type GuideOrderFaction =
+    | 'Amarr'
+    | 'Caldari'
+    | 'Gallente'
+    | 'Minmatar'
+    | 'T1'
+
+export type GuideOrderRow = {{
+    name: string
+    typeId: number
+    kind: GuideOrderHullKind
+    faction: GuideOrderFaction
+    iskPerLp: number | null
+    costPer: number
+    jitaSell: number
+    profitPer: number
+    orderProfit: number
+    note?: string
+}}
+
+export type GuideOrderTableTone = 'info' | 'success' | 'warning' | 'danger'
+
+export type GuideOrderTableRow = {{
+    cells: readonly string[]
+    tone?: GuideOrderTableTone
+}}
+
+/** Kept lines only (explicit cuts + under {min_order_profit // 1_000_000}M x{quantity} removed). */
+export const GUIDE_ORDER_ROWS: readonly GuideOrderRow[] = [
+{rows_joined},
+]
+
+export const CUTS_APPLIED =
+    {CUTS_APPLIED!r}
+
+export const ASSUMPTIONS_TEXT =
+    `{assumptions}`
+
+export function formatIskCompact(isk: number): string {{
+    const abs = Math.abs(isk)
+    const sign = isk < 0 ? '-' : ''
+    if (abs >= 1_000_000_000) {{
+        return `${{sign}}${{(abs / 1_000_000_000).toFixed(2)}}B`
+    }}
+    if (abs >= 1_000_000) {{
+        return `${{sign}}${{(abs / 1_000_000).toFixed(2)}}M`
+    }}
+    if (abs >= 1_000) {{
+        return `${{sign}}${{(abs / 1_000).toFixed(0)}}k`
+    }}
+    return `${{sign}}${{abs.toFixed(0)}}`
+}}
+
+export function formatIskFull(isk: number): string {{
+    return Math.round(isk).toLocaleString('en-US')
+}}
+
+export function shortHullName(name: string): string {{
+    return name
+        .replace(' Navy Issue', ' NI')
+        .replace(' Fleet Issue', ' FI')
+        .replace('Caldari Navy ', '')
+        .replace('Federation Navy ', '')
+        .replace('Imperial Navy ', '')
+        .replace('Republic Fleet ', '')
+}}
+
+export function rowTone(orderProfit: number): GuideOrderTableTone {{
+    if (orderProfit >= 100_000_000) return 'success'
+    if (orderProfit >= MIN_ORDER_PROFIT_ISK) return 'info'
+    return 'danger'
+}}
+
+export function sortedByOrderProfit(
+    rows: readonly GuideOrderRow[] = GUIDE_ORDER_ROWS,
+): GuideOrderRow[] {{
+    return [...rows].sort((a, b) => b.orderProfit - a.orderProfit)
+}}
+
+export function orderTotals(rows: readonly GuideOrderRow[] = GUIDE_ORDER_ROWS) {{
+    const totalProfit = rows.reduce((sum, r) => sum + r.orderProfit, 0)
+    const navyRows = rows.filter((r) => r.kind === 'Navy')
+    const t1Rows = rows.filter((r) => r.kind === 'T1')
+    const sorted = sortedByOrderProfit(rows)
+    return {{
+        totalProfit,
+        hullCount: rows.length,
+        navyCount: navyRows.length,
+        t1Count: t1Rows.length,
+        navyProfit: navyRows.reduce((sum, r) => sum + r.orderProfit, 0),
+        t1Profit: t1Rows.reduce((sum, r) => sum + r.orderProfit, 0),
+        best: sorted[0],
+        worst: sorted[sorted.length - 1],
+        sorted,
+    }}
+}}
+
+export function keptOrderTableRows(
+    rows: readonly GuideOrderRow[] = GUIDE_ORDER_ROWS,
+): GuideOrderTableRow[] {{
+    return rows.map((r) => ({{
+        cells: [
+            r.note ? `${{r.name}}*` : r.name,
+            r.iskPerLp == null ? '-' : String(r.iskPerLp),
+            formatIskCompact(r.costPer),
+            formatIskCompact(r.jitaSell),
+            formatIskFull(r.profitPer),
+            formatIskCompact(r.orderProfit),
+        ] as const,
+        tone: rowTone(r.orderProfit),
+    }}))
+}}
+"""
+
+
+def write_frontend_module(
+    rows: Sequence[GuideOrderRow],
+    *,
+    path: Optional[Path] = None,
+    as_of: Optional[date] = None,
+    quantity: int = ORDER_QTY,
+    min_order_profit: int = MIN_ORDER_PROFIT_ISK,
+    lp_rates: Optional[Dict[str, float]] = None,
+) -> Path:
+    out = path or default_frontend_module_path()
+    out.parent.mkdir(parents=True, exist_ok=True)
+    content = render_typescript_module(
+        rows,
+        as_of=as_of,
+        quantity=quantity,
+        min_order_profit=min_order_profit,
+        lp_rates=lp_rates,
+    )
+    out.write_text(content, encoding="utf-8")
+    return out

--- a/backend/industry/helpers/orders_profit_summary.py
+++ b/backend/industry/helpers/orders_profit_summary.py
@@ -1,0 +1,329 @@
+"""
+Roll up open (or filtered) industry orders into canvas-style profit rows.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Dict, List, Optional, Sequence, Set
+
+from django.db.models import Prefetch, QuerySet
+
+from industry.helpers.discord_summary_display import order_location_short_label
+from industry.helpers.cost_breakdown import jita_sell_prices_by_type_id
+from industry.helpers.facility_api import FACILITY_SYSTEM_NAMES
+from industry.helpers.facility_profiles import FACILITY_PROFILES
+from industry.helpers.product_unit_cost import (
+    FACILITY_KEY,
+    ProductUnitCost,
+    plan_product_unit_cost,
+)
+from industry.models import IndustryOrder, IndustryOrderItem
+
+
+@dataclass(frozen=True)
+class ProfitSummaryOrder:
+    id: int
+    public_short_code: str
+    needed_by: date
+    location_label: str
+    fulfilled_at: Optional[date]
+    item_count: int
+    item_type_ids: List[int]
+    included: bool
+
+
+@dataclass(frozen=True)
+class ProfitSummaryRow:
+    name: str
+    type_id: int
+    kind: str
+    qty: int
+    isk_per_lp: Optional[float]
+    cost_per: int
+    unit_price: int
+    price_source: str  # "ask" | "jita" | "mixed"
+    profit_per: int
+    order_profit: int
+    note: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ProfitSummaryTotals:
+    total_order_amount: int
+    total_profit: int
+    line_count: int
+    total_qty: int
+    best_name: Optional[str]
+    best_profit: Optional[int]
+    worst_name: Optional[str]
+    worst_profit: Optional[int]
+
+
+@dataclass(frozen=True)
+class OrdersProfitSummary:
+    orders: List[ProfitSummaryOrder]
+    rows: List[ProfitSummaryRow]
+    totals: ProfitSummaryTotals
+    assumptions: List[str]
+    facility_key: str
+    compressed: bool
+
+
+def _parse_order_ids(raw: Optional[str | Sequence[int]]) -> Optional[Set[int]]:
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        parts = [p.strip() for p in raw.split(",") if p.strip()]
+        if not parts:
+            return set()
+        return {int(p) for p in parts}
+    return {int(x) for x in raw}
+
+
+def filter_orders_queryset(
+    *,
+    needed_by_from: Optional[date] = None,
+    needed_by_to: Optional[date] = None,
+    open_only: bool = True,
+) -> QuerySet:
+    qs = IndustryOrder.objects.all().select_related("location")
+    if open_only:
+        qs = qs.filter(fulfilled_at__isnull=True)
+    if needed_by_from is not None:
+        qs = qs.filter(needed_by__gte=needed_by_from)
+    if needed_by_to is not None:
+        qs = qs.filter(needed_by__lte=needed_by_to)
+    return qs.order_by("needed_by", "pk")
+
+
+def _line_ask_isk(item: IndustryOrderItem) -> Optional[int]:
+    """Order-item ask, else first assignment ask (same precedence as list API)."""
+    unit = item.target_unit_price
+    if unit is None:
+        for assignment in item.assignments.all():
+            if assignment.target_unit_price is not None:
+                unit = assignment.target_unit_price
+                break
+    if unit is None:
+        return None
+    return int(Decimal(unit))
+
+
+def build_orders_profit_summary(  # noqa: C901
+    *,
+    needed_by_from: Optional[date] = None,
+    needed_by_to: Optional[date] = None,
+    open_only: bool = True,
+    order_ids: Optional[str | Sequence[int]] = None,
+    facility_key: str = FACILITY_KEY,
+    compressed: bool = True,
+) -> OrdersProfitSummary:
+    key = (facility_key or FACILITY_KEY).lower().strip()
+    if key not in FACILITY_PROFILES:
+        raise ValueError(f"Unknown facility {facility_key!r}")
+
+    included_ids = _parse_order_ids(order_ids)
+    candidates = list(
+        filter_orders_queryset(
+            needed_by_from=needed_by_from,
+            needed_by_to=needed_by_to,
+            open_only=open_only,
+        ).prefetch_related(
+            Prefetch(
+                "items",
+                queryset=IndustryOrderItem.objects.select_related(
+                    "eve_type"
+                ).prefetch_related("assignments"),
+            )
+        )
+    )
+
+    order_summaries: List[ProfitSummaryOrder] = []
+    selected: List[IndustryOrder] = []
+    for order in candidates:
+        items = list(order.items.all())
+        item_type_ids = [int(item.eve_type_id) for item in items]
+        included = included_ids is None or order.pk in included_ids
+        fulfilled = (
+            order.fulfilled_at.date()
+            if order.fulfilled_at is not None
+            else None
+        )
+        order_summaries.append(
+            ProfitSummaryOrder(
+                id=order.pk,
+                public_short_code=order.public_short_code,
+                needed_by=order.needed_by,
+                location_label=order_location_short_label(order),
+                fulfilled_at=fulfilled,
+                item_count=len(items),
+                item_type_ids=item_type_ids,
+                included=included,
+            )
+        )
+        if included:
+            selected.append(order)
+
+    qty_by_type: Dict[int, int] = {}
+    name_by_type: Dict[int, str] = {}
+    claim_qty_by_type: Dict[int, int] = {}
+    ask_revenue_by_type: Dict[int, int] = {}
+    ask_qty_by_type: Dict[int, int] = {}
+    missing_ask_qty_by_type: Dict[int, int] = {}
+
+    for order in selected:
+        for item in order.items.all():
+            tid = int(item.eve_type_id)
+            qty = int(item.quantity)
+            qty_by_type[tid] = qty_by_type.get(tid, 0) + qty
+            name_by_type[tid] = item.eve_type.name
+            claim = (
+                int(item.self_assign_maximum)
+                if item.self_assign_maximum is not None
+                else qty
+            )
+            claim = max(claim, 1)
+            claim_qty_by_type[tid] = max(claim_qty_by_type.get(tid, 0), claim)
+            ask = _line_ask_isk(item)
+            if ask is not None and ask > 0:
+                ask_revenue_by_type[tid] = (
+                    ask_revenue_by_type.get(tid, 0) + ask * qty
+                )
+                ask_qty_by_type[tid] = ask_qty_by_type.get(tid, 0) + qty
+            else:
+                missing_ask_qty_by_type[tid] = (
+                    missing_ask_qty_by_type.get(tid, 0) + qty
+                )
+
+    type_ids = sorted(qty_by_type.keys())
+    jita_prices = jita_sell_prices_by_type_id(type_ids) if type_ids else {}
+
+    rows: List[ProfitSummaryRow] = []
+    for tid in type_ids:
+        qty = qty_by_type[tid]
+        claim_qty = claim_qty_by_type.get(tid) or qty
+        ask_qty = ask_qty_by_type.get(tid, 0)
+        missing_qty = missing_ask_qty_by_type.get(tid, 0)
+        jita = int(jita_prices.get(tid) or 0)
+        revenue = ask_revenue_by_type.get(tid, 0) + jita * missing_qty
+        unit_price = int(round(revenue / qty)) if qty else 0
+        if ask_qty > 0 and missing_qty == 0:
+            price_source = "ask"
+        elif ask_qty == 0:
+            price_source = "jita"
+        else:
+            price_source = "mixed"
+
+        try:
+            unit: ProductUnitCost = plan_product_unit_cost(
+                tid,
+                quantity=claim_qty,
+                facility=key,
+                compressed=compressed,
+                use_production_lp=True,
+                sell_prices=jita_prices,
+            )
+            cost_per = unit.cost_per
+            kind = unit.kind
+            isk_per_lp = unit.isk_per_lp
+            name = unit.name or name_by_type.get(tid, str(tid))
+            note = unit.note
+        except Exception as exc:
+            cost_per = 0
+            kind = "T1"
+            isk_per_lp = None
+            name = name_by_type.get(tid, str(tid))
+            note = f"Plan failed: {exc}"
+
+        profit_per = unit_price - cost_per
+        order_profit = profit_per * qty
+        if price_source == "jita":
+            extra = "Ask missing — used Jita sell"
+            note = f"{note}; {extra}" if note else extra
+        elif price_source == "mixed":
+            extra = "Mixed ask + Jita sell"
+            note = f"{note}; {extra}" if note else extra
+
+        rows.append(
+            ProfitSummaryRow(
+                name=name,
+                type_id=tid,
+                kind=kind,
+                qty=qty,
+                isk_per_lp=isk_per_lp,
+                cost_per=cost_per,
+                unit_price=unit_price,
+                price_source=price_source,
+                profit_per=profit_per,
+                order_profit=order_profit,
+                note=note,
+            )
+        )
+
+    rows.sort(key=lambda r: -r.order_profit)
+
+    if rows:
+        best = rows[0]
+        worst = rows[-1]
+        totals = ProfitSummaryTotals(
+            total_order_amount=sum(r.unit_price * r.qty for r in rows),
+            total_profit=sum(r.order_profit for r in rows),
+            line_count=len(rows),
+            total_qty=sum(r.qty for r in rows),
+            best_name=best.name,
+            best_profit=best.order_profit,
+            worst_name=worst.name,
+            worst_profit=worst.order_profit,
+        )
+    else:
+        totals = ProfitSummaryTotals(
+            total_order_amount=0,
+            total_profit=0,
+            line_count=0,
+            total_qty=0,
+            best_name=None,
+            best_profit=None,
+            worst_name=None,
+            worst_profit=None,
+        )
+
+    system_name = FACILITY_SYSTEM_NAMES.get(key, key.title())
+    if compressed:
+        shopping = f"Build costs use compressed ore shopping at {system_name}."
+    else:
+        shopping = (
+            f"Build costs use mineral shopping at {system_name} "
+            "(not compressed ore)."
+        )
+    assumptions = [
+        shopping,
+        (
+            "Navy blueprint copies are ME 0 / TE 0 from the faction warfare "
+            "LP store, priced with the alliance default ISK per LP rates."
+        ),
+        (
+            "Tech 1 ships assume a researched ME 10 / TE 20 blueprint "
+            "(no LP cost)."
+        ),
+        (
+            "Each product's build cost is planned at its maximum claim size "
+            "so ore buying matches how industrialists claim work."
+        ),
+        ("Revenue uses the order ask price when set; otherwise Jita sell."),
+        (
+            "Quantities from included orders are added together for each "
+            "product."
+        ),
+    ]
+
+    return OrdersProfitSummary(
+        orders=order_summaries,
+        rows=rows,
+        totals=totals,
+        assumptions=assumptions,
+        facility_key=key,
+        compressed=compressed,
+    )

--- a/backend/industry/helpers/product_unit_cost.py
+++ b/backend/industry/helpers/product_unit_cost.py
@@ -1,0 +1,231 @@
+"""
+Per-product unit build cost at a facility (Amamake compressed ore + navy BPC).
+
+Shared by guide-order export and open-orders profit-summary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+from eveuniverse.models import EveType
+
+from industry.helpers.blueprint_efficiency import (
+    default_blueprint_me_te_percent,
+    is_faction_navy_hull,
+)
+from industry.helpers.build_planner import plan_build
+from industry.helpers.compressed_ore import build_compressed_ore_plan
+from industry.helpers.cost_breakdown import (
+    build_plan_cost_breakdown,
+    jita_sell_prices_by_type_id,
+)
+from industry.helpers.facility_profiles import get_facility_reprocessing_tax
+from industry.helpers.loyalty_store import (
+    get_offer_for_blueprint_type,
+    navy_bpc_cost_for_plan,
+    resolve_isk_per_lp,
+)
+from industry.helpers.reprocessing_skills import resolve_refine_rate
+from industry.helpers.type_breakdown import get_blueprint_or_reaction_type_id
+
+FACILITY_KEY = "amamake"
+
+# Talwar FI: local SDE may lack BP; BOM matches other navy destroyers.
+TALWAR_FI_TYPE_ID = 91858
+TALWAR_FI_BPC_TYPE_ID = 91862
+TALWAR_FI_BOM_PROXY_TYPE_ID = 73796  # Catalyst Navy Issue
+
+
+@dataclass(frozen=True)
+class ProductUnitCost:
+    type_id: int
+    name: str
+    kind: str  # "Navy" | "T1"
+    cost_per: int
+    jita_sell: int
+    profit_per: int
+    isk_per_lp: Optional[float]
+    note: Optional[str] = None
+
+
+def bom_and_bpc_overrides(
+    type_id: int,
+) -> Tuple[int, Optional[int], Optional[str]]:
+    """Return (bom_type_id, bpc_type_id, note) for known SDE gaps."""
+    if int(type_id) == TALWAR_FI_TYPE_ID:
+        return (
+            TALWAR_FI_BOM_PROXY_TYPE_ID,
+            TALWAR_FI_BPC_TYPE_ID,
+            "BOM proxied (identical navy destroyer recipe)",
+        )
+    return int(type_id), None, None
+
+
+def plan_product(
+    product_type_id: int,
+    *,
+    quantity: int = 1,
+    facility: str = FACILITY_KEY,
+):
+    eve_type = EveType.objects.filter(id=product_type_id).first()
+    if eve_type is None:
+        raise ValueError(f"Unknown product_type_id {product_type_id}")
+    me_pct, te_pct = default_blueprint_me_te_percent(eve_type)
+    return plan_build(
+        eve_type,
+        quantity=quantity,
+        blueprint_me=me_pct / 100.0,
+        blueprint_te=te_pct / 100.0,
+        facility=facility,
+    )
+
+
+def compressed_total_isk(plan, *, facility: str, navy_bpc_isk: int) -> int:
+    refine = resolve_refine_rate(
+        facility,
+        character=None,
+        use_reprocessing_implants=False,
+    )[0]
+    materials = {name: qty for _, (name, qty) in plan.leaf_materials.items()}
+    ore_plan = build_compressed_ore_plan(
+        materials,
+        refine_rate=refine,
+        reprocessing_tax=get_facility_reprocessing_tax(facility),
+    )
+    breakdown = build_plan_cost_breakdown(
+        plan,
+        compressed_ore=ore_plan,
+        navy_bpc_isk=navy_bpc_isk,
+    )
+    return int(breakdown.grand_total_isk)
+
+
+def uncompressed_total_isk(plan, *, navy_bpc_isk: int) -> int:
+    breakdown = build_plan_cost_breakdown(
+        plan,
+        compressed_ore=None,
+        navy_bpc_isk=navy_bpc_isk,
+    )
+    return int(breakdown.grand_total_isk)
+
+
+def navy_bpc_isk_for_product(
+    *,
+    product_type_id: int,
+    bpc_type_id: Optional[int],
+    quantity: int,
+    isk_per_lp: Optional[float],
+) -> Tuple[int, Optional[float]]:
+    """Return (navy_bpc_isk, effective_isk_per_lp)."""
+    blueprint_type_id = bpc_type_id
+    if blueprint_type_id is None:
+        eve_type = EveType.objects.filter(id=product_type_id).first()
+        if eve_type is None or not is_faction_navy_hull(eve_type):
+            return 0, None
+        blueprint_type_id = get_blueprint_or_reaction_type_id(eve_type)
+
+    if blueprint_type_id is None:
+        return 0, None
+
+    offer = get_offer_for_blueprint_type(int(blueprint_type_id))
+    corp_id = offer.corporation_id if offer is not None else None
+    rate = resolve_isk_per_lp(requested=isk_per_lp, corporation_id=corp_id)
+    if rate is None:
+        return 0, None
+
+    cost = navy_bpc_cost_for_plan(
+        int(blueprint_type_id), quantity, float(rate)
+    )
+    if cost is None:
+        return 0, float(rate)
+    return int(cost.total_isk), float(rate)
+
+
+def resolve_production_isk_per_lp(
+    product_type_id: int,
+    *,
+    bpc_type_id: Optional[int] = None,
+) -> Optional[float]:
+    blueprint_type_id = bpc_type_id
+    if blueprint_type_id is None:
+        eve_type = EveType.objects.filter(id=product_type_id).first()
+        if eve_type is None:
+            return None
+        blueprint_type_id = get_blueprint_or_reaction_type_id(eve_type)
+    if blueprint_type_id is None:
+        return None
+    offer = get_offer_for_blueprint_type(int(blueprint_type_id))
+    corp_id = offer.corporation_id if offer is not None else None
+    return resolve_isk_per_lp(requested=None, corporation_id=corp_id)
+
+
+def plan_product_unit_cost(
+    type_id: int,
+    *,
+    quantity: int = 1,
+    facility: str = FACILITY_KEY,
+    compressed: bool = True,
+    isk_per_lp: Optional[float] = None,
+    use_production_lp: bool = True,
+    sell_prices: Optional[Dict[int, int]] = None,
+) -> ProductUnitCost:
+    """
+    Unit build cost + Jita sell for one product.
+
+    Plans a lot of ``quantity`` (e.g. max claim size) then returns per-unit cost,
+    so compressed-ore shopping matches how industrialists actually claim.
+
+    When ``use_production_lp`` is True and ``isk_per_lp`` is None, uses
+    IndustryLoyaltyPoint defaults for the product's LP corp.
+    """
+    type_id = int(type_id)
+    batch = max(int(quantity), 1)
+    eve_type = EveType.objects.filter(id=type_id).first()
+    if eve_type is None:
+        raise ValueError(f"Unknown product_type_id {type_id}")
+
+    bom_type_id, bpc_override, note = bom_and_bpc_overrides(type_id)
+    is_navy = is_faction_navy_hull(eve_type)
+    kind = "Navy" if is_navy else "T1"
+
+    requested_lp: Optional[float] = None
+    if is_navy:
+        if isk_per_lp is not None and float(isk_per_lp) > 0:
+            requested_lp = float(isk_per_lp)
+        elif use_production_lp:
+            requested_lp = resolve_production_isk_per_lp(
+                type_id, bpc_type_id=bpc_override
+            )
+
+    navy_isk, effective_lp = navy_bpc_isk_for_product(
+        product_type_id=type_id,
+        bpc_type_id=bpc_override,
+        quantity=batch,
+        isk_per_lp=requested_lp,
+    )
+
+    plan = plan_product(bom_type_id, quantity=batch, facility=facility)
+    if compressed:
+        batch_total = compressed_total_isk(
+            plan, facility=facility, navy_bpc_isk=navy_isk
+        )
+    else:
+        batch_total = uncompressed_total_isk(plan, navy_bpc_isk=navy_isk)
+    cost_per = int(round(batch_total / batch))
+
+    prices = sell_prices or jita_sell_prices_by_type_id([type_id])
+    jita_sell = int(prices.get(type_id) or 0)
+    profit_per = jita_sell - cost_per
+
+    return ProductUnitCost(
+        type_id=type_id,
+        name=eve_type.name or str(type_id),
+        kind=kind,
+        cost_per=cost_per,
+        jita_sell=jita_sell,
+        profit_per=profit_per,
+        isk_per_lp=effective_lp if is_navy else None,
+        note=note,
+    )

--- a/backend/industry/management/commands/export_guide_order_summary.py
+++ b/backend/industry/management/commands/export_guide_order_summary.py
@@ -1,0 +1,129 @@
+"""
+Re-run Amamake compressed-ore planner + Jita sell and rewrite the frontend
+guide-order-summary data module.
+
+Examples:
+
+    pipenv run python manage.py export_guide_order_summary
+    pipenv run python manage.py export_guide_order_summary --dry-run
+    pipenv run python manage.py export_guide_order_summary --use-production-lp
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from django.core.management.base import BaseCommand, CommandError
+
+from industry.helpers.guide_order_summary_export import (
+    DEFAULT_LP_RATES,
+    FACILITY_KEY,
+    MIN_ORDER_PROFIT_ISK,
+    ORDER_QTY,
+    compute_kept_rows,
+    default_frontend_module_path,
+    write_frontend_module,
+)
+
+
+class Command(BaseCommand):
+    help = (
+        "Plan guide hulls at Amamake (compressed ore), price finished hulls "
+        "at Jita sell, and rewrite frontend guide-order-summary.ts."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--output",
+            default="",
+            help=(
+                "Path to write the TypeScript module "
+                "(default: frontend/app/src/data/industry/guide-order-summary.ts)."
+            ),
+        )
+        parser.add_argument(
+            "--quantity",
+            type=int,
+            default=ORDER_QTY,
+            help=f"Order quantity per hull (default: {ORDER_QTY}).",
+        )
+        parser.add_argument(
+            "--min-order-profit",
+            type=int,
+            default=MIN_ORDER_PROFIT_ISK,
+            help=(
+                "Keep lines with x{qty} profit at or above this ISK "
+                f"(default: {MIN_ORDER_PROFIT_ISK})."
+            ),
+        )
+        parser.add_argument(
+            "--facility",
+            default=FACILITY_KEY,
+            help=f"Facility key (default: {FACILITY_KEY}).",
+        )
+        parser.add_argument(
+            "--use-production-lp",
+            action="store_true",
+            help=(
+                "Use IndustryLoyaltyPoint catalog defaults instead of the "
+                "baked snapshot rates (Minmatar 850 / Caldari 925 / …)."
+            ),
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print kept rows without writing the TypeScript module.",
+        )
+
+    def handle(self, *args, **options):
+        quantity = int(options["quantity"])
+        if quantity < 1:
+            raise CommandError("--quantity must be >= 1")
+
+        min_profit = int(options["min_order_profit"])
+        facility = str(options["facility"]).strip().lower()
+        use_production_lp = bool(options["use_production_lp"])
+        dry_run = bool(options["dry_run"])
+
+        self.stdout.write(
+            f"Planning guide hulls · facility={facility} · qty={quantity} · "
+            f"min_x{quantity}={min_profit:,} · "
+            f"lp={'production' if use_production_lp else 'snapshot'}…"
+        )
+
+        rows = compute_kept_rows(
+            quantity=quantity,
+            facility=facility,
+            min_order_profit=min_profit,
+            lp_rates=DEFAULT_LP_RATES,
+            use_production_lp=use_production_lp,
+        )
+
+        total = sum(r.order_profit for r in rows)
+        self.stdout.write(
+            f"Kept {len(rows)} hulls · total order profit {total:,}"
+        )
+        for row in sorted(rows, key=lambda r: -r.order_profit):
+            lp = "-" if row.isk_per_lp is None else f"{row.isk_per_lp:g}"
+            self.stdout.write(
+                f"  {row.name}\tprofit={row.order_profit:,}\t"
+                f"cost={row.cost_per:,}\tsell={row.jita_sell:,}\tlp={lp}"
+            )
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("Dry run — no file written."))
+            return
+
+        out = (
+            Path(options["output"])
+            if options["output"]
+            else default_frontend_module_path()
+        )
+        path = write_frontend_module(
+            rows,
+            path=out,
+            quantity=quantity,
+            min_order_profit=min_profit,
+            lp_rates=DEFAULT_LP_RATES,
+        )
+        self.stdout.write(self.style.SUCCESS(f"Wrote {path}"))

--- a/backend/industry/management/commands/seed_guide_hull_order.py
+++ b/backend/industry/management/commands/seed_guide_hull_order.py
@@ -1,0 +1,169 @@
+"""Seed an active industry order matching the guide-hull ×100 canvas."""
+
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
+from eveuniverse.models import EveType
+
+from eveonline.models import EveCharacter, EveLocation
+from industry.helpers.guide_order_summary_export import (
+    GUIDE_HULL_CANDIDATES,
+    MIN_ORDER_PROFIT_ISK,
+    ORDER_QTY,
+    EXPLICIT_CUT_TYPE_IDS,
+)
+from industry.models import IndustryOrderItem
+from industry.test_utils import create_industry_order
+
+# Kept guide lines (same set as frontend guide-order-summary.ts).
+# Ask prices match the canvas Jita sells used when the guide report was baked.
+KEPT_HULLS = (
+    (17619, 8_000_000),  # Caldari Navy Hookbill
+    (17841, 8_465_000),  # Federation Navy Comet
+    (17703, 10_000_000),  # Imperial Navy Slicer
+    (17812, 8_998_000),  # Republic Fleet Firetail
+    (37454, 11_490_000),  # Vigil Fleet Issue
+    (73789, 21_300_000),  # Coercer Navy Issue
+    (73794, 18_840_000),  # Thrasher Fleet Issue
+    (73795, 18_000_000),  # Cormorant Navy Issue
+    (91858, 19_522_645),  # Talwar Fleet Issue
+    (16236, 1_386_000),  # Coercer
+    (628, 9_198_000),  # Arbitrator
+    (29337, 43_560_000),  # Augoror Navy Issue
+    (17709, 44_230_000),  # Omen Navy Issue
+    (17634, 40_000_000),  # Caracal Navy Issue
+    (29340, 40_930_000),  # Osprey Navy Issue
+    (630, 11_790_000),  # Bellicose
+    (29336, 42_840_000),  # Scythe Fleet Issue
+    (622, 11_620_000),  # Stabber
+    (17713, 43_340_000),  # Stabber Fleet Issue
+)
+KEPT_TYPE_IDS = tuple(pair[0] for pair in KEPT_HULLS)
+
+
+class Command(BaseCommand):
+    help = (
+        "Seed an active industry order with the kept guide hulls "
+        f"(qty {ORDER_QTY} each) for open-orders profit summary demos."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--quantity",
+            type=int,
+            default=ORDER_QTY,
+            help=f"Quantity per hull (default {ORDER_QTY}).",
+        )
+        parser.add_argument(
+            "--character-id",
+            type=int,
+            default=None,
+            help="Eve character_id for the order owner (default: first character).",
+        )
+        parser.add_argument(
+            "--location-id",
+            type=int,
+            default=None,
+            help="EveLocation.location_id (default: Amamake if present).",
+        )
+        parser.add_argument(
+            "--include-cuts",
+            action="store_true",
+            help=(
+                "Include the full guide catalog except explicit cuts "
+                f"(still drops under-{MIN_ORDER_PROFIT_ISK // 1_000_000}M lines "
+                "only if you filter elsewhere; here adds all non-explicit candidates)."
+            ),
+        )
+
+    def handle(self, *args, **options):
+        qty = int(options["quantity"])
+        if qty < 1:
+            raise CommandError("quantity must be >= 1")
+
+        if options["include_cuts"]:
+            type_ids = [
+                int(c["type_id"])
+                for c in GUIDE_HULL_CANDIDATES
+                if int(c["type_id"]) not in EXPLICIT_CUT_TYPE_IDS
+            ]
+            ask_by_type = {tid: None for tid in type_ids}
+        else:
+            type_ids = [pair[0] for pair in KEPT_HULLS]
+            ask_by_type = dict(KEPT_HULLS)
+
+        types = {
+            tid: EveType.objects.filter(id=tid).first() for tid in type_ids
+        }
+        missing = [tid for tid, et in types.items() if et is None]
+        if missing:
+            raise CommandError(
+                f"Missing EveType rows: {missing}. Load SDE first."
+            )
+
+        character_id = options["character_id"]
+        if character_id is not None:
+            character = EveCharacter.objects.filter(
+                character_id=character_id
+            ).first()
+            if character is None:
+                raise CommandError(
+                    f"No EveCharacter with character_id={character_id}"
+                )
+        else:
+            character = EveCharacter.objects.order_by("id").first()
+            if character is None:
+                raise CommandError(
+                    "No EveCharacter in DB. Create one or pass --character-id."
+                )
+
+        location_id = options["location_id"]
+        if location_id is not None:
+            location = EveLocation.objects.filter(
+                location_id=location_id
+            ).first()
+            if location is None:
+                raise CommandError(
+                    f"No EveLocation with location_id={location_id}"
+                )
+        else:
+            location = (
+                EveLocation.objects.filter(
+                    location_name__icontains="Amamake"
+                ).first()
+                or EveLocation.objects.order_by("location_id").first()
+            )
+
+        order = create_industry_order(
+            needed_by=timezone.now().date() + timedelta(days=30),
+            character=character,
+            location=location,
+            contract_to=character.character_name,
+        )
+        for tid in type_ids:
+            IndustryOrderItem.objects.create(
+                order=order,
+                eve_type=types[tid],
+                quantity=qty,
+                self_assign_maximum=qty,
+                target_unit_price=ask_by_type.get(tid),
+            )
+
+        loc_label = location.location_name if location else "(no location)"
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Created IndustryOrder #{order.pk} "
+                f"(code {order.public_short_code}) at {loc_label}: "
+                f"{len(type_ids)} hulls ×{qty}"
+            )
+        )
+        self.stdout.write(
+            "Open: /industry/orders/summary/ "
+            f"(include order #{order.pk} / {order.public_short_code})"
+        )
+        self.stdout.write(f"API: GET /api/industry/orders/{order.pk}")
+        self.stdout.write(
+            "API: GET /api/industry/orders/profit-summary"
+            f"?order_ids={order.pk}&open_only=true"
+        )

--- a/backend/industry/tests/test_guide_order_summary_export.py
+++ b/backend/industry/tests/test_guide_order_summary_export.py
@@ -1,0 +1,75 @@
+from datetime import date
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from django.test import SimpleTestCase
+
+from industry.helpers.guide_order_summary_export import (
+    GuideOrderRow,
+    render_typescript_module,
+    write_frontend_module,
+)
+
+
+class GuideOrderSummaryExportTest(SimpleTestCase):
+    def test_render_typescript_module_includes_rows_and_assumptions(self):
+        rows = [
+            GuideOrderRow(
+                name="Coercer",
+                type_id=16236,
+                kind="T1",
+                faction="T1",
+                isk_per_lp=None,
+                cost_per=1_047_349,
+                jita_sell=1_386_000,
+                profit_per=338_651,
+                order_profit=33_865_146,
+            ),
+            GuideOrderRow(
+                name="Talwar Fleet Issue",
+                type_id=91858,
+                kind="Navy",
+                faction="Minmatar",
+                isk_per_lp=850,
+                cost_per=15_748_217,
+                jita_sell=19_522_645,
+                profit_per=3_774_428,
+                order_profit=377_442_795,
+                note="BOM proxied (identical navy destroyer recipe)",
+            ),
+        ]
+        text = render_typescript_module(rows, as_of=date(2026, 7, 22))
+        self.assertIn("export const AS_OF_DATE = '22 Jul 2026'", text)
+        self.assertIn("name: 'Coercer'", text)
+        self.assertIn("typeId: 91858", text)
+        self.assertIn(
+            "note: 'BOM proxied (identical navy destroyer recipe)'", text
+        )
+        self.assertIn("${ORDER_QTY}", text)
+        self.assertIn(
+            "pipenv run python manage.py export_guide_order_summary", text
+        )
+
+    def test_write_frontend_module(self):
+        rows = [
+            GuideOrderRow(
+                name="Stabber",
+                type_id=622,
+                kind="T1",
+                faction="T1",
+                isk_per_lp=None,
+                cost_per=1,
+                jita_sell=2,
+                profit_per=1,
+                order_profit=100,
+            )
+        ]
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "guide-order-summary.ts"
+            written = write_frontend_module(
+                rows, path=path, as_of=date(2026, 1, 5)
+            )
+            self.assertEqual(written, path)
+            content = path.read_text(encoding="utf-8")
+            self.assertIn("name: 'Stabber'", content)
+            self.assertIn("AS_OF_DATE = '5 Jan 2026'", content)

--- a/backend/industry/tests/test_orders_profit_summary.py
+++ b/backend/industry/tests/test_orders_profit_summary.py
@@ -1,0 +1,178 @@
+"""Tests for GET /api/industry/orders/profit-summary."""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.test import Client
+from django.utils import timezone
+from eveonline.helpers.characters import set_primary_character
+from eveonline.models import EveCharacter, EveLocation
+from eveuniverse.models import EveCategory, EveGroup, EveType
+
+from app.test import TestCase as AppTestCase
+from industry.helpers.product_unit_cost import ProductUnitCost
+from industry.models import IndustryOrderItem
+from industry.test_utils import create_industry_order
+
+
+class OrdersProfitSummaryEndpointTestCase(AppTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.eve_category, _ = EveCategory.objects.get_or_create(
+            id=1, defaults={"name": "Test Category", "published": True}
+        )
+        cls.eve_group, _ = EveGroup.objects.get_or_create(
+            id=1,
+            defaults={
+                "name": "Test Group",
+                "published": True,
+                "eve_category": cls.eve_category,
+            },
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.client = Client()
+        self.character = EveCharacter.objects.get_or_create(
+            character_id=999101,
+            defaults={"character_name": "Profit Char", "user": self.user},
+        )[0]
+        set_primary_character(self.user, self.character)
+        self.eve_type = EveType.objects.create(
+            id=999301,
+            name="Test Hull",
+            published=True,
+            eve_group=self.eve_group,
+        )
+        self.location = EveLocation.objects.create(
+            location_id=1999101,
+            location_name="Profit Station",
+            solar_system_id=300001,
+            solar_system_name="Test System",
+            short_name="PRF",
+        )
+
+    def _unit_cost(self, type_id: int, name: str) -> ProductUnitCost:
+        return ProductUnitCost(
+            type_id=type_id,
+            name=name,
+            kind="T1",
+            cost_per=1_000_000,
+            jita_sell=1_500_000,
+            profit_per=500_000,
+            isk_per_lp=None,
+            note=None,
+        )
+
+    @patch("industry.helpers.orders_profit_summary.plan_product_unit_cost")
+    @patch(
+        "industry.helpers.orders_profit_summary.jita_sell_prices_by_type_id"
+    )
+    def test_profit_summary_aggregates_included_orders(
+        self, mock_prices, mock_plan
+    ):
+        mock_prices.return_value = {self.eve_type.id: 1_500_000}
+        mock_plan.side_effect = lambda tid, **kw: self._unit_cost(
+            tid, self.eve_type.name
+        )
+
+        needed = (timezone.now() + timedelta(days=14)).date()
+        order_a = create_industry_order(
+            needed_by=needed,
+            character=self.character,
+            location=self.location,
+        )
+        IndustryOrderItem.objects.create(
+            order=order_a,
+            eve_type=self.eve_type,
+            quantity=10,
+            self_assign_maximum=100,
+        )
+        order_b = create_industry_order(
+            needed_by=needed,
+            character=self.character,
+            location=self.location,
+        )
+        IndustryOrderItem.objects.create(
+            order=order_b, eve_type=self.eve_type, quantity=5
+        )
+
+        response = self.client.get(
+            "/api/industry/orders/profit-summary",
+            {
+                "needed_by_from": needed.isoformat(),
+                "needed_by_to": needed.isoformat(),
+                "open_only": "true",
+                "order_ids": str(order_a.pk),
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["orders"]), 2)
+        included = {o["id"]: o["included"] for o in data["orders"]}
+        self.assertTrue(included[order_a.pk])
+        self.assertFalse(included[order_b.pk])
+        self.assertEqual(len(data["rows"]), 1)
+        row = data["rows"][0]
+        self.assertEqual(row["type_id"], self.eve_type.id)
+        self.assertEqual(row["qty"], 10)
+        self.assertEqual(row["order_profit"], 5_000_000)
+        self.assertEqual(data["totals"]["total_profit"], 5_000_000)
+        # Ask missing → Jita 1.5M × 10
+        self.assertEqual(data["totals"]["total_order_amount"], 15_000_000)
+        assumptions_text = " ".join(data["assumptions"]).lower()
+        self.assertIn("order ask", assumptions_text)
+        self.assertIn("maximum claim", assumptions_text)
+        mock_plan.assert_called()
+        _, plan_kwargs = mock_plan.call_args
+        self.assertEqual(plan_kwargs.get("quantity"), 100)
+
+    @patch("industry.helpers.orders_profit_summary.plan_product_unit_cost")
+    @patch(
+        "industry.helpers.orders_profit_summary.jita_sell_prices_by_type_id"
+    )
+    def test_profit_summary_excludes_fulfilled_when_open_only(
+        self, mock_prices, mock_plan
+    ):
+        mock_prices.return_value = {}
+        mock_plan.side_effect = lambda tid, **kw: self._unit_cost(
+            tid, self.eve_type.name
+        )
+
+        needed = (timezone.now() + timedelta(days=7)).date()
+        open_order = create_industry_order(
+            needed_by=needed,
+            character=self.character,
+            location=self.location,
+        )
+        IndustryOrderItem.objects.create(
+            order=open_order, eve_type=self.eve_type, quantity=2
+        )
+        done = create_industry_order(
+            needed_by=needed,
+            character=self.character,
+            location=self.location,
+        )
+        done.fulfilled_at = timezone.now()
+        done.save(update_fields=["fulfilled_at"])
+        IndustryOrderItem.objects.create(
+            order=done, eve_type=self.eve_type, quantity=99
+        )
+
+        response = self.client.get(
+            "/api/industry/orders/profit-summary",
+            {"open_only": "true"},
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        ids = {o["id"] for o in data["orders"]}
+        self.assertIn(open_order.pk, ids)
+        self.assertNotIn(done.pk, ids)
+
+    def test_profit_summary_rejects_unknown_facility(self):
+        response = self.client.get(
+            "/api/industry/orders/profit-summary",
+            {"facility_key": "not-a-facility"},
+        )
+        self.assertEqual(response.status_code, 400)

--- a/frontend/app/src/components/blocks/campaigns/etherium-reach/CampaignDataTable.astro
+++ b/frontend/app/src/components/blocks/campaigns/etherium-reach/CampaignDataTable.astro
@@ -5,13 +5,15 @@ interface Props {
     headers: string[]
     rows: CampaignTableRow[]
     striped?: boolean
+    /** Green ▲ on success-tone first cells (campaign tables). Off for industry. */
+    success_marker?: boolean
 }
 
-const { headers, rows, striped = false } = Astro.props
+const { headers, rows, striped = false, success_marker = true } = Astro.props
 ---
 
 <div class="er-table-wrap" tabindex="0" role="region">
-    <table class:list={['er-table' ]}>
+    <table class:list={['er-table', !success_marker && 'er-table--no-markers']}>
         <thead>
             <tr>
                 {
@@ -35,7 +37,21 @@ const { headers, rows, striped = false } = Astro.props
                         {
                             row.cells.map((cell, index) => (
                                 <td class:list={[index > 0 && 'er-table__numeric']}>
-                                    {cell}
+                                    {index === 0 && row.icon_url ? (
+                                        <span class="er-table__name">
+                                            <img
+                                                class="er-table__icon"
+                                                src={row.icon_url}
+                                                alt=""
+                                                width="24"
+                                                height="24"
+                                                loading="lazy"
+                                            />
+                                            <span>{cell}</span>
+                                        </span>
+                                    ) : (
+                                        cell
+                                    )}
                                 </td>
                             ))
                         }
@@ -89,6 +105,20 @@ const { headers, rows, striped = false } = Astro.props
         font-variant-numeric: tabular-nums;
     }
 
+    .er-table__name {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2xs);
+    }
+
+    .er-table__icon {
+        flex-shrink: 0;
+        width: 24px;
+        height: 24px;
+        object-fit: contain;
+        border-radius: 2px;
+    }
+
     .er-table__row--info td {
         font-weight: 600;
     }
@@ -96,6 +126,10 @@ const { headers, rows, striped = false } = Astro.props
     .er-table__row--success td:first-child:after {
         content: '▲';
         color: var(--green);
+    }
+
+    .er-table--no-markers .er-table__row--success td:first-child:after {
+        content: none;
     }
 
     .er-table__row--warning td:first-child {

--- a/frontend/app/src/components/blocks/industry/guide-order-summary/GuideOrderProfitBarChart.astro
+++ b/frontend/app/src/components/blocks/industry/guide-order-summary/GuideOrderProfitBarChart.astro
@@ -1,0 +1,100 @@
+---
+interface Props {
+    labels: readonly string[]
+    valuesM: readonly number[]
+}
+
+const { labels, valuesM } = Astro.props
+const chartId = `guide-order-profit-bar-${Math.random().toString(36).slice(2, 9)}`
+---
+
+<div
+    class="[ guide-order-profit-chart ]"
+    x-data={`{
+        labels: ${JSON.stringify(labels)},
+        dataM: ${JSON.stringify(valuesM)},
+        chart: null,
+        buildChart() {
+            const canvas = document.getElementById('${chartId}')
+            if (!canvas || typeof Chart === 'undefined') return false
+            if (this.chart) {
+                this.chart.destroy()
+                this.chart = null
+            }
+            const ctx = canvas.getContext('2d')
+            Chart.defaults.borderColor = 'rgb(255, 255, 255, 0.05)'
+            Chart.defaults.color = '#ffffff'
+            Chart.defaults.font.family = 'Montserrat Variable'
+            this.chart = new Chart(ctx, {
+                type: 'bar',
+                data: {
+                    labels: this.labels,
+                    datasets: [{
+                        label: 'Order profit (M ISK)',
+                        data: this.dataM,
+                        backgroundColor: 'rgba(32, 81, 181, 0.75)',
+                        borderColor: '#2051B5',
+                        borderWidth: 1,
+                    }],
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: {
+                        legend: { display: false },
+                        tooltip: {
+                            callbacks: {
+                                label: (ctx) => {
+                                    const v = ctx.parsed.y
+                                    return v == null ? '' : v.toLocaleString() + 'M ISK'
+                                },
+                            },
+                        },
+                    },
+                    scales: {
+                        x: {
+                            ticks: {
+                                maxRotation: 60,
+                                minRotation: 45,
+                                autoSkip: false,
+                                font: { size: 10 },
+                            },
+                        },
+                        y: {
+                            title: {
+                                display: true,
+                                text: 'M ISK',
+                            },
+                            beginAtZero: true,
+                        },
+                    },
+                },
+            })
+            return true
+        },
+        init() {
+            if (this.buildChart()) return
+            let tries = 0
+            const timer = setInterval(() => {
+                tries += 1
+                if (this.buildChart() || tries > 40) clearInterval(timer)
+            }, 100)
+        },
+    }`}
+>
+    <canvas id={chartId} aria-label="Order profit by product in millions of ISK"></canvas>
+</div>
+
+<style lang="scss">
+    .guide-order-profit-chart {
+        position: relative;
+        width: 100%;
+        min-height: 360px;
+        height: min(420px, 70vh);
+    }
+
+    canvas {
+        width: 100% !important;
+        height: 100% !important;
+    }
+</style>

--- a/frontend/app/src/components/blocks/industry/guide-order-summary/OpenOrdersProfitSummary.astro
+++ b/frontend/app/src/components/blocks/industry/guide-order-summary/OpenOrdersProfitSummary.astro
@@ -1,0 +1,315 @@
+---
+import { i18n } from '@helpers/i18n'
+const { translatePath } = i18n(Astro.url)
+
+import type { OrdersProfitSummary } from '@dtypes/api.minmatar.org'
+import type { PlannerFacility } from '@helpers/api.minmatar.org/industry'
+
+import OpenOrdersProfitSummaryOrders from '@components/blocks/industry/guide-order-summary/OpenOrdersProfitSummaryOrders.astro'
+import OpenOrdersProfitSummaryResults from '@components/blocks/industry/guide-order-summary/OpenOrdersProfitSummaryResults.astro'
+import OpenOrdersProfitSummarySkeleton from '@components/blocks/industry/guide-order-summary/OpenOrdersProfitSummarySkeleton.astro'
+import Flexblock from '@components/compositions/Flexblock.astro'
+import FlexInline from '@components/compositions/FlexInline.astro'
+import Input from '@components/blocks/Input.astro'
+import Select from '@components/blocks/Select.astro'
+import Switch from '@components/blocks/Switch.astro'
+
+interface Props {
+    summary: OrdersProfitSummary
+    facilities: PlannerFacility[]
+    facility_key: string
+    needed_by_from: string
+    needed_by_to: string
+    open_only: boolean
+    selected_order_ids: number[]
+}
+
+const {
+    summary,
+    facilities,
+    facility_key,
+    needed_by_from,
+    needed_by_to,
+    open_only,
+    selected_order_ids,
+} = Astro.props
+
+const facility_label =
+    facilities.find((f) => f.key === facility_key)?.system_name ??
+    facility_key.replace(/^\w/, (c) => c.toUpperCase())
+
+const page_action = translatePath('/industry/orders/summary/')
+const results_partial = translatePath(
+    '/partials/order_summary_results_component',
+)
+---
+
+<div class="[ order-summary w-full ]">
+    <Flexblock gap="var(--space-2xl)">
+        <form
+            id="order-summary-filters"
+            class="[ w-full ]"
+            hx-get={results_partial}
+            hx-target="#order-summary-results"
+            hx-swap="innerHTML"
+            hx-trigger="change, orderSummaryRefresh"
+            data-page-action={page_action}
+        >
+            <input type="hidden" name="applied" value="1" />
+            <input
+                type="hidden"
+                name="refresh_orders"
+                id="order-summary-refresh-orders"
+                value="0"
+            />
+
+            <Flexblock gap="var(--space-m)">
+                <Flexblock gap="var(--space-3xs)">
+                    <h2>Filters</h2>
+                    <small>
+                        Pick a needed-by date range, industry system, and which
+                        orders to include. Metrics and charts update when you
+                        change anything here.
+                    </small>
+                </Flexblock>
+
+                <FlexInline gap="var(--space-m)" class="[ flex-wrap items-end ]">
+                    <label class="[ filter-field ]">
+                        <span>Needed by from</span>
+                        <Input
+                            type="date"
+                            name="needed_by_from"
+                            value={needed_by_from}
+                            size="sm"
+                            width="12rem"
+                        />
+                    </label>
+                    <label class="[ filter-field ]">
+                        <span>Needed by to</span>
+                        <Input
+                            type="date"
+                            name="needed_by_to"
+                            value={needed_by_to}
+                            size="sm"
+                            width="12rem"
+                        />
+                    </label>
+                    <label class="[ filter-field ]">
+                        <span>Build Location</span>
+                        <Select
+                            name="facility_key"
+                            size="sm"
+                            width="14rem"
+                        >
+                            {
+                                facilities.map((f) => (
+                                    <option
+                                        value={f.key}
+                                        selected={f.key === facility_key}
+                                    >
+                                        {f.system_name}
+                                    </option>
+                                ))
+                            }
+                        </Select>
+                    </label>
+                    <div class="[ filter-switch ]">
+                        <Switch name="open_only" value="1" checked={open_only}>
+                            Open orders only
+                        </Switch>
+                    </div>
+                </FlexInline>
+
+                <div id="order-summary-orders">
+                    <OpenOrdersProfitSummaryOrders
+                        orders={summary.orders}
+                        selected_order_ids={selected_order_ids}
+                    />
+                </div>
+            </Flexblock>
+        </form>
+
+        <div
+            id="order-summary-results-stack"
+            class="[ order-summary-results-stack w-full ]"
+        >
+            <div
+                id="order-summary-results"
+                class="[ order-summary-results w-full ]"
+                aria-busy="false"
+                aria-live="polite"
+            >
+                <OpenOrdersProfitSummaryResults
+                    summary={summary}
+                    facility_label={facility_label}
+                />
+            </div>
+            <OpenOrdersProfitSummarySkeleton />
+        </div>
+    </Flexblock>
+</div>
+
+<script>
+    const form = document.getElementById(
+        'order-summary-filters',
+    ) as HTMLFormElement | null
+    const refreshOrdersInput = document.getElementById(
+        'order-summary-refresh-orders',
+    ) as HTMLInputElement | null
+    const resultsStack = document.getElementById(
+        'order-summary-results-stack',
+    )
+    const results = document.getElementById('order-summary-results')
+    const pageAction = form?.dataset.pageAction || ''
+
+    const RANGE_FIELDS = new Set([
+        'needed_by_from',
+        'needed_by_to',
+        'open_only',
+    ])
+
+    function syncHistory() {
+        if (!form || !pageAction) return
+        const params = new URLSearchParams(new FormData(form) as any)
+        params.delete('refresh_orders')
+        const qs = params.toString()
+        history.replaceState(null, '', qs ? `${pageAction}?${qs}` : pageAction)
+    }
+
+    function setRefreshOrders(enabled: boolean) {
+        if (refreshOrdersInput) refreshOrdersInput.value = enabled ? '1' : '0'
+    }
+
+    function setResultsLoading(loading: boolean) {
+        resultsStack?.classList.toggle('is-loading', loading)
+        results?.setAttribute('aria-busy', loading ? 'true' : 'false')
+        if (!loading) {
+            document
+                .getElementById('order-summary-orders')
+                ?.classList.remove('is-loading')
+        }
+    }
+
+    if (form && form.dataset.bound !== '1') {
+        form.dataset.bound = '1'
+        if (typeof htmx !== 'undefined') htmx.process(form)
+
+        // Set OOB order-list refresh before HTMX serializes the form.
+        form.addEventListener(
+            'change',
+            (event) => {
+                const target = event.target as HTMLInputElement | null
+                setRefreshOrders(
+                    !!target?.name && RANGE_FIELDS.has(target.name),
+                )
+            },
+            true,
+        )
+
+        form.addEventListener('click', (event) => {
+            const button = (event.target as HTMLElement | null)?.closest(
+                '[data-order-select]',
+            ) as HTMLElement | null
+            if (!button || !form.contains(button)) return
+
+            const mode = button.dataset.orderSelect
+            form
+                .querySelectorAll<HTMLInputElement>('input[name="order_ids"]')
+                .forEach((input) => {
+                    input.checked = mode === 'all'
+                })
+            setRefreshOrders(false)
+            if (typeof htmx !== 'undefined') {
+                htmx.trigger(form, 'orderSummaryRefresh')
+            }
+        })
+
+        document.body.addEventListener('htmx:beforeRequest', (event: any) => {
+            if (event.detail?.elt !== form) return
+            setResultsLoading(true)
+            const orders = document.getElementById('order-summary-orders')
+            if (orders && refreshOrdersInput?.value === '1') {
+                orders.classList.add('is-loading')
+            }
+        })
+
+        document.body.addEventListener('htmx:afterSwap', (event: any) => {
+            const target = event.detail?.target as HTMLElement | undefined
+            if (target?.id !== 'order-summary-results') return
+            setRefreshOrders(false)
+            setResultsLoading(false)
+            syncHistory()
+            if (typeof htmx !== 'undefined') htmx.process(target)
+            if (typeof Alpine !== 'undefined') Alpine.initTree(target)
+            if (typeof tippy === 'function') {
+                tippy('#order-summary-results [data-tippy-content]', {
+                    delay: [100, 200],
+                    arrow: true,
+                })
+            }
+        })
+
+        document.body.addEventListener('htmx:afterRequest', (event: any) => {
+            if (event.detail?.elt !== form) return
+            setResultsLoading(false)
+        })
+    }
+</script>
+
+<style lang="scss">
+    .order-summary {
+        min-width: 0;
+    }
+
+    .filter-field {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3xs);
+        font-size: var(--step--1);
+        color: var(--highlight);
+    }
+
+    .filter-switch {
+        align-self: flex-end;
+        padding-bottom: var(--space-3xs);
+        font-size: var(--step--1);
+    }
+
+    .order-summary-results {
+        min-width: 0;
+    }
+
+    .order-summary-results-stack {
+        min-width: 0;
+        position: relative;
+    }
+
+    :global(#order-summary-orders.is-loading) {
+        position: relative;
+        pointer-events: none;
+
+        &::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            border-radius: 2px;
+            background: linear-gradient(
+                90deg,
+                rgba(0, 0, 0, 0.15) 0%,
+                rgba(255, 255, 255, 0.06) 50%,
+                rgba(0, 0, 0, 0.15) 100%
+            );
+            background-size: 200% 100%;
+            animation: order-summary-orders-skel 1.1s ease-in-out infinite;
+        }
+    }
+
+    @keyframes order-summary-orders-skel {
+        0% {
+            background-position: 100% 0;
+        }
+        100% {
+            background-position: -100% 0;
+        }
+    }
+</style>

--- a/frontend/app/src/components/blocks/industry/guide-order-summary/OpenOrdersProfitSummaryOrders.astro
+++ b/frontend/app/src/components/blocks/industry/guide-order-summary/OpenOrdersProfitSummaryOrders.astro
@@ -1,0 +1,172 @@
+---
+import type { OrdersProfitSummary } from '@dtypes/api.minmatar.org'
+import { get_item_icon } from '@helpers/eve_image_server'
+import Flexblock from '@components/compositions/Flexblock.astro'
+import FlexInline from '@components/compositions/FlexInline.astro'
+import RadioCheckInput from '@components/blocks/RadioCheckInput.astro'
+
+interface Props {
+    orders: OrdersProfitSummary['orders']
+    selected_order_ids: number[]
+}
+
+const { orders, selected_order_ids } = Astro.props
+const selected_set = new Set(selected_order_ids)
+const MAX_ICONS = 12
+---
+
+{
+    orders.length > 0 ? (
+        <Flexblock gap="var(--space-3xs)" class="[ order-summary-orders-inner ]">
+            <FlexInline justification="space-between" class="[ w-full ]">
+                <strong>Orders in range</strong>
+                <FlexInline gap="var(--space-s)">
+                    <button
+                        type="button"
+                        class="[ filter-action ]"
+                        data-order-select="all"
+                    >
+                        Select all
+                    </button>
+                    <button
+                        type="button"
+                        class="[ filter-action ]"
+                        data-order-select="none"
+                    >
+                        Select none
+                    </button>
+                </FlexInline>
+            </FlexInline>
+            <div class="[ order-checklist ]">
+                {orders.map((order) => {
+                    const type_ids = order.item_type_ids ?? []
+                    const shown = type_ids.slice(0, MAX_ICONS)
+                    const overflow = type_ids.length - shown.length
+                    return (
+                        <RadioCheckInput
+                            type="checkbox"
+                            name="order_ids"
+                            value={String(order.id)}
+                            checked={
+                                selected_set.size === 0
+                                    ? order.included
+                                    : selected_set.has(order.id)
+                            }
+                        >
+                            <span class="[ order-check-label ]">
+                                <span class="[ order-check-meta ]">
+                                    <code>{order.public_short_code}</code>
+                                    {' · '}
+                                    {order.location_label}
+                                    {' · '}
+                                    {order.needed_by}
+                                    {order.fulfilled_at ? ' · fulfilled' : ''}
+                                </span>
+                                {shown.length > 0 ? (
+                                    <span class="[ order-item-icons ]">
+                                        {shown.map((type_id) => (
+                                            <img
+                                                class="[ order-item-icon ]"
+                                                src={get_item_icon(type_id, 32)}
+                                                alt=""
+                                                width="24"
+                                                height="24"
+                                                loading="lazy"
+                                            />
+                                        ))}
+                                        {overflow > 0 ? (
+                                            <span class="[ order-item-overflow ]">
+                                                +{overflow}
+                                            </span>
+                                        ) : null}
+                                    </span>
+                                ) : null}
+                            </span>
+                        </RadioCheckInput>
+                    )
+                })}
+            </div>
+        </Flexblock>
+    ) : (
+        <p>No orders match this needed-by date range.</p>
+    )
+}
+
+<style lang="scss">
+    .order-checklist {
+        display: grid;
+        gap: var(--space-2xs);
+        max-height: 16rem;
+        overflow: auto;
+        padding: var(--space-s);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        background-color: rgba(85, 85, 85, 0.1);
+        backdrop-filter: blur(var(--input-backdrop-blur));
+
+        :global(label) {
+            width: 100%;
+            max-width: 100%;
+            align-items: flex-start;
+        }
+
+        /* Checked fill: fleet red to match the page accents. */
+        :global(input:checked + .box) {
+            background-color: var(--fleet-red);
+            border-color: var(--fleet-yellow);
+        }
+    }
+
+    .order-check-label {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3xs);
+        color: var(--foreground);
+        font-size: var(--step--1);
+        line-height: 1.4;
+        min-width: 0;
+    }
+
+    .order-check-meta {
+        color: var(--foreground);
+    }
+
+    .order-item-icons {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.2rem;
+        align-items: center;
+    }
+
+    .order-item-icon {
+        width: 24px;
+        height: 24px;
+        object-fit: contain;
+        border-radius: 2px;
+        background: rgba(0, 0, 0, 0.25);
+    }
+
+    .order-item-overflow {
+        font-size: var(--step--2);
+        color: var(--highlight);
+        padding-inline: 0.25rem;
+    }
+
+    .filter-action {
+        appearance: none;
+        background: none;
+        border: none;
+        padding: 0;
+        margin: 0;
+        cursor: pointer;
+        font: inherit;
+        font-size: var(--step--1);
+        color: var(--highlight);
+        text-decoration: underline;
+        text-underline-offset: 0.15em;
+
+        &:hover,
+        &:focus-visible {
+            color: var(--fleet-yellow, #c9a227);
+        }
+    }
+</style>

--- a/frontend/app/src/components/blocks/industry/guide-order-summary/OpenOrdersProfitSummaryResults.astro
+++ b/frontend/app/src/components/blocks/industry/guide-order-summary/OpenOrdersProfitSummaryResults.astro
@@ -1,0 +1,174 @@
+---
+import type { OrdersProfitSummary } from '@dtypes/api.minmatar.org'
+import type { CampaignTableRow } from '@/data/campaigns/etherium-reach'
+import {
+    formatIskCompact,
+    formatIskFull,
+    rowTone,
+    shortHullName,
+} from '@/data/industry/guide-order-summary'
+import { get_item_icon } from '@helpers/eve_image_server'
+import { number_name } from '@helpers/numbers'
+import { i18n } from '@helpers/i18n'
+
+import CampaignCallout from '@components/blocks/campaigns/etherium-reach/CampaignCallout.astro'
+import CampaignDataTable from '@components/blocks/campaigns/etherium-reach/CampaignDataTable.astro'
+import CampaignStat from '@components/blocks/campaigns/etherium-reach/CampaignStat.astro'
+import GuideOrderProfitBarChart from '@components/blocks/industry/guide-order-summary/GuideOrderProfitBarChart.astro'
+import ComponentBlock from '@components/blocks/ComponentBlock.astro'
+import Flexblock from '@components/compositions/Flexblock.astro'
+import Grid from '@components/compositions/Grid.astro'
+
+interface Props {
+    summary: OrdersProfitSummary
+    facility_label: string
+}
+
+const { summary, facility_label } = Astro.props
+const { lang } = i18n(Astro.url)
+
+const totals = summary.totals
+const sortedRows = [...summary.rows].sort((a, b) => b.order_profit - a.order_profit)
+const chartLabels = sortedRows.map((r) => shortHullName(r.name))
+const chartValuesM = sortedRows.map((r) =>
+    Math.round(r.order_profit / 1_000_000),
+)
+
+const tableRows: CampaignTableRow[] = summary.rows.map((r) => ({
+    cells: [
+        r.name,
+        String(r.qty),
+        r.isk_per_lp == null ? '-' : String(Math.round(r.isk_per_lp)),
+        formatIskCompact(r.cost_per),
+        formatIskCompact(r.unit_price),
+        formatIskFull(r.profit_per),
+        formatIskCompact(r.order_profit),
+    ] as const,
+    tone: rowTone(r.order_profit),
+    icon_url: get_item_icon(r.type_id, 32),
+}))
+
+const tableHeaders = [
+    'Product',
+    'Qty',
+    'ISK/LP',
+    'Cost / item',
+    'Ask / item',
+    'Profit / item',
+    'Order profit',
+]
+
+const assumptions = Array.isArray(summary.assumptions)
+    ? summary.assumptions
+    : [String(summary.assumptions)]
+---
+
+<Flexblock gap="var(--space-2xl)" class="[ order-summary-results-inner w-full ]">
+    <Flexblock gap="var(--space-m)">
+        <Flexblock gap="var(--space-3xs)">
+            <h2>Order key metrics</h2>
+            <small>
+                Totals for the orders you included, using build cost at{' '}
+                {facility_label} and each order’s ask price.
+            </small>
+        </Flexblock>
+
+        <Grid
+            class="[ w-full grid-fill ]"
+            row_gap="var(--space-3xs)"
+            column_gap="var(--space-3xs)"
+            min_item_width="300px"
+        >
+            <CampaignStat label="Total order amount" tone="info">
+                <span
+                    data-tippy-content={number_name(
+                        totals.total_order_amount,
+                        lang,
+                    )}
+                >
+                    {formatIskCompact(totals.total_order_amount)}
+                </span>
+            </CampaignStat>
+            <CampaignStat
+                label="Total order profit"
+                tone={totals.total_profit >= 0 ? 'success' : 'danger'}
+            >
+                <span data-tippy-content={number_name(totals.total_profit, lang)}>
+                    {formatIskCompact(totals.total_profit)}
+                </span>
+            </CampaignStat>
+            <CampaignStat label="Total products" tone="info">
+                {totals.line_count}
+            </CampaignStat>
+            <CampaignStat label="Total order items" tone="info">
+                {totals.total_qty}
+            </CampaignStat>
+        </Grid>
+    </Flexblock>
+
+    {
+        chartLabels.length > 0 ? (
+            <Flexblock gap="var(--space-m)">
+                <Flexblock gap="var(--space-3xs)">
+                    <h2>Order profit by product</h2>
+                    <small>
+                        Profit for each product across the included orders,
+                        sorted from highest to lowest (shown in millions of
+                        ISK).
+                    </small>
+                </Flexblock>
+                <ComponentBlock>
+                    <GuideOrderProfitBarChart
+                        labels={chartLabels}
+                        valuesM={chartValuesM}
+                    />
+                </ComponentBlock>
+            </Flexblock>
+        ) : null
+    }
+
+    {
+        tableRows.length > 0 ? (
+            <Flexblock gap="var(--space-m)">
+                <Flexblock gap="var(--space-3xs)">
+                    <h2>Product breakdown</h2>
+                    <small>
+                        Build cost at {facility_label}. Revenue uses the order
+                        ask; Jita sell is only used when an ask is missing.
+                    </small>
+                </Flexblock>
+                <CampaignDataTable
+                    headers={tableHeaders}
+                    rows={tableRows}
+                    success_marker={false}
+                />
+            </Flexblock>
+        ) : (
+            <CampaignCallout title="Nothing to summarize" tone="info">
+                <p>
+                    Select at least one order in range, or widen the needed-by
+                    dates.
+                </p>
+            </CampaignCallout>
+        )
+    }
+
+    <CampaignCallout title="Assumptions" tone="info">
+        <ul class="[ assumptions-list ]">
+            {assumptions.map((item) => (
+                <li>{item}</li>
+            ))}
+        </ul>
+    </CampaignCallout>
+</Flexblock>
+
+<style lang="scss">
+    .assumptions-list {
+        margin: 0;
+        padding-inline-start: 1.25rem;
+        display: grid;
+        gap: var(--space-2xs);
+        font-size: var(--step--1);
+        line-height: 1.5;
+    }
+</style>

--- a/frontend/app/src/components/blocks/industry/guide-order-summary/OpenOrdersProfitSummarySkeleton.astro
+++ b/frontend/app/src/components/blocks/industry/guide-order-summary/OpenOrdersProfitSummarySkeleton.astro
@@ -1,0 +1,143 @@
+---
+import Flexblock from '@components/compositions/Flexblock.astro'
+import Grid from '@components/compositions/Grid.astro'
+---
+
+<div
+    id="order-summary-skeleton"
+    class="[ order-summary-skeleton w-full ]"
+    aria-hidden="true"
+>
+    <Flexblock gap="var(--space-2xl)" class="[ w-full ]">
+        <Flexblock gap="var(--space-m)">
+            <Flexblock gap="var(--space-3xs)">
+                <div class="[ skel skel-title ]"></div>
+                <div class="[ skel skel-subtitle ]"></div>
+            </Flexblock>
+            <Grid
+                class="[ w-full grid-fill ]"
+                row_gap="var(--space-3xs)"
+                column_gap="var(--space-3xs)"
+                min_item_width="300px"
+            >
+                <div class="[ skel skel-stat ]"></div>
+                <div class="[ skel skel-stat ]"></div>
+                <div class="[ skel skel-stat ]"></div>
+                <div class="[ skel skel-stat ]"></div>
+            </Grid>
+        </Flexblock>
+
+        <Flexblock gap="var(--space-m)">
+            <Flexblock gap="var(--space-3xs)">
+                <div class="[ skel skel-title ]"></div>
+                <div class="[ skel skel-subtitle skel-subtitle--wide ]"></div>
+            </Flexblock>
+            <div class="[ skel skel-chart ]"></div>
+        </Flexblock>
+
+        <Flexblock gap="var(--space-m)">
+            <Flexblock gap="var(--space-3xs)">
+                <div class="[ skel skel-title ]"></div>
+                <div class="[ skel skel-subtitle skel-subtitle--wide ]"></div>
+            </Flexblock>
+            <div class="[ skel-table ]">
+                {
+                    Array.from({ length: 6 }).map(() => (
+                        <div class="[ skel skel-row ]"></div>
+                    ))
+                }
+            </div>
+        </Flexblock>
+    </Flexblock>
+</div>
+
+<style lang="scss" is:global>
+    .order-summary-skeleton {
+        display: none;
+        min-width: 0;
+    }
+
+    .order-summary-results-stack.is-loading .order-summary-skeleton {
+        display: block;
+    }
+
+    .order-summary-results-stack.is-loading #order-summary-results {
+        display: none;
+    }
+
+    .order-summary-skeleton .skel {
+        border-radius: 2px;
+        background: linear-gradient(
+            90deg,
+            rgba(255, 255, 255, 0.06) 0%,
+            rgba(255, 255, 255, 0.12) 50%,
+            rgba(255, 255, 255, 0.06) 100%
+        );
+        background-size: 200% 100%;
+        animation: order-summary-skel 1.1s ease-in-out infinite;
+    }
+
+    .order-summary-skeleton .skel-title {
+        width: 12rem;
+        height: 1.35rem;
+    }
+
+    .order-summary-skeleton .skel-subtitle {
+        width: 22rem;
+        max-width: 100%;
+        height: 0.85rem;
+    }
+
+    .order-summary-skeleton .skel-subtitle--wide {
+        width: 28rem;
+    }
+
+    .order-summary-skeleton .skel-stat {
+        min-height: 4.75rem;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        background-color: rgba(85, 85, 85, 0.12);
+        background-image: linear-gradient(
+            90deg,
+            transparent 0%,
+            rgba(255, 255, 255, 0.08) 50%,
+            transparent 100%
+        );
+        background-size: 200% 100%;
+        animation: order-summary-skel 1.1s ease-in-out infinite;
+    }
+
+    .order-summary-skeleton .skel-chart {
+        width: 100%;
+        min-height: 360px;
+        height: min(420px, 70vh);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        background-color: rgba(85, 85, 85, 0.1);
+        background-image: linear-gradient(
+            90deg,
+            transparent 0%,
+            rgba(255, 255, 255, 0.07) 50%,
+            transparent 100%
+        );
+        background-size: 200% 100%;
+        animation: order-summary-skel 1.1s ease-in-out infinite;
+    }
+
+    .order-summary-skeleton .skel-table {
+        display: grid;
+        gap: var(--space-3xs);
+    }
+
+    .order-summary-skeleton .skel-row {
+        height: 2.75rem;
+        border: 1px solid rgba(255, 255, 255, 0.06);
+    }
+
+    @keyframes order-summary-skel {
+        0% {
+            background-position: 100% 0;
+        }
+        100% {
+            background-position: -100% 0;
+        }
+    }
+</style>

--- a/frontend/app/src/data/campaigns/etherium-reach.ts
+++ b/frontend/app/src/data/campaigns/etherium-reach.ts
@@ -378,4 +378,6 @@ export type CampaignRowTone = 'info' | 'success' | 'warning' | 'danger' | undefi
 export type CampaignTableRow = {
     cells: readonly string[]
     tone?: CampaignRowTone
+    /** Optional leading icon (e.g. EVE type icon) for the first cell. */
+    icon_url?: string
 }

--- a/frontend/app/src/data/industry/guide-order-summary.ts
+++ b/frontend/app/src/data/industry/guide-order-summary.ts
@@ -1,0 +1,344 @@
+/**
+ * Guide hull manufacturing order summary (static report).
+ *
+ * Baked from Amamake compressed-ore planner + Jita sell · qty 100 · 25M+ x100 filter.
+ * Refresh: `pipenv run python manage.py export_guide_order_summary`
+ *
+ * As-of: 22 Jul 2026
+ */
+
+export const AS_OF_DATE = '22 Jul 2026'
+export const ORDER_QTY = 100
+export const MIN_ORDER_PROFIT_ISK = 25_000_000
+export const FACILITY_KEY = 'amamake'
+
+/** ISK/LP used when this snapshot was baked (not necessarily live production defaults). */
+export const LP_RATES = {
+    Minmatar: 850,
+    Caldari: 925,
+    Amarr: 1000,
+    Gallente: 1000,
+} as const
+
+export type GuideOrderHullKind = 'Navy' | 'T1'
+export type GuideOrderFaction =
+    | 'Amarr'
+    | 'Caldari'
+    | 'Gallente'
+    | 'Minmatar'
+    | 'T1'
+
+export type GuideOrderRow = {
+    name: string
+    typeId: number
+    kind: GuideOrderHullKind
+    faction: GuideOrderFaction
+    iskPerLp: number | null
+    costPer: number
+    jitaSell: number
+    profitPer: number
+    orderProfit: number
+    note?: string
+}
+
+export type GuideOrderTableTone = 'info' | 'success' | 'warning' | 'danger'
+
+export type GuideOrderTableRow = {
+    cells: readonly string[]
+    tone?: GuideOrderTableTone
+}
+
+/** Kept lines only (explicit cuts + under 25M x100 removed). */
+export const GUIDE_ORDER_ROWS: readonly GuideOrderRow[] = [
+    {
+        name: 'Caldari Navy Hookbill',
+        typeId: 17619,
+        kind: 'Navy',
+        faction: 'Caldari',
+        iskPerLp: 925,
+        costPer: 7_107_908,
+        jitaSell: 8_000_000,
+        profitPer: 892_092,
+        orderProfit: 89_209_200,
+    },
+    {
+        name: 'Federation Navy Comet',
+        typeId: 17841,
+        kind: 'Navy',
+        faction: 'Gallente',
+        iskPerLp: 1000,
+        costPer: 7_407_908,
+        jitaSell: 8_465_000,
+        profitPer: 1_057_092,
+        orderProfit: 105_709_203,
+    },
+    {
+        name: 'Imperial Navy Slicer',
+        typeId: 17703,
+        kind: 'Navy',
+        faction: 'Amarr',
+        iskPerLp: 1000,
+        costPer: 7_407_908,
+        jitaSell: 10_000_000,
+        profitPer: 2_592_092,
+        orderProfit: 259_209_203,
+    },
+    {
+        name: 'Republic Fleet Firetail',
+        typeId: 17812,
+        kind: 'Navy',
+        faction: 'Minmatar',
+        iskPerLp: 850,
+        costPer: 6_807_908,
+        jitaSell: 8_998_000,
+        profitPer: 2_190_092,
+        orderProfit: 219_009_203,
+    },
+    {
+        name: 'Vigil Fleet Issue',
+        typeId: 37454,
+        kind: 'Navy',
+        faction: 'Minmatar',
+        iskPerLp: 850,
+        costPer: 6_807_908,
+        jitaSell: 11_490_000,
+        profitPer: 4_682_092,
+        orderProfit: 468_209_203,
+    },
+    {
+        name: 'Coercer Navy Issue',
+        typeId: 73789,
+        kind: 'Navy',
+        faction: 'Amarr',
+        iskPerLp: 1000,
+        costPer: 17_548_217,
+        jitaSell: 21_300_000,
+        profitPer: 3_751_783,
+        orderProfit: 375_178_295,
+    },
+    {
+        name: 'Thrasher Fleet Issue',
+        typeId: 73794,
+        kind: 'Navy',
+        faction: 'Minmatar',
+        iskPerLp: 850,
+        costPer: 15_748_217,
+        jitaSell: 18_840_000,
+        profitPer: 3_091_783,
+        orderProfit: 309_178_295,
+    },
+    {
+        name: 'Cormorant Navy Issue',
+        typeId: 73795,
+        kind: 'Navy',
+        faction: 'Caldari',
+        iskPerLp: 925,
+        costPer: 16_648_217,
+        jitaSell: 18_000_000,
+        profitPer: 1_351_783,
+        orderProfit: 135_178_300,
+    },
+    {
+        name: 'Talwar Fleet Issue',
+        typeId: 91858,
+        kind: 'Navy',
+        faction: 'Minmatar',
+        iskPerLp: 850,
+        costPer: 15_748_217,
+        jitaSell: 19_522_645,
+        profitPer: 3_774_428,
+        orderProfit: 377_442_795,
+        note: 'BOM proxied (identical navy destroyer recipe)',
+    },
+    {
+        name: 'Coercer',
+        typeId: 16236,
+        kind: 'T1',
+        faction: 'T1',
+        iskPerLp: null,
+        costPer: 1_047_349,
+        jitaSell: 1_386_000,
+        profitPer: 338_651,
+        orderProfit: 33_865_146,
+    },
+    {
+        name: 'Arbitrator',
+        typeId: 628,
+        kind: 'T1',
+        faction: 'T1',
+        iskPerLp: null,
+        costPer: 8_480_564,
+        jitaSell: 9_198_000,
+        profitPer: 717_436,
+        orderProfit: 71_743_589,
+    },
+    {
+        name: 'Augoror Navy Issue',
+        typeId: 29337,
+        kind: 'Navy',
+        faction: 'Amarr',
+        iskPerLp: 1000,
+        costPer: 41_015_110,
+        jitaSell: 43_560_000,
+        profitPer: 2_544_890,
+        orderProfit: 254_489_050,
+    },
+    {
+        name: 'Omen Navy Issue',
+        typeId: 17709,
+        kind: 'Navy',
+        faction: 'Amarr',
+        iskPerLp: 1000,
+        costPer: 41_015_110,
+        jitaSell: 44_230_000,
+        profitPer: 3_214_890,
+        orderProfit: 321_489_050,
+    },
+    {
+        name: 'Caracal Navy Issue',
+        typeId: 17634,
+        kind: 'Navy',
+        faction: 'Caldari',
+        iskPerLp: 925,
+        costPer: 39_665_110,
+        jitaSell: 40_000_000,
+        profitPer: 334_890,
+        orderProfit: 33_489_050,
+    },
+    {
+        name: 'Osprey Navy Issue',
+        typeId: 29340,
+        kind: 'Navy',
+        faction: 'Caldari',
+        iskPerLp: 925,
+        costPer: 39_665_110,
+        jitaSell: 40_930_000,
+        profitPer: 1_264_890,
+        orderProfit: 126_489_050,
+    },
+    {
+        name: 'Bellicose',
+        typeId: 630,
+        kind: 'T1',
+        faction: 'T1',
+        iskPerLp: null,
+        costPer: 11_307_191,
+        jitaSell: 11_790_000,
+        profitPer: 482_809,
+        orderProfit: 48_280_913,
+    },
+    {
+        name: 'Scythe Fleet Issue',
+        typeId: 29336,
+        kind: 'Navy',
+        faction: 'Minmatar',
+        iskPerLp: 850,
+        costPer: 38_315_110,
+        jitaSell: 42_840_000,
+        profitPer: 4_524_890,
+        orderProfit: 452_489_050,
+    },
+    {
+        name: 'Stabber',
+        typeId: 622,
+        kind: 'T1',
+        faction: 'T1',
+        iskPerLp: null,
+        costPer: 11_307_191,
+        jitaSell: 11_620_000,
+        profitPer: 312_809,
+        orderProfit: 31_280_913,
+    },
+    {
+        name: 'Stabber Fleet Issue',
+        typeId: 17713,
+        kind: 'Navy',
+        faction: 'Minmatar',
+        iskPerLp: 850,
+        costPer: 38_315_110,
+        jitaSell: 43_340_000,
+        profitPer: 5_024_890,
+        orderProfit: 502_489_050,
+    },
+]
+
+export const CUTS_APPLIED =
+    'Removed Dragoon, Thrasher, Omen, Maller, Breacher. Also cut any line under 25M on the x100: Tristan, Algos, Catalyst NI, Exequror NI, Vexor, Vexor NI.'
+
+export const ASSUMPTIONS_TEXT =
+    `Qty ${ORDER_QTY} per hull. Navy BPCs ME0/TE0 from FW LP store (Minmatar ${LP_RATES.Minmatar}, Caldari ${LP_RATES.Caldari}, Amarr ${LP_RATES.Amarr}, Gallente ${LP_RATES.Gallente} ISK/LP). T1 assumes researched ME10/TE20 BPO (no LP). Amamake Sotiyo + Tatara compressed-ore shopping, Jita to Amamake freight, revenue = Jita sell x ${ORDER_QTY} (no broker/sales tax). Talwar FI uses the same navy destroyer BOM.`
+
+export function formatIskCompact(isk: number): string {
+    const abs = Math.abs(isk)
+    const sign = isk < 0 ? '-' : ''
+    if (abs >= 1_000_000_000) {
+        return `${sign}${(abs / 1_000_000_000).toFixed(2)}B`
+    }
+    if (abs >= 1_000_000) {
+        return `${sign}${(abs / 1_000_000).toFixed(2)}M`
+    }
+    if (abs >= 1_000) {
+        return `${sign}${(abs / 1_000).toFixed(0)}k`
+    }
+    return `${sign}${abs.toFixed(0)}`
+}
+
+export function formatIskFull(isk: number): string {
+    return Math.round(isk).toLocaleString('en-US')
+}
+
+export function shortHullName(name: string): string {
+    return name
+        .replace(' Navy Issue', ' NI')
+        .replace(' Fleet Issue', ' FI')
+        .replace('Caldari Navy ', '')
+        .replace('Federation Navy ', '')
+        .replace('Imperial Navy ', '')
+        .replace('Republic Fleet ', '')
+}
+
+export function rowTone(orderProfit: number): GuideOrderTableTone {
+    if (orderProfit >= 100_000_000) return 'success'
+    if (orderProfit >= MIN_ORDER_PROFIT_ISK) return 'info'
+    return 'danger'
+}
+
+export function sortedByOrderProfit(
+    rows: readonly GuideOrderRow[] = GUIDE_ORDER_ROWS,
+): GuideOrderRow[] {
+    return [...rows].sort((a, b) => b.orderProfit - a.orderProfit)
+}
+
+export function orderTotals(rows: readonly GuideOrderRow[] = GUIDE_ORDER_ROWS) {
+    const totalProfit = rows.reduce((sum, r) => sum + r.orderProfit, 0)
+    const navyRows = rows.filter((r) => r.kind === 'Navy')
+    const t1Rows = rows.filter((r) => r.kind === 'T1')
+    const sorted = sortedByOrderProfit(rows)
+    return {
+        totalProfit,
+        hullCount: rows.length,
+        navyCount: navyRows.length,
+        t1Count: t1Rows.length,
+        navyProfit: navyRows.reduce((sum, r) => sum + r.orderProfit, 0),
+        t1Profit: t1Rows.reduce((sum, r) => sum + r.orderProfit, 0),
+        best: sorted[0],
+        worst: sorted[sorted.length - 1],
+        sorted,
+    }
+}
+
+export function keptOrderTableRows(
+    rows: readonly GuideOrderRow[] = GUIDE_ORDER_ROWS,
+): GuideOrderTableRow[] {
+    return rows.map((r) => ({
+        cells: [
+            r.name,
+            r.iskPerLp == null ? '-' : String(r.iskPerLp),
+            formatIskCompact(r.costPer),
+            formatIskCompact(r.jitaSell),
+            formatIskFull(r.profitPer),
+            formatIskCompact(r.orderProfit),
+        ] as const,
+        tone: rowTone(r.orderProfit),
+    }))
+}

--- a/frontend/app/src/helpers/api.minmatar.org/industry.ts
+++ b/frontend/app/src/helpers/api.minmatar.org/industry.ts
@@ -13,6 +13,7 @@ import type {
     OrderAssignmentsBreakdown,
     IndustrySingleOrder,
     OrderAssignment,
+    OrdersProfitSummary,
 } from '@dtypes/api.minmatar.org'
 import {
     get_error_message,
@@ -51,6 +52,62 @@ export async function get_orders_with_location() {
         return await response.json() as IndustryOrder[];
     } catch (error) {
         throw new Error(`Error fetching industry orders: ${error.message}`, { cause: error.cause });
+    }
+}
+
+export type OrdersProfitSummaryParams = {
+    needed_by_from?: string
+    needed_by_to?: string
+    open_only?: boolean
+    order_ids?: string | number[]
+    facility_key?: string
+    compressed?: boolean
+}
+
+export async function get_orders_profit_summary(
+    params: OrdersProfitSummaryParams = {},
+): Promise<OrdersProfitSummary> {
+    const headers = {
+        'Content-Type': 'application/json',
+    }
+
+    const raw: Record<string, string> = {}
+    if (params.needed_by_from) raw.needed_by_from = params.needed_by_from
+    if (params.needed_by_to) raw.needed_by_to = params.needed_by_to
+    if (params.open_only !== undefined)
+        raw.open_only = params.open_only ? 'true' : 'false'
+    if (params.order_ids !== undefined) {
+        raw.order_ids = Array.isArray(params.order_ids)
+            ? params.order_ids.join(',')
+            : String(params.order_ids)
+    }
+    if (params.facility_key) raw.facility_key = params.facility_key
+    if (params.compressed !== undefined)
+        raw.compressed = params.compressed ? 'true' : 'false'
+
+    const qs = query_string(raw)
+    const ENDPOINT = `${API_ENDPOINT}/orders/profit-summary${qs ? `?${qs}` : ''}`
+
+    console.log(`Requesting: ${ENDPOINT}`)
+
+    try {
+        const response = await fetch(ENDPOINT, {
+            headers: headers,
+        })
+
+        if (!response.ok) {
+            throw new Error(
+                get_error_message(response.status, `GET ${ENDPOINT}`),
+                { cause: response.status },
+            )
+        }
+
+        return (await response.json()) as OrdersProfitSummary
+    } catch (error) {
+        throw new Error(
+            `Error fetching orders profit summary: ${error.message}`,
+            { cause: error.cause },
+        )
     }
 }
 

--- a/frontend/app/src/i18n/ui.ts
+++ b/frontend/app/src/i18n/ui.ts
@@ -463,6 +463,15 @@ export const ui = {
         'industry.orders.contract.leading_text': 'Start creating a contract by selecting your items from your Inventory or Personal Assets, at the station specified below, right click and create contract.',
         'industry.orders.contract.meta_description': 'Delivery contract for industry orders.',
 
+        'industry.orders.summary.page_title': 'Order summary',
+        'industry.orders.summary.leading_text':
+            'See expected profit for industry orders using build cost at your selected system and each order’s ask price. Change dates, system, or which orders to include.',
+        'industry.orders.summary.meta_title': 'Order summary | {site}',
+        'industry.orders.summary.meta_description':
+            'Live order summary for Minmatar Fleet industry orders: build cost at a chosen industry system, revenue from order asks, and filters for needed-by date and included orders.',
+        'page_finder.orders.summary.description':
+            'Order summary with build cost, ask revenue, and filters for dates, system, and included orders.',
+        'view_orders_summary': 'Order summary',
         'industry.orders.planner.page_title': 'Build planner',
         'industry.orders.planner.beta_title': 'Beta',
         'industry.orders.planner.beta_warning': 'This build planner is in beta — shopping lists, costs, and refine amounts may be off. Report problems in Discord [#help](https://discordapp.com/channels/1041384161505722368/1183401618943791186).',

--- a/frontend/app/src/json/sitemap.json
+++ b/frontend/app/src/json/sitemap.json
@@ -451,6 +451,13 @@
         "keywords": [ "orders", "manufacturing", "materials", "breakdown" ]
     },
     {
+        "slug": "industry.orders.summary",
+        "path": "/industry/orders/summary/",
+        "publish": true,
+        "description": "page_finder.orders.summary.description",
+        "keywords": [ "orders", "manufacturing", "profit", "summary" ]
+    },
+    {
         "slug": "industry.blueprints",
         "path": "/industry/blueprints/",
         "publish": true,

--- a/frontend/app/src/pages/industry/orders.astro
+++ b/frontend/app/src/pages/industry/orders.astro
@@ -123,6 +123,13 @@ const page_title = t('industry.orders.page_title');
 
         <PageSubheader slot="subheader">
             <Button
+                href={translatePath('/industry/orders/summary/')}
+                size='sm'
+            >
+                {t('view_orders_summary')}
+            </Button>
+
+            <Button
                 href={translatePath('/industry/orders/history/')}
                 size='sm'
             >

--- a/frontend/app/src/pages/industry/orders/summary.astro
+++ b/frontend/app/src/pages/industry/orders/summary.astro
@@ -1,0 +1,196 @@
+---
+import { i18n } from '@helpers/i18n'
+const { t, translatePath } = i18n(Astro.url)
+
+import { get_site_origin } from '@helpers/seo'
+import {
+    get_orders_profit_summary,
+    get_planner_facilities,
+    type PlannerFacility,
+} from '@helpers/api.minmatar.org/industry'
+import type { OrdersProfitSummary } from '@dtypes/api.minmatar.org'
+
+import Viewport from '@layouts/Viewport.astro'
+import PageLanding from '@components/page/PageLanding.astro'
+import PageTitle from '@components/page/PageTitle.astro'
+import Flexblock from '@components/compositions/Flexblock.astro'
+import OpenOrdersProfitSummary from '@components/blocks/industry/guide-order-summary/OpenOrdersProfitSummary.astro'
+import ErrorRefetch from '@components/blocks/ErrorRefetch.astro'
+import Button from '@components/blocks/Button.astro'
+
+function isoDate(d: Date): string {
+    return d.toISOString().slice(0, 10)
+}
+
+const today = new Date()
+const default_from = new Date(today)
+default_from.setUTCDate(default_from.getUTCDate() - 30)
+const default_to = new Date(today)
+default_to.setUTCDate(default_to.getUTCDate() + 60)
+
+const params = Astro.url.searchParams
+const needed_by_from = params.get('needed_by_from') || isoDate(default_from)
+const needed_by_to = params.get('needed_by_to') || isoDate(default_to)
+const applied = params.get('applied') === '1'
+const open_only = applied
+    ? params.get('open_only') === '1' || params.get('open_only') === 'true'
+    : params.get('open_only') !== '0' && params.get('open_only') !== 'false'
+const facility_key = (params.get('facility_key') || 'amamake').toLowerCase()
+const order_id_params = params.getAll('order_ids').filter(Boolean)
+const selected_order_ids = order_id_params
+    .map((id) => parseInt(id, 10))
+    .filter((id) => !Number.isNaN(id) && id > 0)
+
+let summary: OrdersProfitSummary | null = null
+let facilities: PlannerFacility[] = []
+let fetching_error: Error | false = false
+
+try {
+    ;[summary, facilities] = await Promise.all([
+        get_orders_profit_summary({
+            needed_by_from,
+            needed_by_to,
+            open_only,
+            facility_key,
+            // When the form was submitted, honor explicit selection (including empty).
+            order_ids: applied ? selected_order_ids.join(',') : undefined,
+        }),
+        get_planner_facilities(),
+    ])
+    if (!facilities.some((f) => f.key === facility_key) && facilities[0]) {
+        // Keep URL facility if API still accepts it; list may be empty on error.
+    }
+} catch (error) {
+    fetching_error = error
+}
+
+if (facilities.length === 0) {
+    facilities = [
+        {
+            key: 'amamake',
+            system_id: 30002537,
+            system_name: 'Amamake',
+            structures: [],
+            system_cost_bonus: 0,
+            facility_tax: 0,
+            scc_surcharge: 0,
+            reprocessing: {
+                structure_name: '',
+                structure_type_id: 0,
+                rig_name: '',
+                rig_type_id: 0,
+                facility_base_yield: 0,
+                refine_rate: 0,
+                facility_tax: 0,
+                effects: [],
+            },
+        },
+    ]
+}
+
+const page_title = t('industry.orders.summary.page_title')
+const page_description = t('industry.orders.summary.leading_text')
+const meta_title = t('industry.orders.summary.meta_title').replace(
+    '{site}',
+    t('index.page_title'),
+)
+const meta_description = t('industry.orders.summary.meta_description')
+const site_origin = get_site_origin(Astro.url.origin)
+const canonical_url = new URL(
+    translatePath('/industry/orders/summary/'),
+    site_origin,
+).href
+const meta_image = new URL('/images/industry-cover.jpg', site_origin).href
+
+import {
+    get_location_video_cover,
+    get_location_video_cover_thumb,
+    get_location_cover,
+    get_location_cover_990,
+} from '@helpers/covers'
+---
+
+<Viewport
+    title={meta_title}
+    meta_description={meta_description}
+    meta_image={meta_image}
+    canonical_url={canonical_url}
+    og_type="article"
+    components={{
+        alert_dialog: true,
+        tippy: true,
+    }}
+>
+    <PageLanding
+        wide={true}
+        cover={{
+            video:
+                get_location_video_cover('Amamake - 5 times nearly AT winners') ??
+                undefined,
+            video_thumb:
+                get_location_video_cover_thumb(
+                    'Amamake - 5 times nearly AT winners',
+                ) ?? undefined,
+            image:
+                get_location_cover('Amamake - 5 times nearly AT winners') ??
+                '/images/industry-cover.jpg',
+            image_990:
+                get_location_cover_990('Amamake - 5 times nearly AT winners') ??
+                '/images/industry-cover.jpg',
+            animated: false,
+            scrollable: true,
+            overlay: true,
+        }}
+    >
+        <Flexblock gap="var(--space-2xl)" class="[ w-full ]">
+            <Flexblock gap="var(--space-xl)" class="[ w-full ]">
+                <Flexblock gap="var(--space-3xs)">
+                    <PageTitle is_landing={true}>{page_title}</PageTitle>
+                </Flexblock>
+                <p class="[ excerpt ]">{page_description}</p>
+                <Button href={translatePath('/industry/orders/')} size="sm">
+                    {t('view_active_orders')}
+                </Button>
+            </Flexblock>
+
+            {
+                fetching_error !== false ? (
+                    <ErrorRefetch
+                        args={{
+                            partial: translatePath(
+                                `/industry/orders/summary/?needed_by_from=${needed_by_from}&needed_by_to=${needed_by_to}&open_only=${open_only ? '1' : '0'}&facility_key=${facility_key}`,
+                            ),
+                            error: fetching_error,
+                            delay: 0,
+                        }}
+                    />
+                ) : summary ? (
+                    <OpenOrdersProfitSummary
+                        summary={summary}
+                        facilities={facilities}
+                        facility_key={facility_key}
+                        needed_by_from={needed_by_from}
+                        needed_by_to={needed_by_to}
+                        open_only={open_only}
+                        selected_order_ids={
+                            applied
+                                ? selected_order_ids
+                                : summary.orders
+                                      .filter((o) => o.included)
+                                      .map((o) => o.id)
+                        }
+                    />
+                ) : null
+            }
+        </Flexblock>
+    </PageLanding>
+</Viewport>
+
+<style lang="scss">
+    .excerpt,
+    :global(.excerpt p) {
+        font-size: var(--step-1);
+        line-height: 1.6;
+        max-width: 48rem;
+    }
+</style>

--- a/frontend/app/src/pages/partials/order_summary_results_component.astro
+++ b/frontend/app/src/pages/partials/order_summary_results_component.astro
@@ -1,0 +1,81 @@
+---
+import { i18n } from '@helpers/i18n'
+const { translatePath } = i18n(Astro.url)
+
+import {
+    get_orders_profit_summary,
+    get_planner_facilities,
+} from '@helpers/api.minmatar.org/industry'
+import type { OrdersProfitSummary } from '@dtypes/api.minmatar.org'
+import OpenOrdersProfitSummaryResults from '@components/blocks/industry/guide-order-summary/OpenOrdersProfitSummaryResults.astro'
+import OpenOrdersProfitSummaryOrders from '@components/blocks/industry/guide-order-summary/OpenOrdersProfitSummaryOrders.astro'
+import ErrorRefetch from '@components/blocks/ErrorRefetch.astro'
+
+const params = Astro.url.searchParams
+const needed_by_from = params.get('needed_by_from') || ''
+const needed_by_to = params.get('needed_by_to') || ''
+const open_only =
+    params.get('open_only') === '1' || params.get('open_only') === 'true'
+const facility_key = (params.get('facility_key') || 'amamake').toLowerCase()
+const order_id_params = params.getAll('order_ids').filter(Boolean)
+const selected_order_ids = order_id_params
+    .map((id) => parseInt(id, 10))
+    .filter((id) => !Number.isNaN(id) && id > 0)
+const refresh_orders = params.get('refresh_orders') === '1'
+
+let summary: OrdersProfitSummary | null = null
+let fetching_error: Error | false = false
+
+try {
+    // Date / open-only changes rebuild the order list and include every match.
+    // Facility / checkbox changes keep the current selection (including none).
+    summary = await get_orders_profit_summary({
+        needed_by_from: needed_by_from || undefined,
+        needed_by_to: needed_by_to || undefined,
+        open_only,
+        facility_key,
+        order_ids: refresh_orders
+            ? undefined
+            : selected_order_ids.join(','),
+    })
+} catch (error) {
+    fetching_error = error
+}
+
+const facilities = await get_planner_facilities().catch(() => [])
+const facility_label =
+    facilities.find((f) => f.key === facility_key)?.system_name ??
+    facility_key.replace(/^\w/, (c) => c.toUpperCase())
+
+const partial_qs = Astro.url.search
+const partial_url = `${translatePath('/partials/order_summary_results_component')}${partial_qs}`
+---
+
+{
+    fetching_error !== false ? (
+        <ErrorRefetch
+            args={{
+                partial: partial_url,
+                error: fetching_error,
+                delay: 0,
+            }}
+        />
+    ) : summary ? (
+        <>
+            <OpenOrdersProfitSummaryResults
+                summary={summary}
+                facility_label={facility_label}
+            />
+            {refresh_orders ? (
+                <div id="order-summary-orders" hx-swap-oob="innerHTML">
+                    <OpenOrdersProfitSummaryOrders
+                        orders={summary.orders}
+                        selected_order_ids={summary.orders
+                            .filter((order) => order.included)
+                            .map((order) => order.id)}
+                    />
+                </div>
+            ) : null}
+        </>
+    ) : null
+}

--- a/frontend/app/src/types/api.minmatar.org.ts
+++ b/frontend/app/src/types/api.minmatar.org.ts
@@ -1144,6 +1144,51 @@ export interface IndustryOrder {
     assigned_to:        Character[];
 }
 
+export interface OrdersProfitSummaryOrder {
+    id:                 number;
+    public_short_code:  string;
+    needed_by:          string;
+    location_label:     string;
+    fulfilled_at:       string | null;
+    item_count:         number;
+    item_type_ids:      number[];
+    included:           boolean;
+}
+
+export interface OrdersProfitSummaryRow {
+    name:           string;
+    type_id:        number;
+    kind:           string;
+    qty:            number;
+    isk_per_lp:     number | null;
+    cost_per:       number;
+    unit_price:     number;
+    price_source:   string;
+    profit_per:     number;
+    order_profit:   number;
+    note?:          string | null;
+}
+
+export interface OrdersProfitSummaryTotals {
+    total_order_amount: number;
+    total_profit:   number;
+    line_count:     number;
+    total_qty:      number;
+    best_name:      string | null;
+    best_profit:    number | null;
+    worst_name:     string | null;
+    worst_profit:   number | null;
+}
+
+export interface OrdersProfitSummary {
+    orders:         OrdersProfitSummaryOrder[];
+    rows:           OrdersProfitSummaryRow[];
+    totals:         OrdersProfitSummaryTotals;
+    assumptions:    string[];
+    facility_key:   string;
+    compressed:     boolean;
+}
+
 export const freight_contract_statuses = [ 'outstanding', 'in_progress', 'finished'  ] as const
 export type FreightContractStatus = typeof freight_contract_statuses[number]
 


### PR DESCRIPTION
## Summary
- Adds `/industry/orders/summary/` to roll up included industry orders by product: build cost at a selectable system, revenue from order asks (Jita only when ask is missing), and claim-batch cost planning.
- Filters (needed-by, build location, open-only, order checkboxes) refresh metrics/chart/table via HTMX with skeletons; order list shows product icons instead of “N lines”.
- Wires `GET /api/industry/orders/profit-summary`, an Order summary button on active orders, and supporting unit-cost helpers/tests (guide export/seed tooling included for demos).

## Test plan
- [ ] Open `/industry/orders/` → **Order summary**
- [ ] Change dates, build location, open-only, and order checkboxes; confirm only metrics/chart/table refresh (skeleton while loading)
- [ ] Confirm Total order amount / profit / products / items match included asks and costs
- [ ] Confirm product icons appear on order rows; checked boxes use fleet red
- [ ] `pipenv run python manage.py test industry.tests.test_orders_profit_summary --settings=app.settings_test`


Made with [Cursor](https://cursor.com)