### PR TITLE
Skip stale capital jump-range Discord pings

### DIFF
--- a/backend/feed/constants.py
+++ b/backend/feed/constants.py
@@ -134,7 +134,9 @@ ROLLUP_VERSIONS: dict[str, int] = {
 # Capital kill Discord pings (radius from Amamake)
 AMAMAKE_SOLAR_SYSTEM_ID = 30002537
 CAPITAL_PING_MAX_LIGHT_YEARS = 8.0
-CAPITAL_PING_MAX_AGE_SECONDS = 3600
+# Only ping for genuinely fresh kills. Stale killmails (feed backlog, bot
+# restarts, replays) must not fire a "capital within jump range" alert.
+CAPITAL_PING_MAX_AGE_SECONDS = 180
 # Reuse one Discord message for further capital-related kills in the same system.
 CAPITAL_PING_SESSION_SECONDS = 30 * 60
 METERS_PER_LIGHT_YEAR = 9_460_528_400_000_000

--- a/backend/feed/helpers/r2z2.py
+++ b/backend/feed/helpers/r2z2.py
@@ -471,7 +471,9 @@ def poll_r2z2_batch(  # noqa: C901
                 deadline=deadline,
                 allowlist=allowlist,
                 stats=stats,
-                apply_age_gate=False,
+                # Age-gate live too: a gap (bot restart, feed backlog) makes
+                # the live phase churn stale sequences, which must not ping.
+                apply_age_gate=True,
                 pending_capital=pending_capital,
             )
 

--- a/backend/feed/tests/test_capital_pings.py
+++ b/backend/feed/tests/test_capital_pings.py
@@ -665,6 +665,22 @@ class CapitalPingTestCase(TestCase):
         self.assertEqual(FeedCapitalPing.objects.count(), 0)
 
     @patch("feed.helpers.capital_pings.DiscordClient")
+    def test_maybe_notify_age_gate_skips_recently_stale_kill(
+        self, mock_client_cls
+    ):
+        payload = make_killmail_payload(
+            136500018,
+            solar_system_id=AMAMAKE_SOLAR_SYSTEM_ID,
+            ship_type_id=73790,
+            killmail_time=dj_tz.now() - timedelta(minutes=5),
+        )
+        self.assertIsNone(
+            maybe_notify_capital_kill(payload, apply_age_gate=True)
+        )
+        mock_client_cls.return_value.create_message.assert_not_called()
+        self.assertEqual(FeedCapitalPing.objects.count(), 0)
+
+    @patch("feed.helpers.capital_pings.DiscordClient")
     def test_maybe_notify_age_gate_allows_fresh_kill(self, mock_client_cls):
         mock_client = MagicMock()
         create_response = MagicMock()
@@ -676,7 +692,7 @@ class CapitalPingTestCase(TestCase):
             136500009,
             solar_system_id=AMAMAKE_SOLAR_SYSTEM_ID,
             ship_type_id=73790,
-            killmail_time=dj_tz.now() - timedelta(minutes=5),
+            killmail_time=dj_tz.now() - timedelta(minutes=1),
         )
         self.assertTrue(
             maybe_notify_capital_kill(payload, apply_age_gate=True)


### PR DESCRIPTION
## Summary
- Apply the capital-ping age gate to the live R2Z2 poll phase (previously only catch-up was gated), so feed backlogs and bot restarts no longer fire “capital within jump range” alerts for old killmails.
- Tighten `CAPITAL_PING_MAX_AGE_SECONDS` from 1 hour to 3 minutes.
- Add/adjust tests for freshly stale (5 min) vs fresh (1 min) killmails.

## Test plan
- [x] `pipenv run python manage.py test feed.tests.test_capital_pings feed.tests.test_r2z2 --settings=app.settings_test`
- [ ] Confirm a capital kill within ~3 minutes still posts to the capital ping channel
- [ ] Confirm a delayed/backlog capital kill older than 3 minutes is ingested but does not Discord-ping (`capital_pings_age_skipped` increments)


Made with [Cursor](https://cursor.com)