### PR TITLE
Fix industry order item claiming on detail page

### DIFF
--- a/frontend/app/src/components/blocks/ButtonClaimOrder.astro
+++ b/frontend/app/src/components/blocks/ButtonClaimOrder.astro
@@ -16,6 +16,7 @@ interface Props {
     has_blueprints?: boolean;
     hidden?:        boolean;
     id?:            string;
+    render?:        'order_item' | 'breakdown';
 }
 
 const {
@@ -29,9 +30,11 @@ const {
     has_blueprints = false,
     hidden = false,
     id,
+    render = 'order_item',
 } = Astro.props
 
 import { hours_diff } from '@helpers/date'
+import { query_string } from '@helpers/string'
 
 const is_assign_window = new Date(item.self_assign_window_ends_at) > new Date()
 const hours_left = hours_diff(new Date(), item.self_assign_window_ends_at)
@@ -39,12 +42,17 @@ const hours_left = hours_diff(new Date(), item.self_assign_window_ends_at)
 let clip_maximum = false
 let max_claimable_items = item.unassigned_quantity
 
-if (item.self_assign_maximum && item.self_assign_maximum > item.unassigned_quantity && is_assign_window) {
-    max_claimable_items = item.self_assign_maximum - claimed
-    clip_maximum = true
+if (item.self_assign_maximum != null && is_assign_window) {
+    const remaining_under_cap = Math.max(0, item.self_assign_maximum - claimed)
+    max_claimable_items = Math.min(item.unassigned_quantity, remaining_under_cap)
+    clip_maximum = remaining_under_cap < item.unassigned_quantity
 }
 
-const ORDER_ITEM_PARTIAL_URL = translatePath(`/partials/order_item_component?order_id=${order_id}&item_id=${item.id}`)
+const ORDER_ITEM_PARTIAL_URL = translatePath(`/partials/order_item_component?${query_string({
+    order_id: order_id,
+    item_id: item.id,
+    ...(render === 'breakdown' ? { render: 'breakdown' } : {}),
+})}`)
 
 import { number_thousand_separator } from '@helpers/numbers'
 

--- a/frontend/app/src/components/blocks/OrderBreakdown.astro
+++ b/frontend/app/src/components/blocks/OrderBreakdown.astro
@@ -3,6 +3,7 @@ import { i18n } from '@helpers/i18n'
 const { t, translatePath } = i18n(Astro.url)
 
 import type { RootSingleItem } from '@dtypes/api.minmatar.org'
+import type { Alert } from '@dtypes/layout_components'
 
 interface Props {
     order_id:                   number;
@@ -11,6 +12,11 @@ interface Props {
     order_breakdown:            RootSingleItem[];
     location_name:              string | undefined;
     init_tooltips?:             boolean;
+    /** HTMX swap target for claim/delivery. Detail page uses the breakdown root. */
+    swap_target_id?:            string;
+    /** After claim/delivery, render breakdown-only HTML instead of the list OrderItem card. */
+    claim_render?:              'order_item' | 'breakdown';
+    alert?:                     Alert | null;
 }
 
 const {
@@ -20,6 +26,9 @@ const {
     order_breakdown,
     location_name,
     init_tooltips = false,
+    swap_target_id,
+    claim_render = 'order_item',
+    alert = null,
 } = Astro.props
 
 import { query_string } from '@helpers/string';
@@ -32,6 +41,8 @@ const ORDER_BREAKDOWN_PARTIAL_URL = `${translatePath('/partials/order_breakdown_
 })}`
 
 const id = `order-breakdown-${order_id}-inner`
+const hx_swap_target = swap_target_id ?? `order-item-${order_id}`
+const claim_query = claim_render === 'breakdown' ? { render: 'breakdown' } : {}
 
 import { number_thousand_separator } from '@helpers/numbers'
 
@@ -57,7 +68,10 @@ import RefreshIcon from '@components/icons/buttons/RefreshIcon.astro';
 import AddIcon from '@components/icons/buttons/AddIcon.astro';
 ---
 
-<Flexblock id={id}>
+<Flexblock
+    id={id}
+    x-init={alert ? `show_alert_dialog(${JSON.stringify(alert)})` : undefined}
+>
     <hr class="border-bottom">
     <StylessButton
         hx-get={ORDER_BREAKDOWN_PARTIAL_URL}
@@ -196,13 +210,14 @@ import AddIcon from '@components/icons/buttons/AddIcon.astro';
                                         </span>
                                         :
                                         <ButtonClaimOrder
-                                            target_id={`order-item-${order_id}`}
+                                            target_id={hx_swap_target}
                                             reclaim={Boolean(user_assignment)}
                                             order_id={order_id}
                                             claimed={user_assignment?.quantity ?? 0}
                                             item={item}
                                             character_id={primary_character_id as number}
                                             has_blueprints={user_assignment?.has_blueprints ?? false}
+                                            render={claim_render}
                                         />
                                     }</>
                                 }
@@ -231,8 +246,9 @@ import AddIcon from '@components/icons/buttons/AddIcon.astro';
                                                     item_id: item.id,
                                                     assignment_id: user_assignment.id,
                                                     delivery: false,
+                                                    ...claim_query,
                                                 })}`}
-                                                hx-target={`#order-item-${order_id}`}
+                                                hx-target={`#${hx_swap_target}`}
                                                 hx-indicator=".loader"
                                                 hx-swap="outerHTML transition:true"
                                                 x-on:click="$el.setAttribute('disabled','')"

--- a/frontend/app/src/components/blocks/OrderItem.astro
+++ b/frontend/app/src/components/blocks/OrderItem.astro
@@ -3,7 +3,7 @@ import { i18n } from '@helpers/i18n'
 const { lang, t, translatePath } = i18n(Astro.url)
 
 import type { RootSingleItem } from '@dtypes/api.minmatar.org'
-import type { IndustryOrderUI } from '@dtypes/layout_components'
+import type { Alert, IndustryOrderUI } from '@dtypes/layout_components'
 
 interface Props {
     order:                  IndustryOrderUI;
@@ -12,6 +12,7 @@ interface Props {
     claim_disabled_reason?: string | null;
     location_name:          string | undefined;
     init_tooltips:          boolean;
+    alert?:                 Alert | null;
 }
 
 const {
@@ -21,6 +22,7 @@ const {
     claim_disabled_reason = null,
     location_name,
     init_tooltips,
+    alert = null,
 } = Astro.props
 
 import {
@@ -60,7 +62,10 @@ import FlagIcon from '@components/icons/FlagIcon.astro';
 import TippyOrderItem from './TippyOrderItem.astro';
 ---
 
-<div id={`order-item-${order.id}`}>
+<div
+    id={`order-item-${order.id}`}
+    x-init={alert ? `show_alert_dialog(${JSON.stringify(alert)})` : undefined}
+>
     <a
         href={order_detail_href}
         class="[ order-item-link ]"

--- a/frontend/app/src/pages/partials/order_breakdown_component.astro
+++ b/frontend/app/src/pages/partials/order_breakdown_component.astro
@@ -71,6 +71,8 @@ import ErrorRefetch from '@components/blocks/ErrorRefetch.astro'
             order_breakdown={order_breakdown}
             location_name={location_name ?? undefined}
             init_tooltips={true}
+            swap_target_id={`order-breakdown-${order_id}-inner`}
+            claim_render="breakdown"
         />
         :
         <DebugTag>{t('no_order_unexpected_error')}</DebugTag>

--- a/frontend/app/src/pages/partials/order_item_component.astro
+++ b/frontend/app/src/pages/partials/order_item_component.astro
@@ -15,6 +15,7 @@ import type { IndustryOrderUI, Alert } from '@dtypes/layout_components'
 import { post_order_item_assignment, mark_assignment } from '@helpers/api.minmatar.org/industry'
 
 const order_id = parseInt(Astro.url.searchParams.get('order_id') ?? '')
+const render_mode = Astro.url.searchParams.get('render') === 'breakdown' ? 'breakdown' : 'order_item'
 let alert:Alert | null = null
 let fetch_breakdown = false
 
@@ -112,16 +113,19 @@ const claim_disabled_reason_by_availability: Record<Exclude<PrimaryClaimAvailabi
 }
 
 try {
-    order = await fetch_order_by_id(order_id)
+    if (render_mode !== 'breakdown') {
+        order = await fetch_order_by_id(order_id)
+    }
 
     if (!fetch_breakdown)
         fetch_breakdown = JSON.parse(Astro.url.searchParams.get('fetch_breakdown') ?? 'false')
 
-    if (fetch_breakdown) {
+    if (fetch_breakdown || render_mode === 'breakdown') {
         order_breakdown = await fetch_order_breakdown_grouped(order_id)
         const primary = await resolve_primary_for_claim(auth_token)
         primary_character_id = primary.character_id
         claim_availability = primary.availability
+        fetch_breakdown = true
     }
 } catch (error) {
     fetching_error = error
@@ -135,14 +139,13 @@ import { query_string } from '@helpers/string';
 const ORDER_ITEM_PARTIAL_URL = translatePath(`/partials/order_item_component?${query_string({
     order_id: order_id,
     fetch_breakdown: fetch_breakdown,
+    ...(render_mode === 'breakdown' ? { render: 'breakdown' } : {}),
 })}`)
 
 import OrderItem from '@components/blocks/OrderItem.astro';
+import OrderBreakdown from '@components/blocks/OrderBreakdown.astro'
 import ErrorRefetch from '@components/blocks/ErrorRefetch.astro'
-import ShowAlert from '@components/blocks/ShowAlert.astro'
 ---
-
-{alert && <ShowAlert alert={alert} /> }
 
 {fetching_error !== false ?
     <ErrorRefetch
@@ -151,6 +154,17 @@ import ShowAlert from '@components/blocks/ShowAlert.astro'
             error: fetching_error,
             delay: 0,
         }}
+    /> : render_mode === 'breakdown' ?
+    <OrderBreakdown
+        order_id={order_id}
+        primary_character_id={primary_character_id}
+        claim_disabled_reason={claim_disabled_reason}
+        order_breakdown={order_breakdown}
+        location_name={undefined}
+        init_tooltips={true}
+        swap_target_id={`order-breakdown-${order_id}-inner`}
+        claim_render="breakdown"
+        alert={alert}
     /> :
     <OrderItem
         order={order as IndustryOrderUI }
@@ -159,5 +173,6 @@ import ShowAlert from '@components/blocks/ShowAlert.astro'
         location_name={order?.location.location_name}
         primary_character_id={fetch_breakdown ? primary_character_id : undefined}
         claim_disabled_reason={fetch_breakdown ? claim_disabled_reason : undefined}
+        alert={alert}
     />
 }


### PR DESCRIPTION
## Summary
- Claim/delivery HTMX actions on the order detail page now target `#order-breakdown-{id}-inner` and re-render the breakdown, so posts are no longer dropped with `htmx:targetError`.
- Restore the 48h per-character claim max in the claim dialog (`min(unassigned, cap − already claimed)`).
- Surface claim errors via `x-init` on the swapped root instead of a sibling `ShowAlert` that HTMX discarded.

## Test plan
- [ ] Open `/industry/orders/{id}/` while logged in
- [ ] Claim a line within the 48h cap and confirm the producer appears without a full page reload
- [ ] Confirm the dialog max quantity respects `self_assign_maximum` during the window
- [ ] Trigger a claim error (e.g. over cap via API) and confirm an alert shows without blanking the breakdown
- [ ] Smoke-check claim from the orders list card still works


Made with [Cursor](https://cursor.com)