### PR TITLE
Dedupe fleet sightings and upgrade growing gangs in place

### DIFF
--- a/backend/feed/constants.py
+++ b/backend/feed/constants.py
@@ -127,7 +127,7 @@ DEFAULT_ROLLUP_CONFIG: dict[str, dict] = {
 
 ROLLUP_VERSIONS: dict[str, int] = {
     "kill_burst": 6,
-    "fleet_active": 9,
+    "fleet_active": 10,
     "contested_change": 1,
 }
 

--- a/backend/feed/helpers/clusters.py
+++ b/backend/feed/helpers/clusters.py
@@ -106,17 +106,24 @@ def _find_active_fleet_cluster(
     stale_minutes: int,
 ) -> FeedCluster | None:
     cutoff = window_start - timedelta(minutes=stale_minutes)
-    return (
-        FeedCluster.objects.filter(
-            cluster_type=FeedCluster.ClusterType.FLEET_ENGAGEMENT,
-            solar_system_id=solar_system_id,
-            dominant_faction_id=faction_id,
-            is_active=True,
-            last_kill_at__gte=cutoff,
-        )
-        .order_by("-last_kill_at")
-        .first()
-    )
+    active = FeedCluster.objects.filter(
+        cluster_type=FeedCluster.ClusterType.FLEET_ENGAGEMENT,
+        solar_system_id=solar_system_id,
+        is_active=True,
+        last_kill_at__gte=cutoff,
+    ).order_by("-last_kill_at")
+
+    exact = active.filter(dominant_faction_id=faction_id).first()
+    if exact is not None:
+        return exact
+
+    # An orphan window whose dominant faction is unknown (NULL/0) still belongs
+    # to the active fight in the system; likewise attach a newly-resolved faction
+    # to a cluster whose faction could not previously be determined. This avoids
+    # splitting one engagement across ``:0:`` and ``:<faction>:`` cluster keys.
+    if faction_id is None:
+        return active.first()
+    return active.filter(dominant_faction_id__isnull=True).first()
 
 
 def _merge_fleet_cluster(
@@ -159,7 +166,7 @@ def _cluster_defaults(
     }
 
 
-def _build_cluster_stats(killmails: list[FeedKillmail]) -> dict[str, Any]:
+def build_cluster_stats(killmails: list[FeedKillmail]) -> dict[str, Any]:
     attacker_ids: set[int] = set()
     ship_counts: Counter[str] = Counter()
     killmail_ids: list[int] = []
@@ -194,6 +201,10 @@ def _build_cluster_stats(killmails: list[FeedKillmail]) -> dict[str, Any]:
         "attacker_ids": sorted(attacker_ids),
         "killmail_ids": killmail_ids,
     }
+
+
+# Backwards-compatible internal alias.
+_build_cluster_stats = build_cluster_stats
 
 
 def detect_clusters(*, since_hours: int = 48) -> int:

--- a/backend/feed/helpers/clusters.py
+++ b/backend/feed/helpers/clusters.py
@@ -71,7 +71,7 @@ def _upsert_kill_burst_cluster(
         killmails = list(
             FeedKillmail.objects.filter(killmail_id__in=merged_ids)
         )
-        stats = _build_cluster_stats(killmails)
+        stats = build_cluster_stats(killmails)
 
     canonical_key = _cluster_key(
         FeedCluster.ClusterType.KILL_BURST,
@@ -131,7 +131,7 @@ def _merge_fleet_cluster(
 ) -> FeedCluster:
     merged_ids = sorted(set(existing.killmail_ids or []) | set(killmail_ids))
     killmails = list(FeedKillmail.objects.filter(killmail_id__in=merged_ids))
-    stats = _build_cluster_stats(killmails)
+    stats = build_cluster_stats(killmails)
     existing.dominant_faction_id = stats["dominant_faction_id"]
     existing.started_at = stats["started_at"]
     existing.last_kill_at = stats["last_kill_at"]
@@ -201,10 +201,6 @@ def build_cluster_stats(killmails: list[FeedKillmail]) -> dict[str, Any]:
         "attacker_ids": sorted(attacker_ids),
         "killmail_ids": killmail_ids,
     }
-
-
-# Backwards-compatible internal alias.
-_build_cluster_stats = build_cluster_stats
 
 
 def detect_clusters(*, since_hours: int = 48) -> int:
@@ -300,7 +296,7 @@ def _sliding_window_clusters(
             j += 1
 
         if len(window_kills) >= min_kills:
-            stats = _build_cluster_stats(window_kills)
+            stats = build_cluster_stats(window_kills)
             if stats["pilot_count"] >= min_pilots:
                 if cluster_type == FeedCluster.ClusterType.FLEET_ENGAGEMENT:
                     stale_minutes = get_rollup_config("fleet_active").get(

--- a/backend/feed/rollups/fleet_active.py
+++ b/backend/feed/rollups/fleet_active.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from feed.constants import FACTION_AMARR, FACTION_MINMATAR
+from feed.helpers.clusters import build_cluster_stats
 from feed.helpers.killmail_classify import (
     dominant_attacker_faction,
     faction_to_accent_key,
@@ -53,8 +54,13 @@ def _dominant_faction_for_cluster(cluster: FeedCluster) -> int | None:
 
 def _collapse_fleet_clusters(
     clusters,
-) -> list[tuple[FeedCluster, datetime, int | None]]:
-    """Merge adjacent time-bucket splits of the same fight into one cluster."""
+) -> list[list[tuple[FeedCluster, int | None]]]:
+    """Group adjacent time-bucket splits of the same fight into chains.
+
+    Each returned chain is an ordered (by ``started_at``) list of
+    ``(cluster, faction_id)`` tuples that together represent one continuous
+    engagement in a system for a single militia faction.
+    """
     stale_minutes = get_rollup_config("fleet_active").get("stale_minutes", 20)
     stale_delta = timedelta(minutes=stale_minutes)
     chains: list[list[tuple[FeedCluster, int | None]]] = []
@@ -80,23 +86,58 @@ def _collapse_fleet_clusters(
                 break
         if not placed:
             chains.append([(cluster, faction)])
+    return chains
 
-    collapsed: list[tuple[FeedCluster, datetime, int | None]] = []
-    for chain in chains:
-        representative = max(chain, key=lambda row: row[0].last_kill_at)[0]
-        engagement_start = min(row[0].started_at for row in chain)
-        faction = _dominant_faction_for_cluster(representative)
-        collapsed.append((representative, engagement_start, faction))
-    return collapsed
+
+def _persist_fleet_chain(
+    chain: list[tuple[FeedCluster, int | None]],
+) -> tuple[FeedCluster, int | None]:
+    """Collapse a chain into its earliest cluster and drop the extras.
+
+    The earliest cluster becomes the canonical, stable identity for the fight.
+    Killmails from later splits are merged into it and the sibling rows are
+    deleted so a subsequent rollup pass cannot re-key the same engagement.
+    """
+    ordered = sorted(chain, key=lambda row: row[0].started_at)
+    canonical = ordered[0][0]
+    extras = [cluster for cluster, _ in ordered[1:]]
+    if extras:
+        merged_ids: set[int] = set(canonical.killmail_ids or [])
+        for cluster in extras:
+            merged_ids |= set(cluster.killmail_ids or [])
+        killmails = list(
+            FeedKillmail.objects.filter(killmail_id__in=merged_ids)
+        )
+        stats = build_cluster_stats(killmails)
+        tip = max(
+            (cluster for cluster, _ in ordered),
+            key=lambda cluster: cluster.last_kill_at,
+        )
+        canonical.dominant_faction_id = stats["dominant_faction_id"]
+        canonical.started_at = stats["started_at"]
+        canonical.last_kill_at = stats["last_kill_at"]
+        canonical.kill_count = stats["kill_count"]
+        canonical.pilot_count = stats["pilot_count"]
+        canonical.ship_counts = stats["ship_counts"]
+        canonical.attacker_ids = stats["attacker_ids"]
+        canonical.killmail_ids = stats["killmail_ids"]
+        canonical.is_active = tip.is_active
+        canonical.ended_at = None if tip.is_active else stats["last_kill_at"]
+        canonical.save()
+        FeedCluster.objects.filter(
+            pk__in=[cluster.pk for cluster in extras]
+        ).delete()
+
+    faction = _dominant_faction_for_cluster(canonical)
+    return canonical, faction
 
 
 def _fleet_event_cluster_key(
     cluster: FeedCluster,
     *,
-    engagement_start: datetime,
     faction_id: int | None,
 ) -> str:
-    started = engagement_start.replace(second=0, microsecond=0)
+    started = cluster.started_at.replace(second=0, microsecond=0)
     faction = faction_id if faction_id is not None else 0
     return (
         f"fleet_active:{cluster.solar_system_id}:{faction}:"
@@ -112,32 +153,17 @@ def run_fleet_active_rollup(ctx: RollupContext) -> list[RollupResult]:
         last_kill_at__lte=ctx.until,
     )
     results: list[RollupResult] = []
-    best_by_key: dict[str, tuple[FeedCluster, int | None]] = {}
-    engagement_start_by_key: dict[str, datetime] = {}
-    for cluster, engagement_start, faction_id in _collapse_fleet_clusters(
-        clusters
-    ):
-        key = _fleet_event_cluster_key(
-            cluster,
-            engagement_start=engagement_start,
-            faction_id=faction_id,
-        )
-        prev = best_by_key.get(key)
-        if prev is None or cluster.last_kill_at > prev[0].last_kill_at:
-            best_by_key[key] = (cluster, faction_id)
-            engagement_start_by_key[key] = engagement_start
-
-    for key, (cluster, faction_id) in best_by_key.items():
+    for chain in _collapse_fleet_clusters(clusters):
+        cluster, faction_id = _persist_fleet_chain(chain)
         if faction_id is None or cluster.pilot_count <= 5:
             continue
         system = _system_name(ctx, cluster.solar_system_id)
-        engagement_start = engagement_start_by_key[key]
         copy = build_militia_engagement_copy(
             faction_label=_faction_label(faction_id),
             system=system,
             kills=cluster.kill_count,
             pilots=cluster.pilot_count,
-            started_at=engagement_start,
+            started_at=cluster.started_at,
             last_kill_at=cluster.last_kill_at,
             ship_counts=cluster.ship_counts or {},
             is_active=cluster.is_active,
@@ -148,6 +174,7 @@ def run_fleet_active_rollup(ctx: RollupContext) -> list[RollupResult]:
             limit=8,
         )
         faction_key = faction_to_accent_key(faction_id)
+        key = _fleet_event_cluster_key(cluster, faction_id=faction_id)
         results.append(
             RollupResult(
                 kind=FeedEvent.Kind.FLEET_ACTIVE,

--- a/backend/feed/rollups/writer.py
+++ b/backend/feed/rollups/writer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import timedelta
+
 from django.utils import timezone
 
 from feed.models import (
@@ -7,7 +9,12 @@ from feed.models import (
     FeedEventKillmailLink,
     FeedKillmail,
 )
+from feed.rollups.config import get_rollup_config
 from feed.rollups.types import RollupResult
+
+FLEET_ACTIVE_ROLLUP = "fleet_active"
+# Ordered smallest -> largest; index is used to detect tier upgrades.
+_FLEET_TIER_ORDER = ("small", "medium", "large", "heavy", "major")
 
 
 def write_rollup_results(results: list[RollupResult]) -> int:
@@ -19,7 +26,7 @@ def write_rollup_results(results: list[RollupResult]) -> int:
     return written
 
 
-def _upsert_event(result: RollupResult) -> FeedEvent:
+def _event_lookup(result: RollupResult) -> dict:
     lookup: dict = {"rollup_code": result.rollup_code}
     if result.cluster_key:
         lookup["cluster_key"] = result.cluster_key
@@ -30,8 +37,11 @@ def _upsert_event(result: RollupResult) -> FeedEvent:
         lookup["cluster_key"] = (
             f"{result.rollup_code}:{result.occurred_at.isoformat()}"
         )
+    return lookup
 
-    defaults = {
+
+def _event_defaults(result: RollupResult) -> dict:
+    return {
         "kind": result.kind,
         "occurred_at": result.occurred_at,
         "title": result.title,
@@ -45,20 +55,151 @@ def _upsert_event(result: RollupResult) -> FeedEvent:
         "expires_at": result.expires_at,
         "computed_at": timezone.now(),
     }
+
+
+def _upsert_event(result: RollupResult) -> FeedEvent:
+    lookup = _event_lookup(result)
+    defaults = _event_defaults(result)
+
     matches = list(
         FeedEvent.objects.filter(**lookup).order_by("-occurred_at", "-id")
     )
+    prior_payloads: list[dict] = []
     if not matches:
-        return FeedEvent.objects.create(**lookup, **defaults)
-    event = matches[0]
-    if len(matches) > 1:
-        FeedEvent.objects.filter(
-            pk__in=[row.pk for row in matches[1:]]
-        ).delete()
-    for field, value in defaults.items():
-        setattr(event, field, value)
-    event.save()
+        event = FeedEvent.objects.create(**lookup, **defaults)
+    else:
+        event = matches[0]
+        prior_payloads.append(dict(event.payload or {}))
+        if len(matches) > 1:
+            FeedEvent.objects.filter(
+                pk__in=[row.pk for row in matches[1:]]
+            ).delete()
+        for field, value in defaults.items():
+            setattr(event, field, value)
+        event.save()
+
+    if result.rollup_code == FLEET_ACTIVE_ROLLUP:
+        _coalesce_fleet_active_event(event, result, prior_payloads)
     return event
+
+
+def _tier_rank(tier: str | None) -> int:
+    try:
+        return _FLEET_TIER_ORDER.index(tier)  # type: ignore[arg-type]
+    except (ValueError, TypeError):
+        return -1
+
+
+def _find_fleet_duplicates(
+    event: FeedEvent, result: RollupResult
+) -> list[FeedEvent]:
+    """Other fleet_active events for the same ongoing engagement.
+
+    Matches same system + faction and one of: shared engagement cluster,
+    overlapping killmails, or a tip within the stale window of each other.
+    """
+    payload = event.payload or {}
+    system_id = payload.get("system_id")
+    faction = payload.get("faction")
+    if system_id is None:
+        return []
+
+    stale_minutes = get_rollup_config("fleet_active").get("stale_minutes", 20)
+    window_seconds = timedelta(minutes=stale_minutes).total_seconds()
+    related = payload.get("related_cluster_key")
+    event_kms = set(result.killmail_ids or [])
+
+    candidates = FeedEvent.objects.filter(
+        rollup_code=FLEET_ACTIVE_ROLLUP
+    ).exclude(pk=event.pk)
+
+    duplicates: list[FeedEvent] = []
+    for candidate in candidates:
+        cp = candidate.payload or {}
+        if cp.get("system_id") != system_id or cp.get("faction") != faction:
+            continue
+
+        same_engagement = bool(related) and (
+            cp.get("related_cluster_key") == related
+        )
+        close_in_time = (
+            abs((candidate.occurred_at - event.occurred_at).total_seconds())
+            <= window_seconds
+        )
+        shares_killmails = False
+        if event_kms:
+            candidate_kms = set(
+                FeedEventKillmailLink.objects.filter(
+                    feed_event=candidate
+                ).values_list("feed_killmail__killmail_id", flat=True)
+            )
+            shares_killmails = bool(event_kms & candidate_kms)
+
+        if same_engagement or close_in_time or shares_killmails:
+            duplicates.append(candidate)
+    return duplicates
+
+
+def _apply_upgrade_metadata(
+    event: FeedEvent, prior_payloads: list[dict]
+) -> None:
+    """Mark the surviving card when the fight has grown to a larger tier.
+
+    ``upgraded_at`` is sticky: once set it is carried forward on later,
+    non-upgrading updates so the UI can keep showing the cue.
+    """
+    if not prior_payloads:
+        return
+
+    payload = dict(event.payload or {})
+    new_rank = _tier_rank(payload.get("engagement_tier"))
+
+    top_prior = max(
+        prior_payloads,
+        key=lambda pp: _tier_rank(pp.get("engagement_tier")),
+    )
+    top_rank = _tier_rank(top_prior.get("engagement_tier"))
+
+    changed = False
+    if new_rank > top_rank >= 0:
+        payload["previous_tier"] = top_prior.get("engagement_tier")
+        payload["previous_kills"] = top_prior.get("kills")
+        payload["previous_pilots"] = top_prior.get("pilots")
+        payload["upgraded_at"] = timezone.now().isoformat()
+        changed = True
+    else:
+        # Carry forward an existing upgrade marker from the matched-key prior.
+        carry = prior_payloads[0]
+        if carry.get("upgraded_at"):
+            for field in (
+                "previous_tier",
+                "previous_kills",
+                "previous_pilots",
+                "upgraded_at",
+            ):
+                if carry.get(field) is not None:
+                    payload[field] = carry[field]
+                    changed = True
+
+    if changed:
+        event.payload = payload
+        event.save(update_fields=["payload", "updated_at"])
+
+
+def _coalesce_fleet_active_event(
+    event: FeedEvent, result: RollupResult, prior_payloads: list[dict]
+) -> None:
+    duplicates = _find_fleet_duplicates(event, result)
+    prior_payloads = list(prior_payloads) + [
+        dict(dup.payload or {}) for dup in duplicates
+    ]
+
+    _apply_upgrade_metadata(event, prior_payloads)
+
+    if duplicates:
+        FeedEvent.objects.filter(
+            pk__in=[dup.pk for dup in duplicates]
+        ).delete()
 
 
 def _sync_killmail_links(event: FeedEvent, killmail_ids: list[int]) -> None:

--- a/backend/feed/tests/test_fleet_active_rollup.py
+++ b/backend/feed/tests/test_fleet_active_rollup.py
@@ -5,18 +5,29 @@ from datetime import timedelta
 from django.test import TestCase
 from django.utils import timezone
 
-from feed.constants import FACTION_CALDARI
+from feed.constants import FACTION_CALDARI, FACTION_MINMATAR
 from feed.helpers.ingest import upsert_feed_killmail_from_r2z2
-from feed.models import FeedCluster
+from feed.helpers.monitored_systems import (
+    invalidate_monitored_systems_cache,
+)
+from feed.management.commands.seed_feed_monitored_systems import (
+    seed_from_fixture,
+)
+from feed.models import FeedCluster, FeedEvent
 from feed.rollups.fleet_active import (
     _collapse_fleet_clusters,
     run_fleet_active_rollup,
 )
 from feed.rollups.registry import build_context
+from feed.rollups.writer import write_rollup_results
 from feed.tests.helpers import make_killmail_payload
 
 
 class FleetActiveRollupTestCase(TestCase):
+    def setUp(self):
+        seed_from_fixture()
+        invalidate_monitored_systems_cache()
+
     def test_collapse_fleet_clusters_merges_adjacent_buckets(self):
         base = timezone.now()
         clusters = [
@@ -36,11 +47,12 @@ class FleetActiveRollupTestCase(TestCase):
         collapsed = _collapse_fleet_clusters(clusters)
 
         self.assertEqual(len(collapsed), 1)
-        representative, engagement_start = collapsed[0][:2]
-        self.assertEqual(
-            representative.last_kill_at, clusters[-1].last_kill_at
-        )
-        self.assertEqual(engagement_start, clusters[0].started_at)
+        chain = collapsed[0]
+        self.assertEqual(len(chain), 3)
+        # Chain is ordered by started_at: earliest is canonical, last carries
+        # the most recent kill.
+        self.assertEqual(chain[0][0].started_at, clusters[0].started_at)
+        self.assertEqual(chain[-1][0].last_kill_at, clusters[-1].last_kill_at)
 
     def test_collapse_fleet_clusters_keeps_separate_engagements(self):
         base = timezone.now()
@@ -123,3 +135,143 @@ class FleetActiveRollupTestCase(TestCase):
         results = run_fleet_active_rollup(ctx)
 
         self.assertEqual(len(results), 0)
+
+    def _make_fleet_cluster(
+        self,
+        *,
+        killmail_ids,
+        started_at,
+        last_kill_at,
+        kill_count,
+        pilot_count,
+        faction_id=FACTION_MINMATAR,
+        is_active=True,
+        solar_system_id=30002538,
+        key_suffix="",
+    ):
+        started_label = started_at.strftime("%Y-%m-%dT%H:%M")
+        return FeedCluster.objects.create(
+            cluster_key=(
+                f"fleet_engagement:{solar_system_id}:{faction_id}:"
+                f"{started_label}{key_suffix}"
+            ),
+            cluster_type=FeedCluster.ClusterType.FLEET_ENGAGEMENT,
+            solar_system_id=solar_system_id,
+            dominant_faction_id=faction_id,
+            started_at=started_at,
+            last_kill_at=last_kill_at,
+            kill_count=kill_count,
+            pilot_count=pilot_count,
+            killmail_ids=killmail_ids,
+            is_active=is_active,
+        )
+
+    def _seed_killmails(self, start_id, count, base_time):
+        ids = []
+        for i in range(count):
+            km_id = start_id + i
+            upsert_feed_killmail_from_r2z2(
+                make_killmail_payload(
+                    km_id, killmail_time=base_time + timedelta(minutes=i)
+                )
+            )
+            ids.append(km_id)
+        return ids
+
+    def test_growing_fight_updates_single_event_with_upgrade_marker(self):
+        base = timezone.now() - timedelta(minutes=30)
+        killmail_ids = self._seed_killmails(87000000, 6, base)
+        cluster = self._make_fleet_cluster(
+            killmail_ids=killmail_ids,
+            started_at=base,
+            last_kill_at=base + timedelta(minutes=5),
+            kill_count=14,
+            pilot_count=12,
+        )
+
+        now = timezone.now()
+        ctx = build_context(now - timedelta(hours=1), now + timedelta(hours=1))
+        write_rollup_results(run_fleet_active_rollup(ctx))
+
+        events = FeedEvent.objects.filter(kind=FeedEvent.Kind.FLEET_ACTIVE)
+        self.assertEqual(events.count(), 1)
+        self.assertEqual(events.get().payload.get("engagement_tier"), "medium")
+
+        # Same fight grows to a major engagement on the same cluster.
+        cluster.kill_count = 60
+        cluster.pilot_count = 45
+        cluster.last_kill_at = base + timedelta(minutes=12)
+        cluster.save()
+
+        write_rollup_results(run_fleet_active_rollup(ctx))
+
+        events = FeedEvent.objects.filter(kind=FeedEvent.Kind.FLEET_ACTIVE)
+        self.assertEqual(events.count(), 1)
+        event = events.get()
+        self.assertEqual(event.payload.get("engagement_tier"), "major")
+        self.assertEqual(event.payload.get("previous_tier"), "medium")
+        self.assertIsNotNone(event.payload.get("upgraded_at"))
+
+    def test_adjacent_clusters_collapse_to_single_cluster_and_event(self):
+        base = timezone.now() - timedelta(minutes=40)
+        ids_a = self._seed_killmails(85000000, 4, base)
+        ids_b = self._seed_killmails(85000100, 4, base + timedelta(minutes=10))
+        self._make_fleet_cluster(
+            killmail_ids=ids_a,
+            started_at=base,
+            last_kill_at=base + timedelta(minutes=3),
+            kill_count=8,
+            pilot_count=8,
+        )
+        self._make_fleet_cluster(
+            killmail_ids=ids_b,
+            started_at=base + timedelta(minutes=10),
+            last_kill_at=base + timedelta(minutes=13),
+            kill_count=8,
+            pilot_count=8,
+        )
+
+        now = timezone.now()
+        ctx = build_context(now - timedelta(hours=1), now + timedelta(hours=1))
+        write_rollup_results(run_fleet_active_rollup(ctx))
+
+        self.assertEqual(
+            FeedCluster.objects.filter(
+                cluster_type=FeedCluster.ClusterType.FLEET_ENGAGEMENT
+            ).count(),
+            1,
+        )
+        self.assertEqual(
+            FeedEvent.objects.filter(kind=FeedEvent.Kind.FLEET_ACTIVE).count(),
+            1,
+        )
+
+    def test_separate_engagements_stay_distinct(self):
+        base = timezone.now() - timedelta(hours=5)
+        ids1 = self._seed_killmails(86000000, 6, base)
+        self._make_fleet_cluster(
+            killmail_ids=ids1,
+            started_at=base,
+            last_kill_at=base + timedelta(minutes=5),
+            kill_count=14,
+            pilot_count=12,
+        )
+
+        later = base + timedelta(hours=3)
+        ids2 = self._seed_killmails(86000100, 6, later)
+        self._make_fleet_cluster(
+            killmail_ids=ids2,
+            started_at=later,
+            last_kill_at=later + timedelta(minutes=5),
+            kill_count=14,
+            pilot_count=12,
+        )
+
+        now = timezone.now()
+        ctx = build_context(now - timedelta(hours=8), now + timedelta(hours=1))
+        write_rollup_results(run_fleet_active_rollup(ctx))
+
+        self.assertEqual(
+            FeedEvent.objects.filter(kind=FeedEvent.Kind.FLEET_ACTIVE).count(),
+            2,
+        )

--- a/backend/feed/tests/test_writer.py
+++ b/backend/feed/tests/test_writer.py
@@ -52,3 +52,114 @@ class WriterTestCase(TestCase):
         )
         self.assertEqual(events.count(), 1)
         self.assertEqual(events.get().subheader, "Auga · 12 kills · 14 pilots")
+
+    def test_write_coalesces_duplicate_fleet_active_events(self):
+        now = timezone.now()
+        related = "fleet_engagement:30002542:500002:2026-06-19T20:00"
+        # Two pre-existing duplicate cards for the same engagement, keyed
+        # differently (the old bug).
+        for start in ("2026-06-19T20:00", "2026-06-19T20:05"):
+            FeedEvent.objects.create(
+                kind=FeedEvent.Kind.FLEET_ACTIVE,
+                rollup_code="fleet_active",
+                cluster_key=f"fleet_active:30002542:500002:{start}",
+                occurred_at=now,
+                title="Medium Minmatar gang active",
+                subheader="",
+                preview="",
+                body="",
+                accent=FeedEvent.Accent.MILITIA,
+                payload={
+                    "system_id": 30002542,
+                    "faction": "minmatar",
+                    "related_cluster_key": related,
+                    "engagement_tier": "medium",
+                    "kills": 14,
+                    "pilots": 12,
+                },
+                rollup_version=1,
+            )
+        self.assertEqual(
+            FeedEvent.objects.filter(rollup_code="fleet_active").count(), 2
+        )
+
+        write_rollup_results(
+            [
+                RollupResult(
+                    kind=FeedEvent.Kind.FLEET_ACTIVE,
+                    occurred_at=now,
+                    title="Major Minmatar fleet active",
+                    subheader="",
+                    preview="",
+                    body="",
+                    accent=FeedEvent.Accent.MILITIA,
+                    payload={
+                        "system_id": 30002542,
+                        "faction": "minmatar",
+                        "related_cluster_key": related,
+                        "engagement_tier": "major",
+                        "kills": 60,
+                        "pilots": 45,
+                    },
+                    rollup_code="fleet_active",
+                    rollup_version=1,
+                    cluster_key="fleet_active:30002542:500002:2026-06-19T20:00",
+                )
+            ]
+        )
+
+        events = FeedEvent.objects.filter(rollup_code="fleet_active")
+        self.assertEqual(events.count(), 1)
+        event = events.get()
+        self.assertEqual(event.payload.get("engagement_tier"), "major")
+        self.assertEqual(event.payload.get("previous_tier"), "medium")
+        self.assertIsNotNone(event.payload.get("upgraded_at"))
+
+    def test_write_keeps_distinct_fleet_active_events_apart(self):
+        now = timezone.now()
+        # A different system/faction engagement must not be coalesced.
+        FeedEvent.objects.create(
+            kind=FeedEvent.Kind.FLEET_ACTIVE,
+            rollup_code="fleet_active",
+            cluster_key="fleet_active:30002539:500003:2026-06-19T20:00",
+            occurred_at=now,
+            title="Medium Amarr gang active",
+            subheader="",
+            preview="",
+            body="",
+            accent=FeedEvent.Accent.AMARR,
+            payload={
+                "system_id": 30002539,
+                "faction": "amarr",
+                "related_cluster_key": "fleet_engagement:30002539:500003:x",
+                "engagement_tier": "medium",
+            },
+            rollup_version=1,
+        )
+
+        write_rollup_results(
+            [
+                RollupResult(
+                    kind=FeedEvent.Kind.FLEET_ACTIVE,
+                    occurred_at=now,
+                    title="Medium Minmatar gang active",
+                    subheader="",
+                    preview="",
+                    body="",
+                    accent=FeedEvent.Accent.MILITIA,
+                    payload={
+                        "system_id": 30002542,
+                        "faction": "minmatar",
+                        "related_cluster_key": "fleet_engagement:30002542:500002:y",
+                        "engagement_tier": "medium",
+                    },
+                    rollup_code="fleet_active",
+                    rollup_version=1,
+                    cluster_key="fleet_active:30002542:500002:2026-06-19T20:00",
+                )
+            ]
+        )
+
+        self.assertEqual(
+            FeedEvent.objects.filter(rollup_code="fleet_active").count(), 2
+        )

--- a/mobile/src/api/mappers/feed.ts
+++ b/mobile/src/api/mappers/feed.ts
@@ -70,6 +70,9 @@ export function mapApiFeedItemToActivity(item: ApiFeedEventItem): ActivityItem {
         composition: item.body || item.preview || undefined,
         roster: mapRoster(payload),
         roster_total: payload.roster_total as number | undefined,
+        engagement_tier: payload.engagement_tier as string | undefined,
+        previous_tier: payload.previous_tier as string | undefined,
+        upgraded_at: payload.upgraded_at as string | undefined,
       };
     case 'killmail_batch':
       return {

--- a/mobile/src/components/ActivityCard.tsx
+++ b/mobile/src/components/ActivityCard.tsx
@@ -39,9 +39,19 @@ interface ActivityCardProps {
   onView: (item: ActivityItem) => void;
 }
 
+const UPGRADE_BADGE_MAX_AGE_MS = 3 * 60 * 60 * 1000;
+
+function isRecentlyUpgraded(item: ActivityItem): boolean {
+  if (item.kind !== 'fleet_active' || !item.upgraded_at) return false;
+  const upgradedAt = new Date(item.upgraded_at).getTime();
+  if (Number.isNaN(upgradedAt)) return false;
+  return Date.now() - upgradedAt <= UPGRADE_BADGE_MAX_AGE_MS;
+}
+
 export function ActivityCard({ item, isFirst = false, isLast = false, onView }: ActivityCardProps) {
   const { title, subheader, preview } = mapActivityToCard(item);
   const { accent, nodeBg } = getActivityAccent(item);
+  const upgraded = isRecentlyUpgraded(item);
 
   return (
     <View style={styles.row}>
@@ -66,9 +76,16 @@ export function ActivityCard({ item, isFirst = false, isLast = false, onView }: 
             </View>
           </View>
 
-          <Text style={styles.title} numberOfLines={1}>
-            {title}
-          </Text>
+          <View style={styles.titleRow}>
+            <Text style={styles.title} numberOfLines={1}>
+              {title}
+            </Text>
+            {upgraded ? (
+              <Text style={[styles.upgradeBadge, { color: accent, borderColor: accent }]}>
+                Upgraded
+              </Text>
+            ) : null}
+          </View>
           <Text style={styles.subheader} numberOfLines={1}>
             {subheader}
           </Text>
@@ -155,11 +172,28 @@ const styles = StyleSheet.create({
     fontSize: 10,
     lineHeight: 13,
   },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.xs,
+  },
   title: {
     ...typography.bodyStrong,
     color: colors.highlight,
     fontSize: 13,
     lineHeight: 17,
+    flexShrink: 1,
+  },
+  upgradeBadge: {
+    ...typography.overline,
+    fontSize: 8,
+    lineHeight: 12,
+    paddingHorizontal: 4,
+    paddingVertical: 1,
+    borderWidth: 1,
+    borderRadius: 3,
+    textTransform: 'uppercase',
   },
   subheader: {
     ...typography.caption,

--- a/mobile/src/types/activity.ts
+++ b/mobile/src/types/activity.ts
@@ -34,6 +34,10 @@ export interface ActivityItem {
   composition?: string;
   roster?: ActivityPilot[];
   roster_total?: number;
+  /** fleet_active — size/tier growth on the same engagement */
+  engagement_tier?: string;
+  previous_tier?: string;
+  upgraded_at?: string;
   /** killmail_batch */
   killmail_count?: number;
   window_minutes?: number;


### PR DESCRIPTION
## Summary
- Stabilize `fleet_active` feed identity on the earliest cluster in a fight chain, merge sibling `FeedCluster` rows, and attach unknown-faction orphans so one engagement cannot split into multiple keys.
- Coalesce overlapping duplicate `fleet_active` events on write, and when a gang grows (e.g. Medium → Major) update the same row with `previous_tier` / `upgraded_at` plus a mobile “Upgraded” chip.
- Add rollup and writer tests covering single-row growth, adjacent-cluster collapse, writer dedupe, and stale-gap separate engagements.

## Test plan
- [x] `pipenv run python manage.py test feed --settings=app.settings_test` (103 tests OK)
- [ ] Spot-check intel feed after deploy: growing fight should update one card (title/subheader + Upgraded chip) instead of posting Medium and Major duplicates
- [ ] Confirm a new fight after the stale window still creates a separate card
- [ ] Confirm Amarr vs Minmatar fights in the same system remain distinct


Made with [Cursor](https://cursor.com)