### PR TITLE
Fix fleet edit form Alpine crash and EVE-time bindings

### DIFF
--- a/frontend/app/src/components/blocks/FleetForm.astro
+++ b/frontend/app/src/components/blocks/FleetForm.astro
@@ -69,6 +69,9 @@ const default_fleet_type = fleet?.type ?? fleet_types_select_options[0].value
 const default_doctrine = fleet?.doctrine?.id ?? doctrines_select_options[0].value
 const default_audience = fleet_audience_id ?? (audiences_select_options.length !== 2 ? audiences_select_options[0].value : audiences_select_options[1].value)
 
+// Alpine state holds the audience as a string so it matches the `<select>` value
+const default_audience_value = String(default_audience ?? '')
+
 // AUDIENCE_ICONS is deprecated - use audience.image_url instead
 
 import Context from '@components/layout/Context.astro';
@@ -107,18 +110,18 @@ import TimerIcon from '@components/icons/buttons/TimerIcon.astro';
         method="POST"
         x-data={`{
             submitted: false,
-            fleet_type: '${default_fleet_type}',
-            eve_date: '${eve_date}',
-            eve_time: '${eve_time}',
-            audience: '${default_audience}',
-            doctrine_id: '${default_doctrine}',
-            objective: '${fleet?.objective ?? ''}',
+            fleet_type: ${JSON.stringify(String(default_fleet_type))},
+            eve_date: ${JSON.stringify(eve_date)},
+            eve_time: ${JSON.stringify(eve_time)},
+            audience: ${JSON.stringify(default_audience_value)},
+            doctrine_id: ${JSON.stringify(String(default_doctrine))},
+            objective: ${JSON.stringify(fleet?.objective ?? '')},
             local_datetime: '',
             audiences: ${JSON.stringify(AUDIENCES)},
             fleet_types: ${JSON.stringify(FLEET_TYPES_LABELS)},
             get_images() {
                 let images = [{
-                    src: '${get_player_icon(fleet_commander?.character_id ?? 0)}',
+                    src: ${JSON.stringify(get_player_icon(fleet_commander?.character_id ?? 0))},
                     width: 64,
                     height: 64,
                 }];
@@ -136,11 +139,11 @@ import TimerIcon from '@components/icons/buttons/TimerIcon.astro';
             fleet_datetime(utc) {
                 const date_time = this.eve_date+' '+this.eve_time
                 const date_string = new Date(date_time+(utc ? ' UTC' : '')).toLocaleDateString(
-                    '${lang}',
+                    ${JSON.stringify(lang)},
                     ${import.meta.env.DATETIME_FORMAT}
                 )
 
-                return (date_string != 'Invalid Date' ? date_string : '${t('waiting_fleet_time')}')
+                return (date_string != 'Invalid Date' ? date_string : ${JSON.stringify(t('waiting_fleet_time'))})
             },
         }`}
         x-on:submit="launch_confetti(get_images()); submitted = true;"
@@ -159,7 +162,7 @@ import TimerIcon from '@components/icons/buttons/TimerIcon.astro';
                                 <FlexInline class="[ audiences !justify-center ]">
                                     {audiences.map((option) =>
                                         <StylessButton
-                                            x-on:click={`audience = ${option.id}`}
+                                            x-on:click={`audience = ${JSON.stringify(String(option.id))}`}
                                             hx-get={translatePath(`/partials/fleet_cover?audience_id=${option.id}`)}
                                             hx-target="#viewport-cover-oob"
                                             hx-trigger="click"
@@ -169,8 +172,8 @@ import TimerIcon from '@components/icons/buttons/TimerIcon.astro';
                                             data-tippy-content={option.display_name}
                                         >
                                             <img
-                                                class:list={{ selected: option.id === default_audience}}
-                                                x-bind:class={`{ 'selected': audience === ${option.id} }`}
+                                                class:list={{ selected: String(option.id) === default_audience_value }}
+                                                x-bind:class={`{ 'selected': audience === ${JSON.stringify(String(option.id))} }`}
                                                 src={option.image_url ?? '/images/fleet-logo.svg'}
                                                 height="256"
                                                 width="256"
@@ -188,7 +191,7 @@ import TimerIcon from '@components/icons/buttons/TimerIcon.astro';
                                             required
                                         >
                                             {audiences_select_options.map((option) => 
-                                                <option value={option.value}>
+                                                <option value={option.value} selected={String(option.value) === default_audience_value}>
                                                     {option.label}
                                                 </option>
                                             )}
@@ -263,13 +266,13 @@ import TimerIcon from '@components/icons/buttons/TimerIcon.astro';
                                 <label for="type">{t('type')}</label>
                                 <Select id="type" x-model="fleet_type" name="fleet_type">
                                     {fleet_types_select_options.map((option) => 
-                                        <option value={option.value}>{option.label}</option>
+                                        <option value={option.value} selected={option.value === default_fleet_type}>{option.label}</option>
                                     )}
                                 </Select>
                             </FixedFluid>
 
                             <FixedFluid class="[ w-full items-center ]" gap="var(--space-3xs)" width="250px" breakpoint="60%">
-                                <label for="type">{t('objective')}</label>
+                                <label for="objective">{t('objective')}</label>
                                 <Input
                                     id="objective"
                                     name="objective"
@@ -345,12 +348,12 @@ import TimerIcon from '@components/icons/buttons/TimerIcon.astro';
                             </TextGroup>
 
                             <TextGroup
-                                class:list={{ 'text-red': default_audience < 1 }}
-                                x-bind:class="{ 'text-red': audience < 1 }"
+                                class:list={{ 'text-red': !default_audience_value }}
+                                x-bind:class="{ 'text-red': !audience }"
                                 title={t('audience')}
-                                x-text={`audience > 0 ? audiences[audience] : '${t('no_audience_selected')}'`}
+                                x-text={`audience ? audiences[audience] : ${JSON.stringify(t('no_audience_selected'))}`}
                             >
-                                {default_audience > 0 ? AUDIENCES[default_audience] : t('no_audience_selected')}
+                                {default_audience_value ? AUDIENCES[default_audience_value] : t('no_audience_selected')}
                             </TextGroup>
                         </FlexInline>
                     </Flexblock>

--- a/frontend/app/src/pages/fleets/add.astro
+++ b/frontend/app/src/pages/fleets/add.astro
@@ -40,7 +40,7 @@ if (Astro.request.method === "POST") {
         console.log(doctrine_id)
         const start_time = is_flash_form ?
             new Date(new Date().getTime()) :
-            new Date(`${data.get('eve_date')} ${data.get('eve_time')}`)
+            new Date(`${data.get('eve_date')}T${data.get('eve_time')}Z`)
 
         const fleet_data = {
             doctrine_id: doctrine_id,
@@ -142,8 +142,9 @@ const timer = Astro.url.searchParams.get('timer')
 const eve_datetime = timer ? new Date(timer) : new Date()
 eve_datetime.setMinutes(eve_datetime.getMinutes() + 15)
 
+// The form labels these as EVE time, so both parts must come from UTC
 const eve_date = eve_datetime.toISOString().slice(0, 10)
-const eve_time = eve_datetime.toTimeString().slice(0, 5)
+const eve_time = eve_datetime.toISOString().slice(11, 16)
 ---
 
 <Viewport

--- a/frontend/app/src/pages/fleets/upcoming/edit/[fleet_id].astro
+++ b/frontend/app/src/pages/fleets/upcoming/edit/[fleet_id].astro
@@ -44,7 +44,7 @@ if (Astro.request.method === "POST") {
             doctrine_id: doctrine_id,
             description: data.get('description') as string,
             objective: data.get('objective') as string,
-            start_time: new Date(`${data.get('eve_date')} ${data.get('eve_time')}`),
+            start_time: new Date(`${data.get('eve_date')}T${data.get('eve_time')}Z`),
             type: data.get('fleet_type') as FleetTypes,
             audience_id: parseInt(data.get('audience_id') as string),
             disable_motd: (data.get('disable_motd' as string) === 'on'),
@@ -127,8 +127,9 @@ const timer = fleet?.start_time
 const eve_datetime = timer ? new Date(timer) : new Date()
 if (!timer) eve_datetime.setMinutes(eve_datetime.getMinutes() + 15)
 
+// The form labels these as EVE time, so both parts must come from UTC
 const eve_date = eve_datetime.toISOString().slice(0, 10)
-const eve_time = eve_datetime.toTimeString().slice(0, 5)
+const eve_time = eve_datetime.toISOString().slice(11, 16)
 ---
 
 <Viewport

--- a/frontend/app/src/pages/partials/fleet_form_component.astro
+++ b/frontend/app/src/pages/partials/fleet_form_component.astro
@@ -60,8 +60,9 @@ const timer = fleet?.start_time
 const eve_datetime = timer ? new Date(timer) : new Date()
 if (!timer) eve_datetime.setMinutes(eve_datetime.getMinutes() + 15)
 
+// The form labels these as EVE time, so both parts must come from UTC
 const eve_date = eve_datetime.toISOString().slice(0, 10)
-const eve_time = eve_datetime.toTimeString().slice(0, 5)
+const eve_time = eve_datetime.toISOString().slice(11, 16)
 ---
 
 {fetch_doctrines_error ?


### PR DESCRIPTION
## Summary
- Escape fleet form Alpine `x-data` values with `JSON.stringify` so objectives like `Fighting Amarr's fleet` no longer break the entire edit form
- Keep audience selection as string-consistent comparisons so the selected icon/select survive hydration
- Derive and submit fleet date/time as UTC (EVE time) instead of mixing UTC date with local time

## Test plan
- [x] Locally reproduced fleet 2213-equivalent (`Fighting Amarr's fleet`) and confirmed blank date/time, `[object HTMLInputElement]` objective, unselected audience, wrong type
- [x] After fix, same fleet shows correct objective, audience, type, and `23:30` EVE time
- [x] Hostile objective with quotes/`'`/`<b>` renders as plain text and Alpine still initializes
- [x] Save round-trip preserves `start_time` including UTC day-boundary case (`2026-07-28T01:00Z`)
- [x] Add-fleet page still loads with UTC defaults and audience click selection works
- [x] Frontend build succeeds


Made with [Cursor](https://cursor.com)