### PR TITLE
Remove work-in-progress banner from FW cruiser guide

### DIFF
--- a/frontend/app/src/i18n/ui.ts
+++ b/frontend/app/src/i18n/ui.ts
@@ -212,9 +212,6 @@ export const ui = {
         'page_finder.ships.navy_frigate_guide.description': 'Fittings, roles, and 1v1 matchups for frigates in faction warfare.',
 
         'ships.faction_warfare_cruiser_guide.page_title': 'Faction Warfare Cruiser Guide',
-        'ships.faction_warfare_cruiser_guide.leading_text': 'Fittings, roles, and 1v1 matchups for cruisers in faction warfare.',
-        'ships.faction_warfare_cruiser_guide.wip_alert_title': 'Work in progress',
-        'ships.faction_warfare_cruiser_guide.wip_alert_text': 'This guide is still being written. Expect incomplete sections, rough fits, and matchup notes that may change.',
         'ships.faction_warfare_cruiser_guide.meta_title': 'EVE Online FW Cruiser Guide | Fits & 1v1 Matchups | {site}',
         'ships.faction_warfare_cruiser_guide.meta_description': 'EVE Online faction warfare cruiser guide: Arbitrator, Augoror Navy, Omen Navy, Exequror Navy, Vexor Navy, Caracal Navy, Osprey Navy, Scythe Fleet, Stabber Fleet, and supporting T1 hulls—example fits, archetypes, and 1v1 matchup charts.',
         'page_finder.ships.faction_warfare_cruiser_guide.description': 'Fittings, roles, and 1v1 matchups for cruisers in faction warfare.',

--- a/frontend/app/src/pages/guides/faction-warfare-cruiser-guide/index.astro
+++ b/frontend/app/src/pages/guides/faction-warfare-cruiser-guide/index.astro
@@ -16,7 +16,6 @@ import FactionWarfareCruiserGuide from '@components/blocks/faction-warfare-cruis
 import PageProgress from '@components/blocks/PageProgress.astro'
 
 const page_title = t('ships.faction_warfare_cruiser_guide.page_title')
-const page_description = t('ships.faction_warfare_cruiser_guide.leading_text')
 const meta_title = t('ships.faction_warfare_cruiser_guide.meta_title')
     .replace('{site}', t('index.page_title'))
 const meta_description = t('ships.faction_warfare_cruiser_guide.meta_description')
@@ -88,11 +87,6 @@ const progress = pageProgressFromSections({
                         </div>
                     </div>
                     <PageTitle is_landing={true}>{page_title}</PageTitle>
-                    <aside class="fwc-page__wip" role="status">
-                        <p class="fwc-page__wip-title">{t('ships.faction_warfare_cruiser_guide.wip_alert_title')}</p>
-                        <p class="fwc-page__wip-text">{t('ships.faction_warfare_cruiser_guide.wip_alert_text')}</p>
-                    </aside>
-                    <p class="[ excerpt ]">{page_description}</p>
                 </Flexblock>
             </TextBox>
 
@@ -166,33 +160,4 @@ const progress = pageProgressFromSections({
         }
     }
 
-    .fwc-page__wip {
-        max-width: var(--max-text-width);
-        padding: var(--space-s) var(--space-m);
-        border: 1px solid color-mix(in srgb, var(--fleet-yellow) 40%, transparent);
-        border-left: 4px solid var(--fleet-yellow);
-        background: color-mix(in srgb, var(--fleet-yellow) 10%, var(--component-background));
-    }
-
-    .fwc-page__wip-title {
-        margin: 0 0 var(--space-2xs);
-        font-size: var(--step-0);
-        font-weight: 600;
-        color: var(--fleet-yellow);
-        line-height: 1.3;
-    }
-
-    .fwc-page__wip-text {
-        margin: 0;
-        font-size: var(--step--1);
-        line-height: 1.5;
-        color: var(--foreground);
-    }
-
-    .excerpt,
-    :global(.excerpt p) {
-        font-size: var(--step-1);
-        line-height: 1.6;
-        max-width: var(--max-text-width);
-    }
 </style>


### PR DESCRIPTION
## Summary
- Remove the "Work in progress" alert and leading excerpt from the Faction Warfare Cruiser Guide page header.
- Drop the now-unused `leading_text`, `wip_alert_title`, and `wip_alert_text` i18n strings.
- Remove the associated `.fwc-page__wip*` and `.excerpt` styles.

The header now goes straight from the page title into the guide content.

## Test plan
- [ ] Visit `/guides/faction-warfare-cruiser-guide/` and confirm the WIP banner and excerpt no longer render.
- [ ] Confirm the page title, breadcrumb, progress, and guide content still display correctly.

Made with [Cursor](https://cursor.com)