### PR TITLE
Lower price-viability baseline floor to 250k ISK

### DIFF
--- a/backend/market/helpers/price_viability.py
+++ b/backend/market/helpers/price_viability.py
@@ -11,7 +11,7 @@ from typing import NamedTuple
 
 # Listed-within-reason defaults used across market ops, admin sell orders, etc.
 DEFAULT_MAX_MARKUP_PCT = 20
-DEFAULT_BASELINE_PRICE_FLOOR = 1_000_000
+DEFAULT_BASELINE_PRICE_FLOOR = 250_000
 
 
 class PriceViabilityPolicy(NamedTuple):

--- a/backend/market/tests/test_market_vision.py
+++ b/backend/market/tests/test_market_vision.py
@@ -785,7 +785,7 @@ class SellOrderRowsTestCase(TestCase):
         self.assertTrue(_order_quantity_counts_as_reasonable(500_000, 50_000))
         self.assertTrue(_order_quantity_counts_as_reasonable(1_000_000, None))
         self.assertEqual(REASONABLE_MARKUP_MAX_PCT, 20)
-        self.assertEqual(REASONABLE_JITA_PRICE_FLOOR, 1_000_000)
+        self.assertEqual(REASONABLE_JITA_PRICE_FLOOR, 250_000)
         # Shared policy stays the source of truth for sell-order aggregation.
         self.assertEqual(REASONABLE_MARKUP_MAX_PCT, DEFAULT_MAX_MARKUP_PCT)
         self.assertEqual(

--- a/backend/market/tests/test_price_viability.py
+++ b/backend/market/tests/test_price_viability.py
@@ -13,12 +13,12 @@ from market.helpers.price_viability import (
 class PriceViabilityHelperTestCase(SimpleTestCase):
     def test_default_policy_constants(self):
         self.assertEqual(DEFAULT_MAX_MARKUP_PCT, 20)
-        self.assertEqual(DEFAULT_BASELINE_PRICE_FLOOR, 1_000_000)
+        self.assertEqual(DEFAULT_BASELINE_PRICE_FLOOR, 250_000)
         self.assertEqual(
             DEFAULT_PRICE_VIABILITY_POLICY,
             PriceViabilityPolicy(
                 max_markup_pct=20,
-                baseline_price_floor=1_000_000,
+                baseline_price_floor=250_000,
             ),
         )
 
@@ -33,7 +33,9 @@ class PriceViabilityHelperTestCase(SimpleTestCase):
 
     def test_cheap_baseline_always_viable(self):
         self.assertTrue(is_price_viable(500_000, 50_000))
-        self.assertTrue(is_price_viable(9_999_999, 999_999))
+        self.assertTrue(is_price_viable(9_999_999, 249_999))
+        # At/above the floor, markup rules apply (Gyrostab II class items).
+        self.assertFalse(is_price_viable(9_999_999, 250_000))
 
     def test_custom_policy(self):
         policy = PriceViabilityPolicy(


### PR DESCRIPTION
## Summary
- Lower `DEFAULT_BASELINE_PRICE_FLOOR` from 1M to 250k so mid-tier modules (e.g. Gyrostabilizer II ~864k Jita) are subject to the 20% markup viability rule.
- Overpriced Amamake stock for those items now correctly reduces viable quantity and surfaces on Market Ops sell gaps.
- Update viability unit tests for the new floor boundary.

## Test plan
- [x] `pipenv run python manage.py test market.tests.test_price_viability market.tests.test_market_vision.SellOrderRowsTestCase --settings=app.settings_test`
- [ ] Confirm Gyrostabilizer II appears on Market Ops sell gaps after deploy (viable ~21 vs target 340)
- [ ] Spot-check that sub-250k ammo/charges still skip markup checks


Made with [Cursor](https://cursor.com)