### PR TITLE
Cap fleet engagement duration at 90 minutes

### DIFF
--- a/backend/feed/constants.py
+++ b/backend/feed/constants.py
@@ -110,6 +110,9 @@ DEFAULT_ROLLUP_CONFIG: dict[str, dict] = {
         "min_kills": 5,
         "min_pilots": 6,
         "stale_minutes": 20,
+        # Hard cap: busy systems never gap 20m, so without this one cluster
+        # grows for days (Turnur/Kourmonen mega-cards).
+        "max_duration_minutes": 90,
         "dominant_faction_threshold": 0.75,
     },
     "contested_change": {
@@ -127,7 +130,7 @@ DEFAULT_ROLLUP_CONFIG: dict[str, dict] = {
 
 ROLLUP_VERSIONS: dict[str, int] = {
     "kill_burst": 6,
-    "fleet_active": 10,
+    "fleet_active": 11,
     "contested_change": 1,
 }
 

--- a/backend/feed/helpers/clusters.py
+++ b/backend/feed/helpers/clusters.py
@@ -299,8 +299,10 @@ def _sliding_window_clusters(
             stats = build_cluster_stats(window_kills)
             if stats["pilot_count"] >= min_pilots:
                 if cluster_type == FeedCluster.ClusterType.FLEET_ENGAGEMENT:
-                    stale_minutes = get_rollup_config("fleet_active").get(
-                        "stale_minutes", 20
+                    fleet_cfg = get_rollup_config("fleet_active")
+                    stale_minutes = fleet_cfg.get("stale_minutes", 20)
+                    max_duration = timedelta(
+                        minutes=fleet_cfg.get("max_duration_minutes", 90)
                     )
                     existing = _find_active_fleet_cluster(
                         solar_system_id,
@@ -309,10 +311,28 @@ def _sliding_window_clusters(
                         stale_minutes=stale_minutes,
                     )
                     if existing is not None:
-                        _merge_fleet_cluster(existing, stats["killmail_ids"])
-                        upserted += 1
-                        i = j
-                        continue
+                        if (
+                            stats["last_kill_at"] - existing.started_at
+                            > max_duration
+                        ):
+                            # Fight has run long enough; close it and start a
+                            # fresh engagement even though kills continue.
+                            existing.is_active = False
+                            existing.ended_at = existing.last_kill_at
+                            existing.save(
+                                update_fields=[
+                                    "is_active",
+                                    "ended_at",
+                                    "updated_at",
+                                ]
+                            )
+                        else:
+                            _merge_fleet_cluster(
+                                existing, stats["killmail_ids"]
+                            )
+                            upserted += 1
+                            i = j
+                            continue
                     key = _cluster_key(
                         cluster_type,
                         solar_system_id,

--- a/backend/feed/rollups/fleet_active.py
+++ b/backend/feed/rollups/fleet_active.py
@@ -61,8 +61,10 @@ def _collapse_fleet_clusters(
     ``(cluster, faction_id)`` tuples that together represent one continuous
     engagement in a system for a single militia faction.
     """
-    stale_minutes = get_rollup_config("fleet_active").get("stale_minutes", 20)
+    fleet_cfg = get_rollup_config("fleet_active")
+    stale_minutes = fleet_cfg.get("stale_minutes", 20)
     stale_delta = timedelta(minutes=stale_minutes)
+    max_duration = timedelta(minutes=fleet_cfg.get("max_duration_minutes", 90))
     chains: list[list[tuple[FeedCluster, int | None]]] = []
     for cluster in sorted(
         clusters,
@@ -75,11 +77,13 @@ def _collapse_fleet_clusters(
         placed = False
         for chain in chains:
             last_cluster, last_faction = chain[-1]
+            chain_start = chain[0][0].started_at
             if (
                 last_cluster.solar_system_id == cluster.solar_system_id
                 and last_faction == faction
                 and cluster.started_at
                 <= last_cluster.last_kill_at + stale_delta
+                and cluster.last_kill_at - chain_start <= max_duration
             ):
                 chain.append((cluster, faction))
                 placed = True

--- a/backend/feed/tests/test_clusters.py
+++ b/backend/feed/tests/test_clusters.py
@@ -116,3 +116,64 @@ class ClusterRollupTestCase(TestCase):
         cluster = fleet_clusters.get()
         self.assertGreaterEqual(cluster.kill_count, 5)
         self.assertGreaterEqual(cluster.pilot_count, 8)
+
+    def test_continuous_fight_under_max_duration_stays_one_cluster(self):
+        """Kills spanning <90m with <20m gaps stay a single engagement."""
+        FeedKillmail.objects.all().delete()
+        FeedCluster.objects.all().delete()
+        base = timezone.now() - timedelta(hours=2)
+        killmail_id = 310000
+        # Burst every 15m for 75 minutes — under the 90m cap, gaps < stale.
+        for segment in range(6):
+            segment_start = base + timedelta(minutes=segment * 15)
+            for i in range(6):
+                payload = make_killmail_payload(
+                    killmail_id,
+                    killmail_time=segment_start + timedelta(seconds=i * 20),
+                    attacker_count=8,
+                )
+                upsert_feed_killmail_from_r2z2(payload)
+                killmail_id += 1
+
+        detect_clusters(since_hours=3)
+        fleet_clusters = FeedCluster.objects.filter(
+            cluster_type=FeedCluster.ClusterType.FLEET_ENGAGEMENT,
+            solar_system_id=30002538,
+        )
+        self.assertEqual(fleet_clusters.count(), 1)
+        cluster = fleet_clusters.get()
+        span = cluster.last_kill_at - cluster.started_at
+        self.assertLessEqual(span, timedelta(minutes=90))
+
+    def test_continuous_fight_over_max_duration_splits_clusters(self):
+        """Busy-system mega-chain: kills never gap 20m but exceed 90m."""
+        FeedKillmail.objects.all().delete()
+        FeedCluster.objects.all().delete()
+        base = timezone.now() - timedelta(hours=3)
+        killmail_id = 320000
+        # Burst every 15m for 120 minutes (>90m cap, gaps always <20m).
+        for segment in range(9):
+            segment_start = base + timedelta(minutes=segment * 15)
+            for i in range(6):
+                payload = make_killmail_payload(
+                    killmail_id,
+                    killmail_time=segment_start + timedelta(seconds=i * 20),
+                    attacker_count=8,
+                )
+                upsert_feed_killmail_from_r2z2(payload)
+                killmail_id += 1
+
+        detect_clusters(since_hours=4)
+        fleet_clusters = list(
+            FeedCluster.objects.filter(
+                cluster_type=FeedCluster.ClusterType.FLEET_ENGAGEMENT,
+                solar_system_id=30002538,
+            ).order_by("started_at")
+        )
+        self.assertGreaterEqual(len(fleet_clusters), 2)
+        for cluster in fleet_clusters:
+            span = cluster.last_kill_at - cluster.started_at
+            self.assertLessEqual(span, timedelta(minutes=90))
+        # First segment closed when the cap forced a split.
+        self.assertFalse(fleet_clusters[0].is_active)
+        self.assertIsNotNone(fleet_clusters[0].ended_at)

--- a/backend/feed/tests/test_fleet_active_rollup.py
+++ b/backend/feed/tests/test_fleet_active_rollup.py
@@ -54,6 +54,36 @@ class FleetActiveRollupTestCase(TestCase):
         self.assertEqual(chain[0][0].started_at, clusters[0].started_at)
         self.assertEqual(chain[-1][0].last_kill_at, clusters[-1].last_kill_at)
 
+    def test_collapse_respects_max_duration(self):
+        """Adjacent buckets past the 90m cap must not re-glue into one chain."""
+        base = timezone.now()
+        clusters = [
+            FeedCluster(
+                cluster_key=(
+                    f"fleet_engagement:30002542:500002:2026-06-19T"
+                    f"{minute:02d}:00"
+                ),
+                cluster_type=FeedCluster.ClusterType.FLEET_ENGAGEMENT,
+                solar_system_id=30002542,
+                dominant_faction_id=500002,
+                started_at=base + timedelta(minutes=minute),
+                last_kill_at=base + timedelta(minutes=minute + 15),
+                kill_count=8,
+                pilot_count=10,
+            )
+            for minute in (0, 20, 40, 60, 80, 100)
+        ]
+
+        collapsed = _collapse_fleet_clusters(clusters)
+
+        self.assertGreaterEqual(len(collapsed), 2)
+        for chain in collapsed:
+            chain_start = chain[0][0].started_at
+            chain_end = chain[-1][0].last_kill_at
+            self.assertLessEqual(
+                chain_end - chain_start, timedelta(minutes=90)
+            )
+
     def test_collapse_fleet_clusters_keeps_separate_engagements(self):
         base = timezone.now()
         first = FeedCluster(


### PR DESCRIPTION
## Summary
- Add a configurable 90-minute hard cap (`max_duration_minutes`) so continuous kill activity in busy systems (Turnur, Kourmonen) cannot grow into multi-day `fleet_active` cards.
- Detection closes the active cluster and starts a new one when merging would exceed the cap; rollup collapse refuses to re-glue chains past the same limit.
- Bump `fleet_active` rollup version to 11 and add under/over-cap cluster + collapse tests.

## Test plan
- [x] `pipenv run python manage.py test feed.tests.test_clusters feed.tests.test_fleet_active_rollup --settings=app.settings_test`
- [ ] After deploy, rebuild feed clusters/rollups so existing mega-rows (Turnur/Kourmonen) re-derive under the new cap
- [ ] Spot-check feed cards in a busy system overnight — no durations >> ~90m for a single engagement


Made with [Cursor](https://cursor.com)