### PR TITLE
Skip capital intel pings for Minmatar Republic pilots

### DIFF
--- a/backend/feed/helpers/capital_pings.py
+++ b/backend/feed/helpers/capital_pings.py
@@ -17,7 +17,9 @@ from feed.constants import (
     CAPITAL_PING_MAX_AGE_SECONDS,
     CAPITAL_PING_MAX_LIGHT_YEARS,
     CAPITAL_PING_SESSION_SECONDS,
+    FACTION_MINMATAR,
 )
+from feed.helpers.affiliations import lookup_character_militia_factions
 from feed.helpers.capital_ships import (
     collect_killmail_ship_type_ids,
     filter_capital_ship_type_ids,
@@ -173,6 +175,73 @@ def _format_system_line(
     if not names:
         return fallback_name
     return " → ".join(names)
+
+
+def _capital_participant_rows(
+    raw: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Return victim/attacker rows flying capital hulls (excludes CONCORD)."""
+    capital_type_ids = filter_capital_ship_type_ids(
+        collect_killmail_ship_type_ids(raw)
+    )
+    if not capital_type_ids:
+        return []
+
+    rows: list[dict[str, Any]] = []
+    victim = raw.get("victim") or {}
+    victim_ship_type_id = victim.get("ship_type_id")
+    if victim_ship_type_id and int(victim_ship_type_id) in capital_type_ids:
+        rows.append(victim)
+
+    for attacker in raw.get("attackers") or []:
+        if attacker.get("corporation_id") == _CONCORD_CORPORATION_ID:
+            continue
+        ship_type_id = attacker.get("ship_type_id")
+        if ship_type_id and int(ship_type_id) in capital_type_ids:
+            rows.append(attacker)
+    return rows
+
+
+def _capital_pilot_killmail_factions(
+    raw: dict[str, Any],
+) -> dict[int, int | None]:
+    """Map capital pilot IDs to killmail faction_id (None if untagged)."""
+    pilots: dict[int, int | None] = {}
+    for row in _capital_participant_rows(raw):
+        character_id = row.get("character_id")
+        if not character_id:
+            continue
+        character_id = int(character_id)
+        faction_id = row.get("faction_id")
+        if faction_id is not None:
+            pilots[character_id] = int(faction_id)
+        elif character_id not in pilots:
+            pilots[character_id] = None
+    return pilots
+
+
+def _capital_pilot_is_minmatar_republic(raw: dict[str, Any]) -> bool:
+    """True when any capital pilot is Minmatar Republic."""
+    pilots = _capital_pilot_killmail_factions(raw)
+    if not pilots:
+        return False
+
+    unresolved = {
+        character_id
+        for character_id, faction_id in pilots.items()
+        if faction_id is None
+    }
+    affiliations = lookup_character_militia_factions(unresolved)
+
+    for character_id, faction_id in pilots.items():
+        resolved = (
+            faction_id
+            if faction_id is not None
+            else affiliations.get(character_id)
+        )
+        if resolved == FACTION_MINMATAR:
+            return True
+    return False
 
 
 def _capital_entries(raw: dict[str, Any]) -> list[dict[str, Any]]:
@@ -779,6 +848,8 @@ def maybe_notify_capital_kill(
     if FeedCapitalPing.objects.filter(killmail_id=killmail_id).exists():
         return False
     if not killmail_involves_capital(raw):
+        return False
+    if _capital_pilot_is_minmatar_republic(raw):
         return False
 
     distance_ly = light_years_between_systems(

--- a/backend/feed/tests/helpers.py
+++ b/backend/feed/tests/helpers.py
@@ -8,7 +8,8 @@ def make_killmail_payload(
     *,
     solar_system_id: int = 30002538,
     killmail_time: datetime | None = None,
-    faction_id: int = 500002,
+    faction_id: int | None = 500002,
+    victim_faction_id: int | None = None,
     attacker_count: int = 8,
     ship_type_id: int = 22468,
     attacker_ship_type_id: int = 22468,
@@ -17,28 +18,34 @@ def make_killmail_payload(
     if killmail_time is None:
         killmail_time = datetime(2026, 6, 19, 17, 25, 8, tzinfo=timezone.utc)
 
-    attackers = [
-        {
+    attackers = []
+    for i in range(attacker_count):
+        attacker: dict = {
             "character_id": 90000000 + i,
             "corporation_id": 98000000,
             "alliance_id": 99000000,
-            "faction_id": faction_id,
             "ship_type_id": attacker_ship_type_id,
             "damage_done": 1000,
             "final_blow": i == 0,
         }
-        for i in range(attacker_count)
-    ]
+        if faction_id is not None:
+            attacker["faction_id"] = faction_id
+        attackers.append(attacker)
+
+    victim: dict = {
+        "character_id": 80000000 + killmail_id % 1000,
+        "corporation_id": 98000001,
+        "ship_type_id": ship_type_id,
+        "damage_taken": 5000,
+    }
+    if victim_faction_id is not None:
+        victim["faction_id"] = victim_faction_id
+
     raw = {
         "killmail_id": killmail_id,
         "killmail_time": killmail_time.isoformat().replace("+00:00", "Z"),
         "solar_system_id": solar_system_id,
-        "victim": {
-            "character_id": 80000000 + killmail_id % 1000,
-            "corporation_id": 98000001,
-            "ship_type_id": ship_type_id,
-            "damage_taken": 5000,
-        },
+        "victim": victim,
         "attackers": attackers,
     }
     return {

--- a/backend/feed/tests/test_capital_pings.py
+++ b/backend/feed/tests/test_capital_pings.py
@@ -16,7 +16,11 @@ from eveuniverse.models import (
     EveType,
 )
 
-from feed.constants import AMAMAKE_SOLAR_SYSTEM_ID
+from feed.constants import (
+    AMAMAKE_SOLAR_SYSTEM_ID,
+    FACTION_AMARR,
+    FACTION_MINMATAR,
+)
 from feed.helpers.capital_pings import (
     CAPITAL_ALERT_TITLE,
     ZKILL_CHARACTER_URL,
@@ -30,7 +34,11 @@ from feed.helpers.capital_ships import (
     killmail_involves_capital,
 )
 from feed.helpers.system_distance import light_years_between_systems
-from feed.models import FeedCapitalAlert, FeedCapitalPing
+from feed.models import (
+    FeedCapitalAlert,
+    FeedCapitalPing,
+    FeedCharacterAffiliation,
+)
 from feed.tests.helpers import make_killmail_payload
 
 
@@ -416,6 +424,7 @@ class CapitalPingTestCase(TestCase):
             ship_type_id=17715,
             attacker_ship_type_id=73790,
             attacker_count=4,
+            faction_id=FACTION_AMARR,
             killmail_time=datetime(2026, 7, 17, 17, 0, 0, tzinfo=dt_tz.utc),
         )
         second = make_killmail_payload(
@@ -424,6 +433,7 @@ class CapitalPingTestCase(TestCase):
             ship_type_id=17715,
             attacker_ship_type_id=73790,
             attacker_count=4,
+            faction_id=FACTION_AMARR,
             killmail_time=datetime(2026, 7, 17, 17, 1, 0, tzinfo=dt_tz.utc),
         )
 
@@ -470,6 +480,7 @@ class CapitalPingTestCase(TestCase):
             ship_type_id=17715,
             attacker_ship_type_id=73790,
             attacker_count=1,
+            faction_id=FACTION_AMARR,
             killmail_time=datetime(2026, 7, 18, 14, 0, 0, tzinfo=dt_tz.utc),
         )
         second = make_killmail_payload(
@@ -478,6 +489,7 @@ class CapitalPingTestCase(TestCase):
             ship_type_id=17715,
             attacker_ship_type_id=73790,
             attacker_count=1,
+            faction_id=FACTION_AMARR,
             killmail_time=datetime(2026, 7, 18, 14, 10, 0, tzinfo=dt_tz.utc),
         )
 
@@ -526,6 +538,7 @@ class CapitalPingTestCase(TestCase):
             ship_type_id=17715,
             attacker_ship_type_id=73790,
             attacker_count=1,
+            faction_id=FACTION_AMARR,
         )
         second = make_killmail_payload(
             136500041,
@@ -533,6 +546,7 @@ class CapitalPingTestCase(TestCase):
             ship_type_id=17715,
             attacker_ship_type_id=73790,
             attacker_count=1,
+            faction_id=FACTION_AMARR,
         )
         # Distinct capital pilot so character overlap does not chain alerts.
         second["killmail"]["attackers"][0]["character_id"] = 91000001
@@ -568,6 +582,7 @@ class CapitalPingTestCase(TestCase):
             ship_type_id=17726,
             attacker_ship_type_id=73790,
             attacker_count=6,
+            faction_id=FACTION_AMARR,
         )
         self.assertTrue(maybe_notify_capital_kill(payload))
         mock_client.create_message.assert_called_once()
@@ -590,6 +605,71 @@ class CapitalPingTestCase(TestCase):
         )
 
     @patch("feed.helpers.capital_pings.DiscordClient")
+    def test_maybe_notify_skips_minmatar_republic_capitals(
+        self, mock_client_cls
+    ):
+        payload = make_killmail_payload(
+            136500050,
+            solar_system_id=AMAMAKE_SOLAR_SYSTEM_ID,
+            ship_type_id=17726,
+            attacker_ship_type_id=73790,
+            attacker_count=3,
+            faction_id=FACTION_MINMATAR,
+        )
+        self.assertFalse(maybe_notify_capital_kill(payload))
+        mock_client_cls.return_value.create_message.assert_not_called()
+        self.assertEqual(FeedCapitalPing.objects.count(), 0)
+
+    @patch("feed.helpers.capital_pings.DiscordClient")
+    def test_maybe_notify_skips_minmatar_victim_capital(self, mock_client_cls):
+        payload = make_killmail_payload(
+            136500051,
+            solar_system_id=AMAMAKE_SOLAR_SYSTEM_ID,
+            ship_type_id=73790,
+            attacker_ship_type_id=17726,
+            faction_id=FACTION_AMARR,
+            victim_faction_id=FACTION_MINMATAR,
+        )
+        self.assertFalse(maybe_notify_capital_kill(payload))
+        mock_client_cls.return_value.create_message.assert_not_called()
+
+    @patch("feed.helpers.capital_pings.DiscordClient")
+    def test_maybe_notify_skips_minmatar_via_affiliation_cache(
+        self, mock_client_cls
+    ):
+        FeedCharacterAffiliation.objects.create(
+            character_id=90000000,
+            faction_id=FACTION_MINMATAR,
+        )
+        payload = make_killmail_payload(
+            136500052,
+            solar_system_id=AMAMAKE_SOLAR_SYSTEM_ID,
+            ship_type_id=17726,
+            attacker_ship_type_id=73790,
+            attacker_count=1,
+            faction_id=None,
+        )
+        self.assertFalse(maybe_notify_capital_kill(payload))
+        mock_client_cls.return_value.create_message.assert_not_called()
+
+    @patch("feed.helpers.capital_pings.DiscordClient")
+    def test_maybe_notify_skips_when_any_capital_is_minmatar(
+        self, mock_client_cls
+    ):
+        payload = make_killmail_payload(
+            136500053,
+            solar_system_id=AMAMAKE_SOLAR_SYSTEM_ID,
+            ship_type_id=17726,
+            attacker_ship_type_id=73790,
+            attacker_count=2,
+            faction_id=FACTION_AMARR,
+        )
+        payload["killmail"]["attackers"][0]["faction_id"] = FACTION_MINMATAR
+        self.assertFalse(maybe_notify_capital_kill(payload))
+        mock_client_cls.return_value.create_message.assert_not_called()
+        self.assertEqual(FeedCapitalPing.objects.count(), 0)
+
+    @patch("feed.helpers.capital_pings.DiscordClient")
     def test_many_capitals_same_system_one_notification(self, mock_client_cls):
         """Thirty distinct capital pilots in one system still share one alert."""
         mock_client = MagicMock()
@@ -605,6 +685,7 @@ class CapitalPingTestCase(TestCase):
                 ship_type_id=17715,
                 attacker_ship_type_id=73790,
                 attacker_count=1,
+                faction_id=FACTION_AMARR,
             )
             payload["killmail"]["attackers"][0]["character_id"] = (
                 92000000 + index


### PR DESCRIPTION
## Summary
- Skip Discord capital intel pings when any capital pilot on the killmail is Minmatar Republic (`faction_id` 500002)
- Resolve faction from the killmail first, then `FeedCharacterAffiliation` when untagged
- Still ping Amarr / unenlisted / unknown capital pilots

## Test plan
- [x] `pipenv run python manage.py test feed.tests.test_capital_pings --settings=app.settings_test`
- [ ] Confirm a live Minmatar-enlisted dread kill near Amamake does not post to capital ping channels
- [ ] Confirm an Amarr (or unenlisted) capital kill still posts


Made with [Cursor](https://cursor.com)