### PR TITLE
Defer market ops monitor load behind skeletons

### DIFF
--- a/frontend/app/src/components/blocks/OpsMonitorContent.astro
+++ b/frontend/app/src/components/blocks/OpsMonitorContent.astro
@@ -1,0 +1,388 @@
+---
+import { i18n } from '@helpers/i18n'
+const { lang, t } = i18n(Astro.url)
+
+import type { OpsMonitor } from '@dtypes/api.minmatar.org'
+import { from_now_diff } from '@helpers/date'
+
+import Flexblock from '@components/compositions/Flexblock.astro'
+import Grid from '@components/compositions/Grid.astro'
+import Progress from '@components/blocks/Progress.astro'
+import OpsUnderstockedGrid from '@components/blocks/OpsUnderstockedGrid.astro'
+import OpsSellGapsList from '@components/blocks/OpsSellGapsList.astro'
+
+interface Props {
+    monitor: OpsMonitor
+}
+
+const { monitor } = Astro.props
+const summary = monitor.summary
+
+function health_tone(pct: number | null | undefined): 'good' | 'warn' | 'bad' | 'none' {
+    if (pct == null)
+        return 'none'
+    if (pct >= 80)
+        return 'good'
+    if (pct >= 40)
+        return 'warn'
+    return 'bad'
+}
+
+function format_pct(pct: number | null | undefined): string {
+    if (pct == null)
+        return '—'
+    return `${pct % 1 === 0 ? pct.toFixed(0) : pct.toFixed(1)}%`
+}
+
+function fulfilled_label(fulfilled: number, targets: number): string {
+    if (targets <= 0)
+        return t('ops_health_no_targets')
+    return t('ops_health_fulfilled')
+        .replace('{fulfilled}', String(fulfilled))
+        .replace('{targets}', String(targets))
+}
+
+function format_isk(isk: number): string {
+    const abs = Math.abs(isk)
+    if (abs >= 1_000_000_000_000)
+        return `${(isk / 1_000_000_000_000).toFixed(2)}T`
+    if (abs >= 1_000_000_000)
+        return `${(isk / 1_000_000_000).toFixed(1)}B`
+    if (abs >= 1_000_000)
+        return `${(isk / 1_000_000).toFixed(0)}M`
+    if (abs >= 1_000)
+        return `${(isk / 1_000).toFixed(0)}K`
+    return isk.toFixed(0)
+}
+
+function isk_label(template_key: string, isk: number): string {
+    return t(template_key).replace('{isk}', format_isk(isk))
+}
+
+function count_label(template_key: string, count: number): string {
+    return t(template_key).replace('{count}', String(count))
+}
+
+function sync_age_label(iso: string | null | undefined): string {
+    if (!iso)
+        return '—'
+    return from_now_diff(lang, new Date(iso))
+}
+
+const overall_tone = health_tone(summary.overall_health_pct)
+const contracts_tone = health_tone(summary.contracts_health_pct)
+const sell_tone = health_tone(summary.sell_orders_health_pct)
+const sell_viability_tone = health_tone(summary.sell_orders_viability_pct)
+---
+
+<Flexblock gap="var(--space-xl)" class="[ ops-monitor-content ]">
+    <section class:list={['ops-health', `ops-health--${overall_tone}`]}>
+        <div class="[ ops-health__overall ]">
+            <p class="[ ops-health__eyebrow ]">{t('ops_health_overall')}</p>
+            <p class="[ ops-health__pct ]">{format_pct(summary.overall_health_pct)}</p>
+            <Progress
+                class:list={[
+                    'ops-health__bar',
+                    {
+                        success: overall_tone === 'good',
+                        danger: overall_tone === 'bad',
+                        disabled: overall_tone === 'none',
+                    },
+                ]}
+                max="100"
+                value={summary.overall_health_pct != null ? Math.max(summary.overall_health_pct, 0.1) : 0.1}
+            />
+            <p class="[ ops-health__isk ]">
+                {isk_label('ops_health_isk_on_market', summary.total_isk_on_market)}
+            </p>
+            <div
+                class="[ ops-health__sync ]"
+                title={[
+                    monitor.contracts_synced_at ? `Contracts: ${monitor.contracts_synced_at}` : null,
+                    monitor.orders_synced_at ? `Orders: ${monitor.orders_synced_at}` : null,
+                ].filter(Boolean).join(' · ') || undefined}
+            >
+                <small>
+                    {t('ops_sync_age_contracts')
+                        .replace('{age}', sync_age_label(monitor.contracts_synced_at))}
+                </small>
+                <small>
+                    {t('ops_sync_age_orders')
+                        .replace('{age}', sync_age_label(monitor.orders_synced_at))}
+                </small>
+            </div>
+        </div>
+
+        <Grid
+            class="[ ops-health__split ]"
+            min_item_width="280px"
+            row_gap="var(--space-s)"
+            column_gap="var(--space-s)"
+        >
+            <article class:list={['ops-health__card', `ops-health__card--${contracts_tone}`]}>
+                <p class="[ ops-health__card-label ]">{t('ops_health_contracts')}</p>
+                <p class="[ ops-health__card-pct ]">{format_pct(summary.contracts_health_pct)}</p>
+                <Progress
+                    class:list={[
+                        'ops-health__bar',
+                        {
+                            success: contracts_tone === 'good',
+                            danger: contracts_tone === 'bad',
+                            disabled: contracts_tone === 'none',
+                        },
+                    ]}
+                    max="100"
+                    value={summary.contracts_health_pct != null ? Math.max(summary.contracts_health_pct, 0.1) : 0.1}
+                />
+                <p class="[ ops-health__card-meta ]">
+                    {fulfilled_label(summary.contract_fulfilled, summary.contract_targets)}
+                </p>
+                <p class="[ ops-health__card-meta ops-health__card-meta--isk ]">
+                    {isk_label('ops_health_isk_in_contracts', summary.contracts_isk)}
+                </p>
+                <p class="[ ops-health__card-meta ]">
+                    {count_label('ops_health_under_target', summary.understocked_contracts)}
+                </p>
+            </article>
+
+            <article class="[ ops-health__card ]">
+                <p class="[ ops-health__card-label ]">{t('ops_health_sell_orders')}</p>
+                <div class="[ ops-health__dual ]">
+                    <div
+                        class:list={['ops-health__metric', `ops-health__metric--${sell_tone}`]}
+                        title={t('ops_health_coverage_hint')}
+                    >
+                        <p class="[ ops-health__metric-label ]">{t('ops_health_coverage')}</p>
+                        <p class="[ ops-health__card-pct ]">{format_pct(summary.sell_orders_health_pct)}</p>
+                        <Progress
+                            class:list={[
+                                'ops-health__bar',
+                                {
+                                    success: sell_tone === 'good',
+                                    danger: sell_tone === 'bad',
+                                    disabled: sell_tone === 'none',
+                                },
+                            ]}
+                            max="100"
+                            value={summary.sell_orders_health_pct != null ? Math.max(summary.sell_orders_health_pct, 0.1) : 0.1}
+                        />
+                        <p class="[ ops-health__card-meta ]">
+                            {fulfilled_label(summary.sell_order_fulfilled, summary.sell_order_targets)}
+                        </p>
+                    </div>
+                    <div
+                        class:list={['ops-health__metric', `ops-health__metric--${sell_viability_tone}`]}
+                        title={t('ops_health_viability_hint')}
+                    >
+                        <p class="[ ops-health__metric-label ]">{t('ops_health_viability')}</p>
+                        <p class="[ ops-health__card-pct ]">{format_pct(summary.sell_orders_viability_pct)}</p>
+                        <Progress
+                            class:list={[
+                                'ops-health__bar',
+                                {
+                                    success: sell_viability_tone === 'good',
+                                    danger: sell_viability_tone === 'bad',
+                                    disabled: sell_viability_tone === 'none',
+                                },
+                            ]}
+                            max="100"
+                            value={summary.sell_orders_viability_pct != null ? Math.max(summary.sell_orders_viability_pct, 0.1) : 0.1}
+                        />
+                        <p class="[ ops-health__card-meta ]">
+                            {summary.sell_order_targets > 0
+                                ? t('ops_health_viable_fulfilled')
+                                    .replace('{fulfilled}', String(summary.sell_order_viable_fulfilled))
+                                    .replace('{targets}', String(summary.sell_order_targets))
+                                : t('ops_health_no_targets')}
+                        </p>
+                    </div>
+                </div>
+                <p class="[ ops-health__card-meta ops-health__card-meta--isk ]">
+                    {isk_label('ops_health_isk_in_sell_orders', summary.sell_orders_isk)}
+                </p>
+                <p class="[ ops-health__card-meta ]">
+                    {count_label('ops_health_critical_gaps', summary.sell_gaps)}
+                </p>
+            </article>
+        </Grid>
+    </section>
+
+    <Flexblock gap="var(--space-l)">
+        <Flexblock gap="var(--space-s)">
+            <h2>{t('ops_understocked')} ({summary.understocked_contracts})</h2>
+            <OpsUnderstockedGrid
+                rows={monitor.understocked_contracts}
+                hide_location={true}
+            />
+        </Flexblock>
+
+        <OpsSellGapsList
+            rows={monitor.sell_gaps}
+            hide_location={true}
+            jita_copy_label={t('ops_copy_jita_buy_list')}
+            jita_copy_tip={t('ops_copy_jita_buy_list_tip')}
+            sales_history_days={summary.sales_history_days ?? 0}
+        />
+    </Flexblock>
+</Flexblock>
+
+<style lang="scss">
+    .ops-health {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-l);
+        padding: var(--space-l) var(--space-m);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        background: rgba(0, 0, 0, 0.28);
+
+        &--good {
+            border-color: color-mix(in srgb, var(--green) 45%, transparent);
+        }
+
+        &--warn {
+            border-color: color-mix(in srgb, var(--fleet-yellow) 45%, transparent);
+        }
+
+        &--bad {
+            border-color: color-mix(in srgb, var(--fleet-red) 50%, transparent);
+        }
+    }
+
+    .ops-health__overall {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2xs);
+        max-width: 28rem;
+    }
+
+    .ops-health__eyebrow,
+    .ops-health__card-label {
+        margin: 0;
+        font-size: var(--step--1);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--fleet-yellow);
+    }
+
+    .ops-health__pct {
+        margin: 0;
+        font-family: var(--heading-font);
+        font-size: clamp(3.5rem, 8vw, 6rem);
+        font-weight: 400;
+        line-height: 0.9;
+        letter-spacing: -0.03em;
+        color: var(--highlight);
+        text-transform: uppercase;
+    }
+
+    .ops-health--good .ops-health__pct {
+        color: var(--green);
+    }
+
+    .ops-health--warn .ops-health__pct {
+        color: var(--fleet-yellow);
+    }
+
+    .ops-health--bad .ops-health__pct {
+        color: var(--fleet-red);
+    }
+
+    .ops-health__bar {
+        --progress-height: var(--space-2xs);
+        width: 100%;
+        margin-block: var(--space-3xs);
+    }
+
+    .ops-health__sync {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3xs);
+        margin: 0;
+        color: rgba(255, 255, 255, 0.65);
+        font-size: var(--step--1);
+    }
+
+    .ops-health__sync small {
+        margin: 0;
+    }
+
+    .ops-health__card-meta {
+        margin: 0;
+        color: rgba(255, 255, 255, 0.65);
+        font-size: var(--step--1);
+    }
+
+    .ops-health__isk,
+    .ops-health__card-meta--isk {
+        margin: 0;
+        font-family: var(--heading-font);
+        font-size: var(--step-0);
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+        color: var(--highlight);
+    }
+
+    .ops-health__isk {
+        font-size: var(--step-1);
+        margin-block-start: var(--space-3xs);
+    }
+
+    .ops-health__card {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3xs);
+        padding: var(--space-m);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        background: rgba(0, 0, 0, 0.22);
+    }
+
+    .ops-health__card-pct {
+        margin: 0;
+        font-family: var(--heading-font);
+        font-size: clamp(2.25rem, 5vw, 3.5rem);
+        line-height: 0.95;
+        letter-spacing: -0.02em;
+        text-transform: uppercase;
+        color: var(--highlight);
+    }
+
+    .ops-health__dual {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: var(--space-s);
+    }
+
+    .ops-health__metric {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3xs);
+        min-width: 0;
+    }
+
+    .ops-health__metric-label {
+        margin: 0;
+        font-size: var(--step--1);
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: rgba(255, 255, 255, 0.7);
+    }
+
+    .ops-health__card--good .ops-health__card-pct,
+    .ops-health__metric--good .ops-health__card-pct {
+        color: var(--green);
+    }
+
+    .ops-health__card--warn .ops-health__card-pct,
+    .ops-health__metric--warn .ops-health__card-pct {
+        color: var(--fleet-yellow);
+    }
+
+    .ops-health__card--bad .ops-health__card-pct,
+    .ops-health__metric--bad .ops-health__card-pct {
+        color: var(--fleet-red);
+    }
+
+    h2 {
+        font-size: var(--step-1);
+    }
+</style>

--- a/frontend/app/src/components/blocks/OpsMonitorSkeleton.astro
+++ b/frontend/app/src/components/blocks/OpsMonitorSkeleton.astro
@@ -1,0 +1,222 @@
+---
+import Flexblock from '@components/compositions/Flexblock.astro'
+import Grid from '@components/compositions/Grid.astro'
+---
+
+<div
+    class="[ ops-monitor-skeleton ]"
+    aria-busy="true"
+    aria-live="polite"
+>
+    <Flexblock gap="var(--space-xl)">
+        <section class="[ ops-monitor-skeleton__health ]">
+            <div class="[ ops-monitor-skeleton__overall ]">
+                <div class="[ skel skel-eyebrow ]"></div>
+                <div class="[ skel skel-pct ]"></div>
+                <div class="[ skel skel-bar ]"></div>
+                <div class="[ skel skel-line skel-line--med ]"></div>
+                <div class="[ skel skel-line skel-line--short ]"></div>
+                <div class="[ skel skel-line skel-line--short ]"></div>
+            </div>
+
+            <Grid
+                class="[ ops-monitor-skeleton__split ]"
+                min_item_width="280px"
+                row_gap="var(--space-s)"
+                column_gap="var(--space-s)"
+            >
+                <div class="[ ops-monitor-skeleton__card ]">
+                    <div class="[ skel skel-eyebrow ]"></div>
+                    <div class="[ skel skel-card-pct ]"></div>
+                    <div class="[ skel skel-bar ]"></div>
+                    <div class="[ skel skel-line ]"></div>
+                    <div class="[ skel skel-line skel-line--med ]"></div>
+                    <div class="[ skel skel-line skel-line--short ]"></div>
+                </div>
+                <div class="[ ops-monitor-skeleton__card ]">
+                    <div class="[ skel skel-eyebrow ]"></div>
+                    <div class="[ ops-monitor-skeleton__dual ]">
+                        <div class="[ ops-monitor-skeleton__metric ]">
+                            <div class="[ skel skel-line skel-line--short ]"></div>
+                            <div class="[ skel skel-card-pct ]"></div>
+                            <div class="[ skel skel-bar ]"></div>
+                            <div class="[ skel skel-line ]"></div>
+                        </div>
+                        <div class="[ ops-monitor-skeleton__metric ]">
+                            <div class="[ skel skel-line skel-line--short ]"></div>
+                            <div class="[ skel skel-card-pct ]"></div>
+                            <div class="[ skel skel-bar ]"></div>
+                            <div class="[ skel skel-line ]"></div>
+                        </div>
+                    </div>
+                    <div class="[ skel skel-line skel-line--med ]"></div>
+                    <div class="[ skel skel-line skel-line--short ]"></div>
+                </div>
+            </Grid>
+        </section>
+
+        <Flexblock gap="var(--space-l)">
+            <Flexblock gap="var(--space-s)">
+                <div class="[ skel skel-heading ]"></div>
+                <Grid
+                    class="[ ops-monitor-skeleton__tiles ]"
+                    min_item_width="140px"
+                    row_gap="var(--space-s)"
+                    column_gap="var(--space-s)"
+                >
+                    {Array.from({ length: 8 }).map(() =>
+                        <div class="[ skel skel-tile ]"></div>
+                    )}
+                </Grid>
+            </Flexblock>
+
+            <Flexblock gap="var(--space-s)">
+                <div class="[ skel skel-heading ]"></div>
+                <div class="[ skel skel-filters ]"></div>
+                <Flexblock gap="var(--space-2xs)">
+                    {Array.from({ length: 6 }).map(() =>
+                        <div class="[ skel skel-row ]"></div>
+                    )}
+                </Flexblock>
+            </Flexblock>
+        </Flexblock>
+    </Flexblock>
+</div>
+
+<style lang="scss">
+    .ops-monitor-skeleton .skel {
+        border-radius: 2px;
+        background: linear-gradient(
+            90deg,
+            rgba(255, 255, 255, 0.06) 0%,
+            rgba(255, 255, 255, 0.12) 50%,
+            rgba(255, 255, 255, 0.06) 100%
+        );
+        background-size: 200% 100%;
+        animation: ops-monitor-skel 1.1s ease-in-out infinite;
+    }
+
+    .ops-monitor-skeleton__health {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-l);
+        padding: var(--space-l) var(--space-m);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        background: rgba(0, 0, 0, 0.28);
+    }
+
+    .ops-monitor-skeleton__overall {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2xs);
+        max-width: 28rem;
+    }
+
+    .ops-monitor-skeleton__card {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3xs);
+        padding: var(--space-m);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        background: rgba(0, 0, 0, 0.22);
+    }
+
+    .ops-monitor-skeleton__dual {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: var(--space-s);
+    }
+
+    .ops-monitor-skeleton__metric {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3xs);
+        min-width: 0;
+    }
+
+    .skel-eyebrow {
+        width: 8rem;
+        height: 0.75rem;
+    }
+
+    .skel-pct {
+        width: 11rem;
+        height: clamp(3.5rem, 8vw, 5.5rem);
+        max-width: 100%;
+    }
+
+    .skel-card-pct {
+        width: 6.5rem;
+        height: clamp(2rem, 4vw, 3rem);
+    }
+
+    .skel-bar {
+        width: 100%;
+        height: var(--space-2xs);
+        margin-block: var(--space-3xs);
+    }
+
+    .skel-line {
+        width: 14rem;
+        max-width: 100%;
+        height: 0.85rem;
+    }
+
+    .skel-line--med {
+        width: 11rem;
+    }
+
+    .skel-line--short {
+        width: 7.5rem;
+    }
+
+    .skel-heading {
+        width: 14rem;
+        max-width: 100%;
+        height: 1.35rem;
+    }
+
+    .skel-tile {
+        min-height: 9.5rem;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        background-color: rgba(85, 85, 85, 0.12);
+        background-image: linear-gradient(
+            90deg,
+            transparent 0%,
+            rgba(255, 255, 255, 0.08) 50%,
+            transparent 100%
+        );
+        background-size: 200% 100%;
+        animation: ops-monitor-skel 1.1s ease-in-out infinite;
+    }
+
+    .skel-filters {
+        width: 100%;
+        min-height: 6.5rem;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        background-color: rgba(85, 85, 85, 0.1);
+        background-image: linear-gradient(
+            90deg,
+            transparent 0%,
+            rgba(255, 255, 255, 0.07) 50%,
+            transparent 100%
+        );
+        background-size: 200% 100%;
+        animation: ops-monitor-skel 1.1s ease-in-out infinite;
+    }
+
+    .skel-row {
+        width: 100%;
+        height: 4.25rem;
+        border: 1px solid rgba(255, 255, 255, 0.06);
+    }
+
+    @keyframes ops-monitor-skel {
+        0% {
+            background-position: 100% 0;
+        }
+        100% {
+            background-position: -100% 0;
+        }
+    }
+</style>

--- a/frontend/app/src/pages/market/ops.astro
+++ b/frontend/app/src/pages/market/ops.astro
@@ -1,19 +1,15 @@
 ---
 import { i18n } from '@helpers/i18n'
-const { lang, t, translatePath } = i18n(Astro.url)
+const { t, translatePath } = i18n(Astro.url)
 
-import { get_ops_monitor } from '@helpers/api.minmatar.org/market'
 import { get_market_locations } from '@helpers/api.minmatar.org/locations'
-import type { OpsMonitor } from '@dtypes/api.minmatar.org'
 import { query_string } from '@helpers/string'
-import { from_now_diff } from '@helpers/date'
 import {
     ops_params_need_canonicalization,
     ops_redirect_path,
     resolve_ops_location_id,
 } from '@helpers/market_ops_redirect'
 
-let monitor: OpsMonitor | null = null
 let fetch_error: Error | false = false
 let locations: Awaited<ReturnType<typeof get_market_locations>> = []
 let location_id: number | undefined
@@ -30,68 +26,9 @@ try {
     ) {
         return Astro.redirect(ops_redirect_path(translatePath, location_id))
     }
-
-    monitor = await get_ops_monitor(location_id)
 } catch (error) {
     fetch_error = error as Error
 }
-
-function health_tone(pct: number | null | undefined): 'good' | 'warn' | 'bad' | 'none' {
-    if (pct == null)
-        return 'none'
-    if (pct >= 80)
-        return 'good'
-    if (pct >= 40)
-        return 'warn'
-    return 'bad'
-}
-
-function format_pct(pct: number | null | undefined): string {
-    if (pct == null)
-        return '—'
-    return `${pct % 1 === 0 ? pct.toFixed(0) : pct.toFixed(1)}%`
-}
-
-function fulfilled_label(fulfilled: number, targets: number): string {
-    if (targets <= 0)
-        return t('ops_health_no_targets')
-    return t('ops_health_fulfilled')
-        .replace('{fulfilled}', String(fulfilled))
-        .replace('{targets}', String(targets))
-}
-
-function format_isk(isk: number): string {
-    const abs = Math.abs(isk)
-    if (abs >= 1_000_000_000_000)
-        return `${(isk / 1_000_000_000_000).toFixed(2)}T`
-    if (abs >= 1_000_000_000)
-        return `${(isk / 1_000_000_000).toFixed(1)}B`
-    if (abs >= 1_000_000)
-        return `${(isk / 1_000_000).toFixed(0)}M`
-    if (abs >= 1_000)
-        return `${(isk / 1_000).toFixed(0)}K`
-    return isk.toFixed(0)
-}
-
-function isk_label(template_key: string, isk: number): string {
-    return t(template_key).replace('{isk}', format_isk(isk))
-}
-
-function count_label(template_key: string, count: number): string {
-    return t(template_key).replace('{count}', String(count))
-}
-
-function sync_age_label(iso: string | null | undefined): string {
-    if (!iso)
-        return '—'
-    return from_now_diff(lang, new Date(iso))
-}
-
-const summary = monitor?.summary
-const overall_tone = health_tone(summary?.overall_health_pct)
-const contracts_tone = health_tone(summary?.contracts_health_pct)
-const sell_tone = health_tone(summary?.sell_orders_health_pct)
-const sell_viability_tone = health_tone(summary?.sell_orders_viability_pct)
 
 import Viewport from '@layouts/Viewport.astro';
 import PageWide from '@components/page/PageWide.astro';
@@ -99,22 +36,30 @@ import PageTitle from '@components/page/PageTitle.astro';
 import TextBox from '@components/layout/TextBox.astro';
 import Flexblock from '@components/compositions/Flexblock.astro';
 import FlexInline from '@components/compositions/FlexInline.astro';
-import Grid from '@components/compositions/Grid.astro';
 import Button from '@components/blocks/Button.astro';
 import ErrorRefetch from '@components/blocks/ErrorRefetch.astro';
 import Markdown from '@components/blocks/Markdown.astro';
-import Progress from '@components/blocks/Progress.astro';
-import OpsUnderstockedGrid from '@components/blocks/OpsUnderstockedGrid.astro';
-import OpsSellGapsList from '@components/blocks/OpsSellGapsList.astro';
+import OpsMonitorSkeleton from '@components/blocks/OpsMonitorSkeleton.astro';
 
 const page_title = t('staging_supply.ops.page_title')
 const api_base = import.meta.env.API_URL || ''
 const admin_hub = location_id != null
     ? `${api_base}/admin/market/location/${location_id}/`
     : `${api_base}/admin/market/locations/`
+
+const MONITOR_PARTIAL = translatePath(
+    `/partials/ops_monitor_component${
+        location_id != null
+            ? `?${query_string({ location_id })}`
+            : ''
+    }`,
+)
 ---
 
-<Viewport title={page_title} meta_description={t('staging_supply.ops.meta_description')}>
+<Viewport
+    title={page_title}
+    meta_description={t('staging_supply.ops.meta_description')}
+>
     <PageWide
         cover={{
             image: '/images/market-cover.jpg',
@@ -145,326 +90,75 @@ const admin_hub = location_id != null
                     error: fetch_error,
                     delay: 0,
                 }} />
-                : monitor && summary &&
-                <>
-                    <section class:list={['ops-health', `ops-health--${overall_tone}`]}>
-                        <div class="[ ops-health__overall ]">
-                            <p class="[ ops-health__eyebrow ]">{t('ops_health_overall')}</p>
-                            <p class="[ ops-health__pct ]">{format_pct(summary.overall_health_pct)}</p>
-                            <Progress
-                                class:list={[
-                                    'ops-health__bar',
-                                    {
-                                        success: overall_tone === 'good',
-                                        danger: overall_tone === 'bad',
-                                        disabled: overall_tone === 'none',
-                                    },
-                                ]}
-                                max="100"
-                                value={summary.overall_health_pct != null ? Math.max(summary.overall_health_pct, 0.1) : 0.1}
-                            />
-                            <p class="[ ops-health__isk ]">
-                                {isk_label('ops_health_isk_on_market', summary.total_isk_on_market)}
-                            </p>
-                            <div
-                                class="[ ops-health__sync ]"
-                                title={[
-                                    monitor.contracts_synced_at ? `Contracts: ${monitor.contracts_synced_at}` : null,
-                                    monitor.orders_synced_at ? `Orders: ${monitor.orders_synced_at}` : null,
-                                ].filter(Boolean).join(' · ') || undefined}
-                            >
-                                <small>
-                                    {t('ops_sync_age_contracts')
-                                        .replace('{age}', sync_age_label(monitor.contracts_synced_at))}
-                                </small>
-                                <small>
-                                    {t('ops_sync_age_orders')
-                                        .replace('{age}', sync_age_label(monitor.orders_synced_at))}
-                                </small>
-                            </div>
-                        </div>
-
-                        <Grid
-                            class="[ ops-health__split ]"
-                            min_item_width="280px"
-                            row_gap="var(--space-s)"
-                            column_gap="var(--space-s)"
-                        >
-                            <article class:list={['ops-health__card', `ops-health__card--${contracts_tone}`]}>
-                                <p class="[ ops-health__card-label ]">{t('ops_health_contracts')}</p>
-                                <p class="[ ops-health__card-pct ]">{format_pct(summary.contracts_health_pct)}</p>
-                                <Progress
-                                    class:list={[
-                                        'ops-health__bar',
-                                        {
-                                            success: contracts_tone === 'good',
-                                            danger: contracts_tone === 'bad',
-                                            disabled: contracts_tone === 'none',
-                                        },
-                                    ]}
-                                    max="100"
-                                    value={summary.contracts_health_pct != null ? Math.max(summary.contracts_health_pct, 0.1) : 0.1}
-                                />
-                                <p class="[ ops-health__card-meta ]">
-                                    {fulfilled_label(summary.contract_fulfilled, summary.contract_targets)}
-                                </p>
-                                <p class="[ ops-health__card-meta ops-health__card-meta--isk ]">
-                                    {isk_label('ops_health_isk_in_contracts', summary.contracts_isk)}
-                                </p>
-                                <p class="[ ops-health__card-meta ]">
-                                    {count_label('ops_health_under_target', summary.understocked_contracts)}
-                                </p>
-                            </article>
-
-                            <article class="[ ops-health__card ]">
-                                <p class="[ ops-health__card-label ]">{t('ops_health_sell_orders')}</p>
-                                <div class="[ ops-health__dual ]">
-                                    <div
-                                        class:list={['ops-health__metric', `ops-health__metric--${sell_tone}`]}
-                                        title={t('ops_health_coverage_hint')}
-                                    >
-                                        <p class="[ ops-health__metric-label ]">{t('ops_health_coverage')}</p>
-                                        <p class="[ ops-health__card-pct ]">{format_pct(summary.sell_orders_health_pct)}</p>
-                                        <Progress
-                                            class:list={[
-                                                'ops-health__bar',
-                                                {
-                                                    success: sell_tone === 'good',
-                                                    danger: sell_tone === 'bad',
-                                                    disabled: sell_tone === 'none',
-                                                },
-                                            ]}
-                                            max="100"
-                                            value={summary.sell_orders_health_pct != null ? Math.max(summary.sell_orders_health_pct, 0.1) : 0.1}
-                                        />
-                                        <p class="[ ops-health__card-meta ]">
-                                            {fulfilled_label(summary.sell_order_fulfilled, summary.sell_order_targets)}
-                                        </p>
-                                    </div>
-                                    <div
-                                        class:list={['ops-health__metric', `ops-health__metric--${sell_viability_tone}`]}
-                                        title={t('ops_health_viability_hint')}
-                                    >
-                                        <p class="[ ops-health__metric-label ]">{t('ops_health_viability')}</p>
-                                        <p class="[ ops-health__card-pct ]">{format_pct(summary.sell_orders_viability_pct)}</p>
-                                        <Progress
-                                            class:list={[
-                                                'ops-health__bar',
-                                                {
-                                                    success: sell_viability_tone === 'good',
-                                                    danger: sell_viability_tone === 'bad',
-                                                    disabled: sell_viability_tone === 'none',
-                                                },
-                                            ]}
-                                            max="100"
-                                            value={summary.sell_orders_viability_pct != null ? Math.max(summary.sell_orders_viability_pct, 0.1) : 0.1}
-                                        />
-                                        <p class="[ ops-health__card-meta ]">
-                                            {summary.sell_order_targets > 0
-                                                ? t('ops_health_viable_fulfilled')
-                                                    .replace('{fulfilled}', String(summary.sell_order_viable_fulfilled))
-                                                    .replace('{targets}', String(summary.sell_order_targets))
-                                                : t('ops_health_no_targets')}
-                                        </p>
-                                    </div>
-                                </div>
-                                <p class="[ ops-health__card-meta ops-health__card-meta--isk ]">
-                                    {isk_label('ops_health_isk_in_sell_orders', summary.sell_orders_isk)}
-                                </p>
-                                <p class="[ ops-health__card-meta ]">
-                                    {count_label('ops_health_critical_gaps', summary.sell_gaps)}
-                                </p>
-                            </article>
-                        </Grid>
-                    </section>
-
-                    <Flexblock gap="var(--space-l)">
-                        <Flexblock gap="var(--space-s)">
-                            <h2>{t('ops_understocked')} ({monitor.summary.understocked_contracts})</h2>
-                            <OpsUnderstockedGrid
-                                rows={monitor.understocked_contracts}
-                                hide_location={true}
-                            />
-                        </Flexblock>
-
-                        <OpsSellGapsList
-                            rows={monitor.sell_gaps}
-                            hide_location={true}
-                            jita_copy_label={t('ops_copy_jita_buy_list')}
-                            jita_copy_tip={t('ops_copy_jita_buy_list_tip')}
-                            sales_history_days={monitor.summary.sales_history_days ?? 0}
-                        />
-                    </Flexblock>
-                </>
+                :
+                <div
+                    id="ops-monitor-slot"
+                    data-ops-monitor-deferred="1"
+                    hx-get={MONITOR_PARTIAL}
+                    hx-trigger="load"
+                    hx-swap="innerHTML"
+                    hx-indicator=".loader"
+                    aria-busy="true"
+                    aria-live="polite"
+                >
+                    <OpsMonitorSkeleton />
+                </div>
             }
         </Flexblock>
     </PageWide>
 </Viewport>
 
-<style lang="scss">
-    .ops-health {
-        display: flex;
-        flex-direction: column;
-        gap: var(--space-l);
-        padding: var(--space-l) var(--space-m);
-        border: 1px solid rgba(255, 255, 255, 0.12);
-        background: rgba(0, 0, 0, 0.28);
+<script>
+    function refreshOpsMonitorSlot() {
+        const slot = document.getElementById('ops-monitor-slot')
+        if (!slot)
+            return
 
-        &--good {
-            border-color: color-mix(in srgb, var(--green) 45%, transparent);
-        }
-
-        &--warn {
-            border-color: color-mix(in srgb, var(--fleet-yellow) 45%, transparent);
-        }
-
-        &--bad {
-            border-color: color-mix(in srgb, var(--fleet-red) 50%, transparent);
+        slot.setAttribute('aria-busy', 'false')
+        if (typeof htmx !== 'undefined')
+            htmx.process(slot)
+        if (typeof Alpine !== 'undefined')
+            Alpine.initTree(slot)
+        if (typeof tippy === 'function') {
+            tippy('#ops-monitor-slot [data-tippy-content]', {
+                delay: [100, 200],
+                arrow: true,
+            })
         }
     }
 
-    .ops-health__overall {
-        display: flex;
-        flex-direction: column;
-        gap: var(--space-2xs);
-        max-width: 28rem;
+    function isOpsMonitorRequest(event: any): boolean {
+        const path = String(
+            event.detail?.pathInfo?.requestPath
+                || event.detail?.xhr?.responseURL
+                || event.detail?.elt?.getAttribute?.('hx-get')
+                || '',
+        )
+        return path.includes('ops_monitor_component')
     }
 
-    .ops-health__eyebrow,
-    .ops-health__card-label {
-        margin: 0;
-        font-size: var(--step--1);
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        color: var(--fleet-yellow);
+    function bindOpsMonitorDeferred() {
+        const slot = document.getElementById('ops-monitor-slot')
+        if (!slot || slot.dataset.bound === '1')
+            return
+        slot.dataset.bound = '1'
+
+        document.body.addEventListener('htmx:afterSwap', (event: any) => {
+            if (!isOpsMonitorRequest(event))
+                return
+            refreshOpsMonitorSlot()
+        })
+
+        document.body.addEventListener('htmx:afterRequest', (event: any) => {
+            if (!isOpsMonitorRequest(event))
+                return
+            if (!event.detail?.successful) {
+                const root = document.getElementById('ops-monitor-slot')
+                root?.setAttribute('aria-busy', 'false')
+            }
+        })
     }
 
-    .ops-health__pct {
-        margin: 0;
-        font-family: var(--heading-font);
-        font-size: clamp(3.5rem, 8vw, 6rem);
-        font-weight: 400;
-        line-height: 0.9;
-        letter-spacing: -0.03em;
-        color: var(--highlight);
-        text-transform: uppercase;
-    }
-
-    .ops-health--good .ops-health__pct {
-        color: var(--green);
-    }
-
-    .ops-health--warn .ops-health__pct {
-        color: var(--fleet-yellow);
-    }
-
-    .ops-health--bad .ops-health__pct {
-        color: var(--fleet-red);
-    }
-
-    .ops-health__bar {
-        --progress-height: var(--space-2xs);
-        width: 100%;
-        margin-block: var(--space-3xs);
-    }
-
-    .ops-health__sync {
-        display: flex;
-        flex-direction: column;
-        gap: var(--space-3xs);
-        margin: 0;
-        color: rgba(255, 255, 255, 0.65);
-        font-size: var(--step--1);
-    }
-
-    .ops-health__sync small {
-        margin: 0;
-    }
-
-    .ops-health__card-meta {
-        margin: 0;
-        color: rgba(255, 255, 255, 0.65);
-        font-size: var(--step--1);
-    }
-
-    .ops-health__isk,
-    .ops-health__card-meta--isk {
-        margin: 0;
-        font-family: var(--heading-font);
-        font-size: var(--step-0);
-        letter-spacing: 0.02em;
-        text-transform: uppercase;
-        color: var(--highlight);
-    }
-
-    .ops-health__isk {
-        font-size: var(--step-1);
-        margin-block-start: var(--space-3xs);
-    }
-
-    .ops-health__card {
-        display: flex;
-        flex-direction: column;
-        gap: var(--space-3xs);
-        padding: var(--space-m);
-        border: 1px solid rgba(255, 255, 255, 0.1);
-        background: rgba(0, 0, 0, 0.22);
-    }
-
-    .ops-health__card-pct {
-        margin: 0;
-        font-family: var(--heading-font);
-        font-size: clamp(2.25rem, 5vw, 3.5rem);
-        line-height: 0.95;
-        letter-spacing: -0.02em;
-        text-transform: uppercase;
-        color: var(--highlight);
-    }
-
-    .ops-health__dual {
-        display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: var(--space-s);
-    }
-
-    .ops-health__metric {
-        display: flex;
-        flex-direction: column;
-        gap: var(--space-3xs);
-        min-width: 0;
-    }
-
-    .ops-health__metric-label {
-        margin: 0;
-        font-size: var(--step--1);
-        letter-spacing: 0.06em;
-        text-transform: uppercase;
-        color: rgba(255, 255, 255, 0.7);
-    }
-
-    .ops-health__card--good .ops-health__card-pct,
-    .ops-health__metric--good .ops-health__card-pct {
-        color: var(--green);
-    }
-
-    .ops-health__card--warn .ops-health__card-pct,
-    .ops-health__metric--warn .ops-health__card-pct {
-        color: var(--fleet-yellow);
-    }
-
-    .ops-health__card--bad .ops-health__card-pct,
-    .ops-health__metric--bad .ops-health__card-pct {
-        color: var(--fleet-red);
-    }
-
-    .ops-qty {
-        font-family: var(--heading-font);
-        text-transform: uppercase;
-        color: var(--highlight);
-        white-space: nowrap;
-    }
-
-    h2 {
-        font-size: var(--step-1);
-    }
-</style>
+    bindOpsMonitorDeferred()
+    document.addEventListener('astro:page-load', bindOpsMonitorDeferred)
+</script>

--- a/frontend/app/src/pages/partials/ops_monitor_component.astro
+++ b/frontend/app/src/pages/partials/ops_monitor_component.astro
@@ -1,0 +1,47 @@
+---
+import { i18n } from '@helpers/i18n'
+const { translatePath } = i18n(Astro.url)
+
+import { get_ops_monitor } from '@helpers/api.minmatar.org/market'
+import type { OpsMonitor } from '@dtypes/api.minmatar.org'
+import { query_string } from '@helpers/string'
+
+const location_id_param = Astro.url.searchParams.get('location_id')
+const parsed_location_id = location_id_param != null && location_id_param !== ''
+    ? parseInt(location_id_param, 10)
+    : NaN
+const location_id = Number.isNaN(parsed_location_id) ? undefined : parsed_location_id
+
+let monitor: OpsMonitor | null = null
+let fetching_error: Error | false = false
+
+try {
+    monitor = await get_ops_monitor(location_id)
+} catch (error) {
+    fetching_error = error as Error
+}
+
+const partial_url = translatePath(
+    `/partials/ops_monitor_component${
+        location_id != null
+            ? `?${query_string({ location_id })}`
+            : ''
+    }`,
+)
+
+import OpsMonitorContent from '@components/blocks/OpsMonitorContent.astro'
+import ErrorRefetch from '@components/blocks/ErrorRefetch.astro'
+---
+
+{fetching_error !== false ?
+    <ErrorRefetch
+        args={{
+            partial: partial_url,
+            error: fetching_error,
+            delay: 0,
+        }}
+    />
+    : monitor ?
+        <OpsMonitorContent monitor={monitor} />
+    : null
+}


### PR DESCRIPTION
## Summary
- Market Operations (`/market/ops/`) now renders the page shell immediately and HTMX-loads the heavy ops-monitor payload
- Adds matching skeletons for health cards, understocked tiles, and sell-gap rows while the monitor loads
- Extracts monitor UI into `OpsMonitorContent` and a reusable partial for retries / Alpine re-init after swap

## Test plan
- [ ] Open `/market/ops/` and confirm title + leading text appear quickly with skeletons
- [ ] Confirm health, understocked, and sell-gap sections replace skeletons when the monitor finishes
- [ ] Confirm sell-gap filters and Jita copy still work after deferred load
- [ ] Confirm location canonical redirects still work
- [ ] Force a monitor API failure and confirm ErrorRefetch retries the partial


Made with [Cursor](https://cursor.com)