### PR TITLE
Fix Sentry races, noise paths, and ops-monitor cost

### DIFF
--- a/backend/discord/signals.py
+++ b/backend/discord/signals.py
@@ -64,9 +64,7 @@ def _discord_role_call(
     try:
         call(discord_user.id, role.role_id)
     except Exception as exc:
-        if handle_discord_guild_member_error(
-            user, exc, context, offboard_if_missing=False
-        ):
+        if handle_discord_guild_member_error(user, exc, context):
             return False
         raise
     return True

--- a/backend/discord/tasks.py
+++ b/backend/discord/tasks.py
@@ -56,6 +56,10 @@ def sync_discord_users():
         try:
             sync_discord_user(user.id)
         except Exception as e:
+            if handle_discord_guild_member_error(
+                user, e, "sync_discord_users"
+            ):
+                continue
             notify_technology_team("sync_discord_users")
             logger.error(
                 "Failed to sync discord user %s: %s", user.username, e

--- a/backend/eveonline/apps.py
+++ b/backend/eveonline/apps.py
@@ -7,3 +7,8 @@ class EveonlineConfig(AppConfig):
 
     def ready(self):
         import eveonline.signals  # pylint: disable=unused-import, import-outside-toplevel
+        from eveonline.esi_view_patches import (  # pylint: disable=import-outside-toplevel
+            patch_esi_receive_callback,
+        )
+
+        patch_esi_receive_callback()

--- a/backend/eveonline/client.py
+++ b/backend/eveonline/client.py
@@ -186,6 +186,15 @@ class EsiClient:
                 response_code=SUCCESS,
                 data=_esi_to_python(operation.results(**kwargs)),
             )
+        except (InvalidGrantError, TokenInvalidError) as e:
+            logger.info(
+                "ESI operation.results() token invalid for %s: %s",
+                getattr(
+                    getattr(operation, "operation", None), "operationId", None
+                ),
+                e,
+            )
+            return EsiResponse(response_code=ERROR_CALLING_ESI, response=e)
         except Exception as e:
             logger.warning(
                 "ESI operation.results() failed for %s: %s",
@@ -193,7 +202,6 @@ class EsiClient:
                     getattr(operation, "operation", None), "operationId", None
                 ),
                 e,
-                exc_info=True,
             )
             return EsiResponse(response_code=ERROR_CALLING_ESI, response=e)
 
@@ -201,10 +209,28 @@ class EsiClient:
         # See _operation_results — same 304/ETag pitfall for single-object ops.
         kwargs.setdefault("use_etag", False)
         try:
+            data = _esi_to_python(operation.result(**kwargs))
+            # Belt-and-suspenders: some operations return a one-element list
+            # instead of the single dict callers expect.
+            if (
+                isinstance(data, list)
+                and len(data) == 1
+                and isinstance(data[0], dict)
+            ):
+                data = data[0]
             return EsiResponse(
                 response_code=SUCCESS,
-                data=_esi_to_python(operation.result(**kwargs)),
+                data=data,
             )
+        except (InvalidGrantError, TokenInvalidError) as e:
+            logger.info(
+                "ESI operation.result() token invalid for %s: %s",
+                getattr(
+                    getattr(operation, "operation", None), "operationId", None
+                ),
+                e,
+            )
+            return EsiResponse(response_code=ERROR_CALLING_ESI, response=e)
         except Exception as e:
             logger.warning(
                 "ESI operation.result() failed for %s: %s",
@@ -212,7 +238,6 @@ class EsiClient:
                     getattr(operation, "operation", None), "operationId", None
                 ),
                 e,
-                exc_info=True,
             )
             return EsiResponse(response_code=ERROR_CALLING_ESI, response=e)
 

--- a/backend/eveonline/esi_view_patches.py
+++ b/backend/eveonline/esi_view_patches.py
@@ -1,0 +1,32 @@
+"""
+Patches for django-esi views.
+
+``esi.views.receive_callback`` slices ``request.session.session_key[:5]``
+for logging. If the session has no key yet (e.g. a fresh/anonymous session
+that has not been saved), ``session_key`` is ``None`` and the slice raises
+``TypeError: 'NoneType' object is not subscriptable`` (REST-API-A2).
+
+We wrap the view so a session key always exists before the original view
+(and its logging) runs.
+"""
+
+import esi.views
+
+_PATCHED_ATTR = "_minmatar_session_key_patched"
+
+
+def patch_esi_receive_callback() -> None:
+    """Ensure ``request.session.session_key`` is set before django-esi's
+    callback view runs, so its logging can safely slice it."""
+    if getattr(esi.views.receive_callback, _PATCHED_ATTR, False):
+        return
+
+    original_receive_callback = esi.views.receive_callback
+
+    def _safe_receive_callback(request, *args, **kwargs):
+        if request.session.session_key is None:
+            request.session.create()
+        return original_receive_callback(request, *args, **kwargs)
+
+    setattr(_safe_receive_callback, _PATCHED_ATTR, True)
+    esi.views.receive_callback = _safe_receive_callback

--- a/backend/eveonline/tests/test_esi_view_patches.py
+++ b/backend/eveonline/tests/test_esi_view_patches.py
@@ -1,0 +1,76 @@
+from unittest.mock import MagicMock
+
+from django.test import SimpleTestCase
+
+import esi.views
+
+from eveonline.esi_view_patches import patch_esi_receive_callback
+
+
+def _make_recording_view(return_value):
+    """A plain function (not a Mock) so the patch's idempotency marker
+    check behaves like it would against the real django-esi view, instead
+    of a Mock auto-vivifying a truthy attribute for any name."""
+    calls = []
+
+    def _view(request, *args, **kwargs):
+        calls.append((request, args, kwargs))
+        return return_value
+
+    _view.calls = calls
+    return _view
+
+
+class EsiReceiveCallbackPatchTest(SimpleTestCase):
+    """REST-API-A2: a session with no key must not crash the callback view."""
+
+    def setUp(self):
+        super().setUp()
+        self._original_receive_callback = esi.views.receive_callback
+        self.addCleanup(
+            setattr,
+            esi.views,
+            "receive_callback",
+            self._original_receive_callback,
+        )
+
+    def test_creates_session_when_key_missing_before_delegating(self):
+        original = _make_recording_view("response")
+        esi.views.receive_callback = original
+
+        patch_esi_receive_callback()
+
+        request = MagicMock()
+        request.session.session_key = None
+
+        result = esi.views.receive_callback(request)
+
+        request.session.create.assert_called_once()
+        self.assertEqual(len(original.calls), 1)
+        self.assertIs(original.calls[0][0], request)
+        self.assertEqual(result, "response")
+
+    def test_does_not_create_session_when_key_present(self):
+        original = _make_recording_view("response")
+        esi.views.receive_callback = original
+
+        patch_esi_receive_callback()
+
+        request = MagicMock()
+        request.session.session_key = "abcdef"
+
+        esi.views.receive_callback(request)
+
+        request.session.create.assert_not_called()
+        self.assertEqual(len(original.calls), 1)
+
+    def test_patch_is_idempotent(self):
+        original = _make_recording_view("response")
+        esi.views.receive_callback = original
+
+        patch_esi_receive_callback()
+        patched_once = esi.views.receive_callback
+
+        patch_esi_receive_callback()
+
+        self.assertIs(patched_once, esi.views.receive_callback)

--- a/backend/feed/helpers/clusters.py
+++ b/backend/feed/helpers/clusters.py
@@ -4,6 +4,7 @@ from collections import Counter, defaultdict
 from datetime import timedelta
 from typing import Any
 
+from django.db.models import F
 from django.utils import timezone
 
 from feed.helpers.killmail_classify import dominant_attacker_faction
@@ -317,14 +318,10 @@ def _sliding_window_clusters(
                         ):
                             # Fight has run long enough; close it and start a
                             # fresh engagement even though kills continue.
-                            existing.is_active = False
-                            existing.ended_at = existing.last_kill_at
-                            existing.save(
-                                update_fields=[
-                                    "is_active",
-                                    "ended_at",
-                                    "updated_at",
-                                ]
+                            FeedCluster.objects.filter(pk=existing.pk).update(
+                                is_active=False,
+                                ended_at=F("last_kill_at"),
+                                updated_at=timezone.now(),
                             )
                         else:
                             _merge_fleet_cluster(
@@ -363,12 +360,12 @@ def _sliding_window_clusters(
 
 def _mark_stale_fleet_clusters(stale_minutes: int) -> None:
     cutoff = timezone.now() - timedelta(minutes=stale_minutes)
-    stale = FeedCluster.objects.filter(
+    FeedCluster.objects.filter(
         cluster_type=FeedCluster.ClusterType.FLEET_ENGAGEMENT,
         is_active=True,
         last_kill_at__lt=cutoff,
+    ).update(
+        is_active=False,
+        ended_at=F("last_kill_at"),
+        updated_at=timezone.now(),
     )
-    for cluster in stale:
-        cluster.is_active = False
-        cluster.ended_at = cluster.last_kill_at
-        cluster.save(update_fields=["is_active", "ended_at", "updated_at"])

--- a/backend/feed/tests/test_clusters.py
+++ b/backend/feed/tests/test_clusters.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from django.test import TestCase
 from django.utils import timezone
 
-from feed.helpers.clusters import detect_clusters
+from feed.helpers.clusters import _mark_stale_fleet_clusters, detect_clusters
 from feed.helpers.ingest import upsert_feed_killmail_from_r2z2
 from feed.management.commands.seed_feed_monitored_systems import (
     seed_from_fixture,
@@ -177,3 +177,39 @@ class ClusterRollupTestCase(TestCase):
         # First segment closed when the cap forced a split.
         self.assertFalse(fleet_clusters[0].is_active)
         self.assertIsNotNone(fleet_clusters[0].ended_at)
+
+    def test_mark_stale_fleet_clusters_deactivates_and_sets_ended_at(self):
+        """Stale active fleet clusters are deactivated via a single queryset update."""
+        FeedCluster.objects.all().delete()
+        last_kill_at = timezone.now() - timedelta(minutes=30)
+        stale_cluster = FeedCluster.objects.create(
+            cluster_key="fleet_engagement:30002538:500002:stale",
+            cluster_type=FeedCluster.ClusterType.FLEET_ENGAGEMENT,
+            solar_system_id=30002538,
+            dominant_faction_id=500002,
+            started_at=last_kill_at - timedelta(minutes=10),
+            last_kill_at=last_kill_at,
+            is_active=True,
+            kill_count=5,
+            pilot_count=8,
+        )
+        fresh_cluster = FeedCluster.objects.create(
+            cluster_key="fleet_engagement:30002538:500002:fresh",
+            cluster_type=FeedCluster.ClusterType.FLEET_ENGAGEMENT,
+            solar_system_id=30002538,
+            dominant_faction_id=500002,
+            started_at=timezone.now() - timedelta(minutes=2),
+            last_kill_at=timezone.now(),
+            is_active=True,
+            kill_count=5,
+            pilot_count=8,
+        )
+
+        _mark_stale_fleet_clusters(stale_minutes=20)
+
+        stale_cluster.refresh_from_db()
+        fresh_cluster.refresh_from_db()
+        self.assertFalse(stale_cluster.is_active)
+        self.assertEqual(stale_cluster.ended_at, stale_cluster.last_kill_at)
+        self.assertTrue(fresh_cluster.is_active)
+        self.assertIsNone(fresh_cluster.ended_at)

--- a/backend/fleets/endpoints/fleet/get_fleet_users.py
+++ b/backend/fleets/endpoints/fleet/get_fleet_users.py
@@ -26,6 +26,8 @@ def get_fleet_users(request, fleet_id: int):
         return 403, None
 
     audience = fleet.audience
+    if audience is None:
+        return [{"fleet_id": fleet_id, "user_ids": []}]
     groups = audience.groups.all()
 
     users = set()

--- a/backend/fleets/endpoints/helpers.py
+++ b/backend/fleets/endpoints/helpers.py
@@ -89,6 +89,9 @@ def _fleet_authorized(request, fleet: EveFleet) -> bool:
 
 def send_discord_pre_ping(fleet: EveFleet) -> bool:
     """Send a Discord pre-ping for a fleet."""
+    if not fleet.audience:
+        return False
+
     notification = get_fleet_discord_notification(
         is_pre_ping=True,
         fleet_id=fleet.id,

--- a/backend/fleets/models.py
+++ b/backend/fleets/models.py
@@ -158,7 +158,7 @@ class EveFleet(models.Model):
         """
         Send the fleet notification to the audience's Discord channel, if configured.
         """
-        if not self.audience.discord_channel_id:
+        if not self.audience or not self.audience.discord_channel_id:
             return
 
         doctrine = None if self.type == "strategic" else self.doctrine

--- a/backend/groups/helpers/feature_access.py
+++ b/backend/groups/helpers/feature_access.py
@@ -141,8 +141,10 @@ def _evaluate_resource_match(feature: PilotFeature, user, fleet) -> bool:
     if fleet is None:
         return _evaluate_affiliation(feature, user)
     if _evaluate_affiliation(feature, user):
-        audience_group_ids = set(
-            fleet.audience.groups.values_list("pk", flat=True)
+        audience_group_ids = (
+            set(fleet.audience.groups.values_list("pk", flat=True))
+            if fleet.audience is not None
+            else set()
         )
         if not audience_group_ids:
             return True

--- a/backend/market/helpers/ops_monitor.py
+++ b/backend/market/helpers/ops_monitor.py
@@ -2,9 +2,21 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from datetime import timedelta
 
-from django.db.models import Count, DecimalField, F, Sum, Value
+from django.db.models import (
+    Case,
+    Count,
+    DecimalField,
+    F,
+    IntegerField,
+    Max,
+    Min,
+    Sum,
+    Value,
+    When,
+)
 from django.db.models.functions import Coalesce
 from django.utils import timezone
 from eveuniverse.models import EveType
@@ -132,6 +144,7 @@ def build_ops_monitor(*, location_id: int | None = None) -> dict:  # noqa: C901
                 "total_isk_on_market": 0.0,
                 "sales_history_days": 0,
             },
+            "by_location": {},
         }
 
     location_pks = [loc.pk for loc in locations]
@@ -155,14 +168,15 @@ def build_ops_monitor(*, location_id: int | None = None) -> dict:  # noqa: C901
 
     understocked_contracts = []
     contract_fill_ratios: list[float] = []
+    contract_fill_ratios_by_loc: dict[int, list[float]] = defaultdict(list)
     for expectation in expectations:
         current = outstanding.get(
             (expectation.location_id, expectation.fitting_id), 0
         )
         if expectation.quantity > 0:
-            contract_fill_ratios.append(
-                min(1.0, current / expectation.quantity)
-            )
+            ratio = min(1.0, current / expectation.quantity)
+            contract_fill_ratios.append(ratio)
+            contract_fill_ratios_by_loc[expectation.location_id].append(ratio)
         level = fitting_readiness(current, expectation.quantity)
         if level in ("ready", "unknown"):
             continue
@@ -249,44 +263,47 @@ def build_ops_monitor(*, location_id: int | None = None) -> dict:  # noqa: C901
         since_7 = now - timedelta(days=_VOLUME_DAYS_7)
         since_30 = now - timedelta(days=_VOLUME_DAYS_30)
         since_90 = now - timedelta(days=_VOLUME_DAYS_90)
-        for row in EveMarketInferredSale.objects.filter(
-            location_id__in=location_pks,
-            item_id__in=target_type_ids,
-            inferred_at__gte=since_90,
-        ).values("location_id", "item_id", "quantity", "inferred_at"):
-            key = (row["location_id"], row["item_id"])
-            qty = int(row["quantity"] or 0)
-            units_90d_by_loc_item[key] = (
-                units_90d_by_loc_item.get(key, 0) + qty
-            )
-            inferred_at = row["inferred_at"]
-            if inferred_at >= since_30:
-                units_30d_by_loc_item[key] = (
-                    units_30d_by_loc_item.get(key, 0) + qty
-                )
-            if inferred_at >= since_7:
-                weekly_units_by_loc_item[key] = (
-                    weekly_units_by_loc_item.get(key, 0) + qty
-                )
-            if inferred_at >= since_3:
-                units_3d_by_loc_item[key] = (
-                    units_3d_by_loc_item.get(key, 0) + qty
-                )
-            if inferred_at >= since_1:
-                units_1d_by_loc_item[key] = (
-                    units_1d_by_loc_item.get(key, 0) + qty
-                )
 
-        # How much history exists, so the UI can hide windows it cannot fill.
-        earliest_sale = (
+        def _windowed_sum(since):
+            return Coalesce(
+                Sum(
+                    Case(
+                        When(inferred_at__gte=since, then=F("quantity")),
+                        default=0,
+                        output_field=IntegerField(),
+                    )
+                ),
+                0,
+            )
+
+        sales_aggregates = (
             EveMarketInferredSale.objects.filter(
                 location_id__in=location_pks,
+                item_id__in=target_type_ids,
                 inferred_at__gte=since_90,
             )
-            .order_by("inferred_at")
-            .values_list("inferred_at", flat=True)
-            .first()
+            .values("location_id", "item_id")
+            .annotate(
+                units_1d=_windowed_sum(since_1),
+                units_3d=_windowed_sum(since_3),
+                units_7d=_windowed_sum(since_7),
+                units_30d=_windowed_sum(since_30),
+                units_90d=Coalesce(Sum("quantity"), 0),
+            )
         )
+        for row in sales_aggregates:
+            key = (row["location_id"], row["item_id"])
+            units_1d_by_loc_item[key] = row["units_1d"]
+            units_3d_by_loc_item[key] = row["units_3d"]
+            weekly_units_by_loc_item[key] = row["units_7d"]
+            units_30d_by_loc_item[key] = row["units_30d"]
+            units_90d_by_loc_item[key] = row["units_90d"]
+
+        # How much history exists, so the UI can hide windows it cannot fill.
+        earliest_sale = EveMarketInferredSale.objects.filter(
+            location_id__in=location_pks,
+            inferred_at__gte=since_90,
+        ).aggregate(earliest=Min("inferred_at"))["earliest"]
         if earliest_sale is not None:
             sales_history_days = max(
                 1, int((now - earliest_sale).total_seconds() // 86400) + 1
@@ -295,6 +312,11 @@ def build_ops_monitor(*, location_id: int | None = None) -> dict:  # noqa: C901
     sell_targets = 0
     sell_fulfilled = 0
     sell_viable_fulfilled = 0
+    sell_fill_ratios_by_loc: dict[int, list[float]] = defaultdict(list)
+    sell_viable_fill_ratios_by_loc: dict[int, list[float]] = defaultdict(list)
+    sell_targets_by_loc: dict[int, int] = defaultdict(int)
+    sell_fulfilled_by_loc: dict[int, int] = defaultdict(int)
+    sell_viable_fulfilled_by_loc: dict[int, int] = defaultdict(int)
     for loc_pk, name_map in effective.items():
         loc = location_by_pk[loc_pk]
         for name, desired in name_map.items():
@@ -306,12 +328,19 @@ def build_ops_monitor(*, location_id: int | None = None) -> dict:  # noqa: C901
             current = stock_by_loc_item.get((loc_pk, eve_type.id), 0)
             viable = viable_by_loc_item.get((loc_pk, eve_type.id), 0)
             sell_targets += 1
-            sell_fill_ratios.append(min(1.0, current / desired))
-            sell_viable_fill_ratios.append(min(1.0, viable / desired))
+            sell_targets_by_loc[loc_pk] += 1
+            sell_ratio = min(1.0, current / desired)
+            sell_viable_ratio = min(1.0, viable / desired)
+            sell_fill_ratios.append(sell_ratio)
+            sell_fill_ratios_by_loc[loc_pk].append(sell_ratio)
+            sell_viable_fill_ratios.append(sell_viable_ratio)
+            sell_viable_fill_ratios_by_loc[loc_pk].append(sell_viable_ratio)
             if current >= desired:
                 sell_fulfilled += 1
+                sell_fulfilled_by_loc[loc_pk] += 1
             if viable >= desired:
                 sell_viable_fulfilled += 1
+                sell_viable_fulfilled_by_loc[loc_pk] += 1
             coverage_gap = current < desired * _CRITICAL_RATIO
             viability_gap = viable < desired * _CRITICAL_RATIO
             if not coverage_gap and not viability_gap:
@@ -397,7 +426,20 @@ def build_ops_monitor(*, location_id: int | None = None) -> dict:  # noqa: C901
         .values_list("created_at", flat=True)
         .first()
     )
+    latest_contract_by_loc = dict(
+        EveMarketContract.objects.filter(location_id__in=location_pks)
+        .values("location_id")
+        .annotate(latest=Max("last_updated"))
+        .values_list("location_id", "latest")
+    )
+    latest_order_by_loc = dict(
+        EveMarketItemOrder.objects.filter(location_id__in=location_pks)
+        .values("location_id")
+        .annotate(latest=Max("created_at"))
+        .values_list("location_id", "latest")
+    )
 
+    isk_decimal_field = DecimalField(max_digits=32, decimal_places=2)
     contracts_isk = float(
         EveMarketContract.objects.filter(
             location_id__in=location_pks,
@@ -405,16 +447,26 @@ def build_ops_monitor(*, location_id: int | None = None) -> dict:  # noqa: C901
         ).aggregate(
             total=Coalesce(
                 Sum("price"),
-                Value(
-                    0,
-                    output_field=DecimalField(max_digits=32, decimal_places=2),
-                ),
+                Value(0, output_field=isk_decimal_field),
             )
         )[
             "total"
         ]
         or 0
     )
+    contracts_isk_by_loc = {
+        row["location_id"]: float(row["total"] or 0)
+        for row in EveMarketContract.objects.filter(
+            location_id__in=location_pks,
+            status="outstanding",
+        )
+        .values("location_id")
+        .annotate(
+            total=Coalesce(
+                Sum("price"), Value(0, output_field=isk_decimal_field)
+            )
+        )
+    }
     sell_line_value = F("price") * F("quantity")
     sell_orders_isk = float(
         EveMarketItemOrder.objects.filter(
@@ -426,19 +478,87 @@ def build_ops_monitor(*, location_id: int | None = None) -> dict:  # noqa: C901
         )
         .aggregate(
             total=Coalesce(
-                Sum(
-                    "line_value",
-                    output_field=DecimalField(max_digits=32, decimal_places=2),
-                ),
-                Value(
-                    0,
-                    output_field=DecimalField(max_digits=32, decimal_places=2),
-                ),
+                Sum("line_value", output_field=isk_decimal_field),
+                Value(0, output_field=isk_decimal_field),
             ),
         )["total"]
         or 0
     )
+    sell_orders_isk_by_loc = {
+        row["location_id"]: float(row["total"] or 0)
+        for row in EveMarketItemOrder.objects.filter(
+            location_id__in=location_pks,
+            is_buy_order=False,
+        )
+        .annotate(line_value=sell_line_value)
+        .values("location_id")
+        .annotate(
+            total=Coalesce(
+                Sum("line_value", output_field=isk_decimal_field),
+                Value(0, output_field=isk_decimal_field),
+            )
+        )
+    }
     total_isk_on_market = contracts_isk + sell_orders_isk
+
+    by_location: dict[int, dict] = {}
+    for loc in locations:
+        loc_pk = loc.pk
+        loc_contract_ratios = contract_fill_ratios_by_loc.get(loc_pk, [])
+        loc_sell_ratios = sell_fill_ratios_by_loc.get(loc_pk, [])
+        loc_sell_viable_ratios = sell_viable_fill_ratios_by_loc.get(loc_pk, [])
+        loc_understocked = [
+            row
+            for row in understocked_contracts
+            if row["location_id"] == loc.location_id
+        ]
+        loc_sell_gaps = [
+            row for row in sell_gaps if row["location_id"] == loc.location_id
+        ]
+        loc_contracts_isk = contracts_isk_by_loc.get(loc_pk, 0.0)
+        loc_sell_orders_isk = sell_orders_isk_by_loc.get(loc_pk, 0.0)
+        loc_contracts_health_pct = _health_pct(loc_contract_ratios)
+        loc_sell_orders_health_pct = _health_pct(loc_sell_ratios)
+        loc_sell_orders_viability_pct = _health_pct(loc_sell_viable_ratios)
+        loc_latest_contract = latest_contract_by_loc.get(loc_pk)
+        loc_latest_order = latest_order_by_loc.get(loc_pk)
+        by_location[loc.location_id] = {
+            "contracts_synced_at": (
+                loc_latest_contract.isoformat()
+                if loc_latest_contract
+                else None
+            ),
+            "orders_synced_at": (
+                loc_latest_order.isoformat() if loc_latest_order else None
+            ),
+            "understocked_contracts": loc_understocked[:50],
+            "sell_gaps": loc_sell_gaps,
+            "summary": {
+                "understocked_contracts": min(len(loc_understocked), 50),
+                "sell_gaps": len(loc_sell_gaps),
+                "contracts_health_pct": loc_contracts_health_pct,
+                "sell_orders_health_pct": loc_sell_orders_health_pct,
+                "sell_orders_viability_pct": loc_sell_orders_viability_pct,
+                "overall_health_pct": _combined_health(
+                    loc_contracts_health_pct, loc_sell_orders_health_pct
+                ),
+                "contract_targets": len(loc_contract_ratios),
+                "contract_fulfilled": sum(
+                    1 for ratio in loc_contract_ratios if ratio >= 1.0
+                ),
+                "sell_order_targets": sell_targets_by_loc.get(loc_pk, 0),
+                "sell_order_fulfilled": sell_fulfilled_by_loc.get(loc_pk, 0),
+                "sell_order_viable_fulfilled": (
+                    sell_viable_fulfilled_by_loc.get(loc_pk, 0)
+                ),
+                "contracts_isk": round(loc_contracts_isk, 2),
+                "sell_orders_isk": round(loc_sell_orders_isk, 2),
+                "total_isk_on_market": round(
+                    loc_contracts_isk + loc_sell_orders_isk, 2
+                ),
+                "sales_history_days": sales_history_days,
+            },
+        }
 
     return {
         "synced_at": timezone.now().isoformat(),
@@ -467,6 +587,10 @@ def build_ops_monitor(*, location_id: int | None = None) -> dict:  # noqa: C901
             "total_isk_on_market": round(total_isk_on_market, 2),
             "sales_history_days": sales_history_days,
         },
+        # Per-location breakdown of the same payload shape, so callers that
+        # need every market-active location (e.g. snapshotting) can compute
+        # this once instead of calling build_ops_monitor() per location.
+        "by_location": by_location,
     }
 
 

--- a/backend/market/helpers/ops_snapshot.py
+++ b/backend/market/helpers/ops_snapshot.py
@@ -100,9 +100,21 @@ def record_ops_monitor_snapshots(
         )
         return 0
 
+    if location_id is not None:
+        # Single location requested: one build is already minimal work.
+        payload_by_location = {
+            location_id: build_ops_monitor(location_id=location_id)
+        }
+    else:
+        # All locations: compute the shared queries once and split the
+        # result per location instead of calling build_ops_monitor() N times.
+        payload_by_location = build_ops_monitor().get("by_location", {})
+
     created = 0
     for loc in locations:
-        payload = build_ops_monitor(location_id=loc.location_id)
+        payload = payload_by_location.get(
+            loc.location_id
+        ) or build_ops_monitor(location_id=loc.location_id)
         summary = payload["summary"]
         EveMarketOpsMonitorSnapshot.objects.create(
             location=loc,

--- a/backend/market/tests/test_ops_monitor_snapshots.py
+++ b/backend/market/tests/test_ops_monitor_snapshots.py
@@ -6,6 +6,7 @@ from app.test import TestCase
 from eveonline.client import EsiResponse
 from eveonline.models import EveLocation
 from fittings.models import EveFitting
+from market.helpers.ops_monitor import build_ops_monitor
 from market.helpers.ops_snapshot import (
     list_ops_monitor_snapshots,
     record_ops_monitor_snapshots,
@@ -106,6 +107,61 @@ class OpsMonitorSnapshotTestCase(TestCase):
             location_id=self.loc.location_id, limit=2
         )
         self.assertEqual(len(rows), 2)
+
+    def test_record_snapshot_for_all_locations_builds_once(self):
+        """Snapshotting every location computes the shared queries once
+        (build_ops_monitor()) and splits results per location (CELERY-JC)."""
+        other_loc = EveLocation.objects.create(
+            location_id=100,
+            location_name="Elsewhere",
+            short_name="Elsewhere",
+            solar_system_id=2,
+            solar_system_name="Elsewhere",
+            market_active=True,
+        )
+        other_fit = EveFitting.objects.create(
+            name="[NVY-5] Rifter",
+            ship_id=587,
+            description="Testing",
+            eft_format="[Rifter, [NVY-5] Rifter]",
+        )
+        EveMarketContractExpectation.objects.create(
+            fitting=other_fit,
+            location=other_loc,
+            quantity=2,
+        )
+
+        with patch(
+            "market.helpers.ops_snapshot.build_ops_monitor",
+            wraps=build_ops_monitor,
+        ) as build_mock:
+            created = record_ops_monitor_snapshots(
+                trigger=EveMarketOpsMonitorSnapshot.TRIGGER_CONTRACTS,
+            )
+
+        self.assertEqual(created, 2)
+        build_mock.assert_called_once_with()
+
+        snap_by_loc = {
+            snap.location_id: snap
+            for snap in EveMarketOpsMonitorSnapshot.objects.all()
+        }
+        self.assertEqual(
+            snap_by_loc[self.loc.pk].understocked_contracts[0]["fitting_name"],
+            self.fit.name,
+        )
+        self.assertEqual(
+            snap_by_loc[other_loc.pk].understocked_contracts[0][
+                "fitting_name"
+            ],
+            other_fit.name,
+        )
+        self.assertEqual(
+            snap_by_loc[self.loc.pk].understocked_contracts_count, 1
+        )
+        self.assertEqual(
+            snap_by_loc[other_loc.pk].understocked_contracts_count, 1
+        )
 
     @patch("market.tasks.record_ops_monitor_snapshot_task")
     @patch("market.tasks.fetch_contract_items_task")

--- a/backend/structures/tasks.py
+++ b/backend/structures/tasks.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from django.conf import settings
 
 from app.celery import app
+from app.models import get_or_create_active
 
 from discord.client import DiscordClient
 from eveonline.client import EsiClient, esi_for
@@ -86,49 +87,37 @@ def update_corporation_structures(corporation_id: int):
             corporation = EveCorporation.objects.get(
                 corporation_id=structure["corporation_id"]
             )
-            if EveStructure.objects.filter(
-                id=structure["structure_id"]
-            ).exists():
+            services = structure.get("services")
+            structure_defaults = {
+                "system_id": structure["system_id"],
+                "system_name": system.name,
+                "type_id": structure["type_id"],
+                "type_name": structure_type.name,
+                "name": structure["name"],
+                "reinforce_hour": structure["reinforce_hour"],
+                "state": structure["state"],
+                "state_timer_start": structure.get("state_timer_start"),
+                "state_timer_end": structure.get("state_timer_end"),
+                "fuel_expires": structure.get("fuel_expires"),
+                "fitting": (
+                    json.dumps(services, indent=2) if services else None
+                ),
+                "corporation": corporation,
+            }
+            eve_structure, created = get_or_create_active(
+                EveStructure,
+                id=structure["structure_id"],
+                defaults=structure_defaults,
+            )
+            if created:
+                logger.debug("Creating new structure %s", structure["name"])
+            else:
                 logger.debug(
                     "Updating existing structure %s", structure["name"]
                 )
-                eve_structure = EveStructure.objects.get(
-                    id=structure["structure_id"]
-                )
-                eve_structure.state = structure["state"]
-                eve_structure.state_timer_start = structure.get(
-                    "state_timer_start"
-                )
-                eve_structure.state_timer_end = structure.get(
-                    "state_timer_end"
-                )
-                eve_structure.fuel_expires = structure.get("fuel_expires")
-                eve_structure.name = structure["name"]
-                services = structure.get("services")
-                eve_structure.fitting = (
-                    json.dumps(services, indent=2) if services else None
-                )
+                for key, value in structure_defaults.items():
+                    setattr(eve_structure, key, value)
                 eve_structure.save()
-            else:
-                logger.debug("Creating new structure %s", structure["name"])
-                services = structure.get("services")
-                eve_structure = EveStructure.objects.create(
-                    id=structure["structure_id"],
-                    system_id=structure["system_id"],
-                    system_name=system.name,
-                    type_id=structure["type_id"],
-                    type_name=structure_type.name,
-                    name=structure["name"],
-                    reinforce_hour=structure["reinforce_hour"],
-                    state=structure["state"],
-                    state_timer_start=structure.get("state_timer_start"),
-                    state_timer_end=structure.get("state_timer_end"),
-                    fuel_expires=structure.get("fuel_expires"),
-                    fitting=(
-                        json.dumps(services, indent=2) if services else None
-                    ),
-                    corporation=corporation,
-                )
 
             known_structure_ids.append(eve_structure.id)
 

--- a/backend/structures/tests/test_tasks.py
+++ b/backend/structures/tests/test_tasks.py
@@ -156,7 +156,12 @@ class StructureTaskTests(TestCase):
                 }
             ],
         )
-        esi.get_solar_system.return_value = MagicMock(name="Home")
+        system_mock = MagicMock()
+        system_mock.name = "Home"
+        esi.get_solar_system.return_value = system_mock
+        type_mock = MagicMock()
+        type_mock.name = "Astrahus"
+        esi.get_eve_type.return_value = type_mock
 
         EveStructure.objects.create(
             id=100001,
@@ -167,3 +172,71 @@ class StructureTaskTests(TestCase):
         )
 
         update_corporation_structures(corp.corporation_id)
+
+    @factory.django.mute_signals(signals.pre_save, signals.post_save)
+    @patch("eveonline.utils.get_esi_downtime_countdown", return_value=0)
+    @patch("structures.tasks.esi_for")
+    @patch("structures.tasks.get_director_with_scope")
+    def test_update_corporation_structures_restores_soft_deleted(
+        self, get_director_mock, esi_mock, get_downtime_mock
+    ):
+        """A soft-deleted structure reappearing in ESI is restored, not
+        re-created (which would previously raise an IntegrityError)."""
+        ceo = EveCharacter.objects.create(
+            character_id=1002,
+            character_name="Mr CEO 2",
+            esi_token_level="ceo",
+        )
+        corp = EveCorporation.objects.create(
+            corporation_id=2002,
+            name="MegaCorp2",
+            ceo=ceo,
+        )
+        get_director_mock.return_value = ceo
+
+        structure = EveStructure.objects.create(
+            id=100002,
+            corporation=corp,
+            system_id=100002,
+            system_name="Old System",
+            type_id=100002,
+            type_name="Old Type",
+            name="Old Name",
+            reinforce_hour=10,
+        )
+        structure.delete()
+        self.assertIsNotNone(EveStructure.all_objects.get(id=100002).deleted)
+
+        esi = esi_mock.return_value
+        esi.get_corp_structures.return_value = EsiResponse(
+            response_code=200,
+            data=[
+                {
+                    "structure_id": 100002,
+                    "corporation_id": corp.corporation_id,
+                    "name": "MegaStructure",
+                    "system_id": 100002,
+                    "type_id": 100002,
+                    "reinforce_hour": 12,
+                    "state": "shield_vulnerable",
+                    "state_timer_start": None,
+                    "state_timer_end": None,
+                    "fuel_expires": None,
+                }
+            ],
+        )
+        system_mock = MagicMock()
+        system_mock.name = "Home System"
+        esi.get_solar_system.return_value = system_mock
+        type_mock = MagicMock()
+        type_mock.name = "Astrahus"
+        esi.get_eve_type.return_value = type_mock
+
+        update_corporation_structures(corp.corporation_id)
+
+        restored = EveStructure.objects.get(id=100002)
+        self.assertIsNone(restored.deleted)
+        self.assertEqual("MegaStructure", restored.name)
+        self.assertEqual("shield_vulnerable", restored.state)
+        self.assertEqual("Home System", restored.system_name)
+        self.assertEqual("Astrahus", restored.type_name)


### PR DESCRIPTION
## Summary
- Stop feed-cluster `DatabaseError` and structure soft-delete `IntegrityError` storms with bulk updates and `get_or_create_active`
- Harden null `fleet.audience`, Discord unknown-member offboarding, ESI expected-failure logging, and django-esi SSO `session_key` logging
- Cut ops-monitor snapshot cost: one `build_ops_monitor()` pass plus SQL inferred-sales aggregates (addresses CELERY-JC / REST-API-MF)

Addresses triage from [Sentry audit](https://minmatar-fleet.sentry.io/issues/?query=is%3Aunresolved): CELERY-JF/JG, CELERY-HS, REST-API-A2, Discord 404 storms, ESI 906 noise, ops-monitor slow queries.

## Test plan
- [x] `pipenv run python manage.py test feed.tests.test_clusters structures.tests.test_tasks discord.tests eveonline.tests.test_esi_view_patches market.tests.test_ops_monitor_snapshots --settings=app.settings_test`
- [x] Full backend suite green in worktree (1132 tests)
- [ ] After deploy: confirm CELERY-JF / CELERY-HS event rate drops
- [ ] After deploy: resolve already-fixed Sentry groups (HV/HW/J5/M6/M1/M2 GET) and stale ESI 906 / Discord 404 noise


Made with [Cursor](https://cursor.com)