### PR TITLE
Keep opposing militia fleets as separate feed sightings

### DIFF
--- a/backend/feed/helpers/clusters.py
+++ b/backend/feed/helpers/clusters.py
@@ -7,7 +7,11 @@ from typing import Any
 from django.db.models import F
 from django.utils import timezone
 
-from feed.helpers.killmail_classify import dominant_attacker_faction
+from feed.constants import MILITIA_FACTION_IDS
+from feed.helpers.killmail_classify import (
+    dominant_attacker_faction,
+    resolve_attacker_militia_factions,
+)
 from feed.models import FeedCluster, FeedKillmail
 from feed.rollups.config import get_rollup_config
 
@@ -128,11 +132,17 @@ def _find_active_fleet_cluster(
 
 
 def _merge_fleet_cluster(
-    existing: FeedCluster, killmail_ids: list[int]
+    existing: FeedCluster,
+    killmail_ids: list[int],
+    *,
+    faction_id: int | None = None,
 ) -> FeedCluster:
     merged_ids = sorted(set(existing.killmail_ids or []) | set(killmail_ids))
     killmails = list(FeedKillmail.objects.filter(killmail_id__in=merged_ids))
-    stats = build_cluster_stats(killmails)
+    scope = (
+        faction_id if faction_id is not None else existing.dominant_faction_id
+    )
+    stats = build_cluster_stats(killmails, faction_id=scope)
     existing.dominant_faction_id = stats["dominant_faction_id"]
     existing.started_at = stats["started_at"]
     existing.last_kill_at = stats["last_kill_at"]
@@ -167,41 +177,170 @@ def _cluster_defaults(
     }
 
 
-def build_cluster_stats(killmails: list[FeedKillmail]) -> dict[str, Any]:
+def _attacker_faction_id(
+    attacker: dict[str, Any],
+    char_factions: dict[int, int],
+) -> int | None:
+    char_id = attacker.get("character_id")
+    if not char_id:
+        return None
+    resolved = char_factions.get(char_id)
+    if resolved in MILITIA_FACTION_IDS:
+        return resolved
+    tagged = attacker.get("faction_id")
+    if tagged in MILITIA_FACTION_IDS:
+        return tagged
+    return None
+
+
+def build_cluster_stats(
+    killmails: list[FeedKillmail],
+    *,
+    faction_id: int | None = None,
+) -> dict[str, Any]:
+    """Aggregate killmails into cluster stats.
+
+    When ``faction_id`` is set, only that militia's attackers and the killmails
+    they appear on are counted. This keeps opposing fleets on the same grid as
+    separate engagements instead of one mixed blob.
+    """
+    if not killmails:
+        return {
+            "dominant_faction_id": faction_id,
+            "started_at": None,
+            "last_kill_at": None,
+            "kill_count": 0,
+            "pilot_count": 0,
+            "ship_counts": {},
+            "attacker_ids": [],
+            "killmail_ids": [],
+        }
+
+    raw_kms = [km.raw_killmail for km in killmails]
+    char_factions = (
+        resolve_attacker_militia_factions(raw_kms)
+        if faction_id is not None
+        else {}
+    )
+
     attacker_ids: set[int] = set()
     ship_counts: Counter[str] = Counter()
     killmail_ids: list[int] = []
-    raw_kms: list[dict] = []
+    scoped_kms: list[FeedKillmail] = []
 
     for km in killmails:
-        killmail_ids.append(km.killmail_id)
-        raw_kms.append(km.raw_killmail)
-        ship_type = km.victim_ship_type_id
-        if ship_type:
-            ship_counts[str(ship_type)] += 1
+        faction_on_mail = False
         for attacker in km.attacker_summary or []:
             char_id = attacker.get("character_id")
-            if char_id:
+            if not char_id:
+                continue
+            if faction_id is None:
                 attacker_ids.add(char_id)
+                continue
+            if _attacker_faction_id(attacker, char_factions) == faction_id:
+                attacker_ids.add(char_id)
+                faction_on_mail = True
+        if faction_id is None or faction_on_mail:
+            scoped_kms.append(km)
+            killmail_ids.append(km.killmail_id)
+            ship_type = km.victim_ship_type_id
+            if ship_type:
+                ship_counts[str(ship_type)] += 1
 
-    fleet_cfg = get_rollup_config("fleet_active")
-    dominant = dominant_attacker_faction(
-        raw_kms,
-        threshold=fleet_cfg.get("dominant_faction_threshold", 0.75),
-    )
-    started_at = min(km.killmail_time for km in killmails)
-    last_kill_at = max(km.killmail_time for km in killmails)
+    if faction_id is None:
+        fleet_cfg = get_rollup_config("fleet_active")
+        dominant = dominant_attacker_faction(
+            raw_kms,
+            threshold=fleet_cfg.get("dominant_faction_threshold", 0.75),
+        )
+    else:
+        dominant = faction_id
+
+    if not scoped_kms:
+        return {
+            "dominant_faction_id": dominant,
+            "started_at": min(km.killmail_time for km in killmails),
+            "last_kill_at": max(km.killmail_time for km in killmails),
+            "kill_count": 0,
+            "pilot_count": 0,
+            "ship_counts": {},
+            "attacker_ids": [],
+            "killmail_ids": [],
+        }
 
     return {
         "dominant_faction_id": dominant,
-        "started_at": started_at,
-        "last_kill_at": last_kill_at,
-        "kill_count": len(killmails),
+        "started_at": min(km.killmail_time for km in scoped_kms),
+        "last_kill_at": max(km.killmail_time for km in scoped_kms),
+        "kill_count": len(scoped_kms),
         "pilot_count": len(attacker_ids),
         "ship_counts": dict(ship_counts),
         "attacker_ids": sorted(attacker_ids),
         "killmail_ids": killmail_ids,
     }
+
+
+def _militia_factions_in_window(
+    killmails: list[FeedKillmail],
+) -> dict[int, set[int]]:
+    """Map militia faction_id -> attacker character ids in the window."""
+    raw_kms = [km.raw_killmail for km in killmails]
+    char_factions = resolve_attacker_militia_factions(raw_kms)
+    faction_pilots: dict[int, set[int]] = defaultdict(set)
+    for char_id, resolved in char_factions.items():
+        if resolved in MILITIA_FACTION_IDS:
+            faction_pilots[resolved].add(char_id)
+    return faction_pilots
+
+
+def _upsert_one_fleet_cluster(
+    solar_system_id: int,
+    stats: dict[str, Any],
+    window_start,
+    *,
+    stale_minutes: int,
+    max_duration: timedelta,
+) -> int:
+    """Merge into an active same-faction cluster or create a new one."""
+    if stats["kill_count"] <= 0 or stats["started_at"] is None:
+        return 0
+
+    existing = _find_active_fleet_cluster(
+        solar_system_id,
+        stats["dominant_faction_id"],
+        window_start,
+        stale_minutes=stale_minutes,
+    )
+    if existing is not None:
+        if stats["last_kill_at"] - existing.started_at > max_duration:
+            FeedCluster.objects.filter(pk=existing.pk).update(
+                is_active=False,
+                ended_at=F("last_kill_at"),
+                updated_at=timezone.now(),
+            )
+        else:
+            _merge_fleet_cluster(
+                existing,
+                stats["killmail_ids"],
+                faction_id=stats["dominant_faction_id"],
+            )
+            return 1
+
+    key = _cluster_key(
+        FeedCluster.ClusterType.FLEET_ENGAGEMENT,
+        solar_system_id,
+        stats["dominant_faction_id"],
+        stats["started_at"],
+    )
+    FeedCluster.objects.update_or_create(
+        cluster_key=key,
+        defaults=_cluster_defaults(
+            FeedCluster.ClusterType.FLEET_ENGAGEMENT,
+            solar_system_id,
+            stats,
+        ),
+    )
+    return 1
 
 
 def detect_clusters(*, since_hours: int = 48) -> int:
@@ -297,52 +436,28 @@ def _sliding_window_clusters(
             j += 1
 
         if len(window_kills) >= min_kills:
-            stats = build_cluster_stats(window_kills)
-            if stats["pilot_count"] >= min_pilots:
-                if cluster_type == FeedCluster.ClusterType.FLEET_ENGAGEMENT:
-                    fleet_cfg = get_rollup_config("fleet_active")
-                    stale_minutes = fleet_cfg.get("stale_minutes", 20)
-                    max_duration = timedelta(
-                        minutes=fleet_cfg.get("max_duration_minutes", 90)
-                    )
-                    existing = _find_active_fleet_cluster(
-                        solar_system_id,
-                        stats["dominant_faction_id"],
-                        window_start,
-                        stale_minutes=stale_minutes,
-                    )
-                    if existing is not None:
-                        if (
-                            stats["last_kill_at"] - existing.started_at
-                            > max_duration
-                        ):
-                            # Fight has run long enough; close it and start a
-                            # fresh engagement even though kills continue.
-                            FeedCluster.objects.filter(pk=existing.pk).update(
-                                is_active=False,
-                                ended_at=F("last_kill_at"),
-                                updated_at=timezone.now(),
-                            )
-                        else:
-                            _merge_fleet_cluster(
-                                existing, stats["killmail_ids"]
-                            )
-                            upserted += 1
-                            i = j
-                            continue
-                    key = _cluster_key(
-                        cluster_type,
-                        solar_system_id,
-                        stats["dominant_faction_id"],
-                        stats["started_at"],
-                    )
-                    FeedCluster.objects.update_or_create(
-                        cluster_key=key,
-                        defaults=_cluster_defaults(
-                            cluster_type, solar_system_id, stats
-                        ),
-                    )
-                else:
+            if cluster_type == FeedCluster.ClusterType.FLEET_ENGAGEMENT:
+                fleet_cfg = get_rollup_config("fleet_active")
+                stale_minutes = fleet_cfg.get("stale_minutes", 20)
+                max_duration = timedelta(
+                    minutes=fleet_cfg.get("max_duration_minutes", 90)
+                )
+                created = _upsert_fleet_engagement_window(
+                    solar_system_id,
+                    window_kills,
+                    window_start,
+                    min_kills=min_kills,
+                    min_pilots=min_pilots,
+                    stale_minutes=stale_minutes,
+                    max_duration=max_duration,
+                )
+                if created:
+                    upserted += created
+                    i = j
+                    continue
+            else:
+                stats = build_cluster_stats(window_kills)
+                if stats["pilot_count"] >= min_pilots:
                     started_bucket = _window_start(
                         window_start, window_minutes
                     )
@@ -351,11 +466,66 @@ def _sliding_window_clusters(
                         started_bucket,
                         stats,
                     )
-                upserted += 1
-                i = j
-                continue
+                    upserted += 1
+                    i = j
+                    continue
         i += 1
     return upserted
+
+
+def _upsert_fleet_engagement_window(
+    solar_system_id: int,
+    window_kills: list[FeedKillmail],
+    window_start,
+    *,
+    min_kills: int,
+    min_pilots: int,
+    stale_minutes: int,
+    max_duration: timedelta,
+) -> int:
+    """Emit one fleet cluster per militia faction with enough attackers.
+
+    Opposing fleets on the same grid (e.g. Amarr Cerbs vs Minmatar) become
+    separate engagements instead of a single mixed pilot blob.
+    """
+    faction_pilots = _militia_factions_in_window(window_kills)
+    factions = [
+        faction_id
+        for faction_id, pilots in faction_pilots.items()
+        if len(pilots) >= min_pilots
+    ]
+
+    if not factions:
+        stats = build_cluster_stats(window_kills)
+        if (
+            stats["pilot_count"] >= min_pilots
+            and stats["kill_count"] >= min_kills
+        ):
+            return _upsert_one_fleet_cluster(
+                solar_system_id,
+                stats,
+                window_start,
+                stale_minutes=stale_minutes,
+                max_duration=max_duration,
+            )
+        return 0
+
+    created = 0
+    for faction_id in sorted(factions):
+        stats = build_cluster_stats(window_kills, faction_id=faction_id)
+        if (
+            stats["pilot_count"] < min_pilots
+            or stats["kill_count"] < min_kills
+        ):
+            continue
+        created += _upsert_one_fleet_cluster(
+            solar_system_id,
+            stats,
+            window_start,
+            stale_minutes=stale_minutes,
+            max_duration=max_duration,
+        )
+    return created
 
 
 def _mark_stale_fleet_clusters(stale_minutes: int) -> None:

--- a/backend/feed/helpers/eve_names.py
+++ b/backend/feed/helpers/eve_names.py
@@ -288,11 +288,9 @@ def sample_fleet_roster(
     limit: int = 8,
 ) -> tuple[list[dict[str, int | str]], int]:
     ids = list(attacker_ids or [])
-    total = len(ids)
     if not ids:
         return [], 0
 
-    sample: list[int] = []
     if faction_id:
         enlisted = set(
             FeedCharacterAffiliation.objects.filter(
@@ -300,19 +298,18 @@ def sample_fleet_roster(
                 faction_id=faction_id,
             ).values_list("character_id", flat=True)
         )
-        for character_id in ids:
-            if character_id in enlisted:
-                sample.append(character_id)
-            if len(sample) >= limit:
-                break
-
-    if len(sample) < limit:
-        seen = set(sample)
-        for character_id in ids:
-            if character_id not in seen:
-                sample.append(character_id)
-            if len(sample) >= limit:
-                break
+        # Prefer affiliation-confirmed pilots; otherwise trust caller-scoped ids.
+        # Never pad with opposing-faction characters.
+        scoped = (
+            [character_id for character_id in ids if character_id in enlisted]
+            if enlisted
+            else ids
+        )
+        total = len(scoped)
+        sample = scoped[:limit]
+    else:
+        total = len(ids)
+        sample = ids[:limit]
 
     names = resolve_character_names(sample)
     roster = [

--- a/backend/feed/rollups/fleet_active.py
+++ b/backend/feed/rollups/fleet_active.py
@@ -37,15 +37,28 @@ def _accent_for_faction(faction_id: int | None) -> str:
 
 
 def _dominant_faction_for_cluster(cluster: FeedCluster) -> int | None:
+    """Return the militia faction for a fleet cluster.
+
+    When the cluster was stored as Amarr/Minmatar (faction-scoped detection),
+    re-validate against that faction's attackers on the linked killmails so a
+    mixed grid cannot flip labels — while still dropping stale wrong labels
+    (e.g. Minmatar stamped on Caldari-heavy mails).
+    """
     killmail_ids = cluster.killmail_ids or []
     if not killmail_ids:
         return None
-    raw = list(
-        FeedKillmail.objects.filter(killmail_id__in=killmail_ids).values_list(
-            "raw_killmail", flat=True
-        )
-    )
+
+    killmails = list(FeedKillmail.objects.filter(killmail_id__in=killmail_ids))
+    raw = [km.raw_killmail for km in killmails]
     fleet_cfg = get_rollup_config("fleet_active")
+    stored = cluster.dominant_faction_id
+
+    if stored in (FACTION_AMARR, FACTION_MINMATAR):
+        stats = build_cluster_stats(killmails, faction_id=stored)
+        if stats["pilot_count"] > 5:
+            return stored
+        return None
+
     return dominant_attacker_faction(
         raw,
         threshold=fleet_cfg.get("dominant_faction_threshold", 0.75),
@@ -112,7 +125,9 @@ def _persist_fleet_chain(
         killmails = list(
             FeedKillmail.objects.filter(killmail_id__in=merged_ids)
         )
-        stats = build_cluster_stats(killmails)
+        stats = build_cluster_stats(
+            killmails, faction_id=canonical.dominant_faction_id
+        )
         tip = max(
             (cluster for cluster, _ in ordered),
             key=lambda cluster: cluster.last_kill_at,

--- a/backend/feed/tests/helpers.py
+++ b/backend/feed/tests/helpers.py
@@ -12,6 +12,8 @@ def make_killmail_payload(
     victim_faction_id: int | None = None,
     attacker_count: int = 8,
     attacker_id_base: int = 90000000,
+    corporation_id: int = 98000000,
+    alliance_id: int = 99000000,
     ship_type_id: int = 22468,
     attacker_ship_type_id: int = 22468,
 ) -> dict:
@@ -23,8 +25,8 @@ def make_killmail_payload(
     for i in range(attacker_count):
         attacker: dict = {
             "character_id": attacker_id_base + i,
-            "corporation_id": 98000000 + (0 if faction_id == 500002 else 1),
-            "alliance_id": 99000000 + (0 if faction_id == 500002 else 1),
+            "corporation_id": corporation_id,
+            "alliance_id": alliance_id,
             "ship_type_id": attacker_ship_type_id,
             "damage_done": 1000,
             "final_blow": i == 0,

--- a/backend/feed/tests/helpers.py
+++ b/backend/feed/tests/helpers.py
@@ -11,6 +11,7 @@ def make_killmail_payload(
     faction_id: int | None = 500002,
     victim_faction_id: int | None = None,
     attacker_count: int = 8,
+    attacker_id_base: int = 90000000,
     ship_type_id: int = 22468,
     attacker_ship_type_id: int = 22468,
 ) -> dict:
@@ -21,9 +22,9 @@ def make_killmail_payload(
     attackers = []
     for i in range(attacker_count):
         attacker: dict = {
-            "character_id": 90000000 + i,
-            "corporation_id": 98000000,
-            "alliance_id": 99000000,
+            "character_id": attacker_id_base + i,
+            "corporation_id": 98000000 + (0 if faction_id == 500002 else 1),
+            "alliance_id": 99000000 + (0 if faction_id == 500002 else 1),
             "ship_type_id": attacker_ship_type_id,
             "damage_done": 1000,
             "final_blow": i == 0,

--- a/backend/feed/tests/test_clusters.py
+++ b/backend/feed/tests/test_clusters.py
@@ -5,8 +5,10 @@ from datetime import timedelta
 from django.test import TestCase
 from django.utils import timezone
 
+from feed.constants import FACTION_AMARR, FACTION_MINMATAR
 from feed.helpers.clusters import _mark_stale_fleet_clusters, detect_clusters
 from feed.helpers.ingest import upsert_feed_killmail_from_r2z2
+from feed.helpers.monitored_systems import invalidate_monitored_systems_cache
 from feed.management.commands.seed_feed_monitored_systems import (
     seed_from_fixture,
 )
@@ -213,3 +215,77 @@ class ClusterRollupTestCase(TestCase):
         self.assertEqual(stale_cluster.ended_at, stale_cluster.last_kill_at)
         self.assertTrue(fresh_cluster.is_active)
         self.assertIsNone(fresh_cluster.ended_at)
+
+    def test_opposing_militia_fleets_produce_separate_clusters(self):
+        """Auga-style mixed grid: Amarr and Minmatar each get their own fleet.
+
+        Reproduces Militia Monday failure mode where ~equal attacker counts on
+        both sides collapsed into one Minmatar-labeled blob.
+        """
+        seed_from_fixture()
+        invalidate_monitored_systems_cache()
+        FeedKillmail.objects.all().delete()
+        FeedCluster.objects.all().delete()
+
+        base = timezone.now() - timedelta(minutes=25)
+        # Amarr wipe Minmatar (Cerb-style): many Amarr attackers on Min victims.
+        for i in range(8):
+            upsert_feed_killmail_from_r2z2(
+                make_killmail_payload(
+                    500000 + i,
+                    killmail_time=base + timedelta(minutes=i),
+                    faction_id=FACTION_AMARR,
+                    victim_faction_id=FACTION_MINMATAR,
+                    attacker_count=12,
+                    attacker_id_base=91000000,
+                    attacker_ship_type_id=11993,
+                )
+            )
+        # Minmatar also get kills on Amarr in the same window.
+        for i in range(6):
+            upsert_feed_killmail_from_r2z2(
+                make_killmail_payload(
+                    500100 + i,
+                    killmail_time=base + timedelta(minutes=i, seconds=30),
+                    faction_id=FACTION_MINMATAR,
+                    victim_faction_id=FACTION_AMARR,
+                    attacker_count=10,
+                    attacker_id_base=92000000,
+                )
+            )
+
+        detect_clusters(since_hours=2)
+
+        amarr = FeedCluster.objects.filter(
+            cluster_type=FeedCluster.ClusterType.FLEET_ENGAGEMENT,
+            dominant_faction_id=FACTION_AMARR,
+        )
+        minmatar = FeedCluster.objects.filter(
+            cluster_type=FeedCluster.ClusterType.FLEET_ENGAGEMENT,
+            dominant_faction_id=FACTION_MINMATAR,
+        )
+        self.assertEqual(amarr.count(), 1)
+        self.assertEqual(minmatar.count(), 1)
+
+        amarr_cluster = amarr.get()
+        minmatar_cluster = minmatar.get()
+        self.assertGreaterEqual(amarr_cluster.pilot_count, 8)
+        self.assertGreaterEqual(minmatar_cluster.pilot_count, 8)
+        # Pilot sets must not mix opposing militia attackers.
+        self.assertTrue(
+            set(amarr_cluster.attacker_ids).isdisjoint(
+                set(minmatar_cluster.attacker_ids)
+            )
+        )
+        self.assertTrue(
+            all(
+                91000000 <= cid < 92000000
+                for cid in amarr_cluster.attacker_ids
+            )
+        )
+        self.assertTrue(
+            all(cid >= 92000000 for cid in minmatar_cluster.attacker_ids)
+        )
+        # Neither side should absorb the other's full pilot count.
+        self.assertLess(amarr_cluster.pilot_count, 22)
+        self.assertLess(minmatar_cluster.pilot_count, 22)

--- a/backend/feed/tests/test_eve_names.py
+++ b/backend/feed/tests/test_eve_names.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 from django.test import TestCase
 from eveuniverse.models import EveCategory, EveGroup, EveType
 
+from feed.constants import FACTION_AMARR, FACTION_MINMATAR
 from feed.helpers.eve_names import (
     detect_formation_type,
+    sample_fleet_roster,
     top_hull_classes_from_counts,
     top_ships_from_counts,
     without_capsule_ship_counts,
 )
+from feed.models import FeedCharacterAffiliation
 
 
 class EveNamesTestCase(TestCase):
@@ -80,3 +83,29 @@ class EveNamesTestCase(TestCase):
     def test_detect_formation_type_gang_without_counts(self):
         self.assertEqual(detect_formation_type(None), "gang")
         self.assertEqual(detect_formation_type({}), "gang")
+
+    def test_sample_fleet_roster_does_not_pad_with_other_faction(self):
+        FeedCharacterAffiliation.objects.create(
+            character_id=101,
+            faction_id=FACTION_AMARR,
+            corporation_id=1,
+        )
+        FeedCharacterAffiliation.objects.create(
+            character_id=201,
+            faction_id=FACTION_MINMATAR,
+            corporation_id=2,
+        )
+        FeedCharacterAffiliation.objects.create(
+            character_id=202,
+            faction_id=FACTION_MINMATAR,
+            corporation_id=2,
+        )
+
+        roster, total = sample_fleet_roster(
+            [101, 201, 202, 203],
+            faction_id=FACTION_AMARR,
+            limit=8,
+        )
+
+        self.assertEqual(total, 1)
+        self.assertEqual([row["character_id"] for row in roster], [101])

--- a/backend/feed/tests/test_fleet_active_rollup.py
+++ b/backend/feed/tests/test_fleet_active_rollup.py
@@ -5,7 +5,8 @@ from datetime import timedelta
 from django.test import TestCase
 from django.utils import timezone
 
-from feed.constants import FACTION_CALDARI, FACTION_MINMATAR
+from feed.constants import FACTION_AMARR, FACTION_CALDARI, FACTION_MINMATAR
+from feed.helpers.clusters import detect_clusters
 from feed.helpers.ingest import upsert_feed_killmail_from_r2z2
 from feed.helpers.monitored_systems import (
     invalidate_monitored_systems_cache,
@@ -13,7 +14,7 @@ from feed.helpers.monitored_systems import (
 from feed.management.commands.seed_feed_monitored_systems import (
     seed_from_fixture,
 )
-from feed.models import FeedCluster, FeedEvent
+from feed.models import FeedCluster, FeedEvent, FeedKillmail
 from feed.rollups.fleet_active import (
     _collapse_fleet_clusters,
     run_fleet_active_rollup,
@@ -305,3 +306,54 @@ class FleetActiveRollupTestCase(TestCase):
             FeedEvent.objects.filter(kind=FeedEvent.Kind.FLEET_ACTIVE).count(),
             2,
         )
+
+    def test_opposing_fleets_rollup_to_separate_faction_events(self):
+        """Mixed Auga-style fight must emit Amarr and Minmatar fleet_active."""
+        seed_from_fixture()
+        invalidate_monitored_systems_cache()
+        FeedKillmail.objects.all().delete()
+        FeedCluster.objects.all().delete()
+        FeedEvent.objects.all().delete()
+
+        base = timezone.now() - timedelta(minutes=20)
+        for i in range(8):
+            upsert_feed_killmail_from_r2z2(
+                make_killmail_payload(
+                    710000 + i,
+                    killmail_time=base + timedelta(minutes=i),
+                    faction_id=FACTION_AMARR,
+                    victim_faction_id=FACTION_MINMATAR,
+                    attacker_count=12,
+                    attacker_id_base=93000000,
+                )
+            )
+        for i in range(7):
+            upsert_feed_killmail_from_r2z2(
+                make_killmail_payload(
+                    710100 + i,
+                    killmail_time=base + timedelta(minutes=i, seconds=20),
+                    faction_id=FACTION_MINMATAR,
+                    victim_faction_id=FACTION_AMARR,
+                    attacker_count=11,
+                    attacker_id_base=94000000,
+                )
+            )
+
+        detect_clusters(since_hours=2)
+        now = timezone.now()
+        ctx = build_context(now - timedelta(hours=1), now + timedelta(hours=1))
+        write_rollup_results(run_fleet_active_rollup(ctx))
+
+        events = list(
+            FeedEvent.objects.filter(kind=FeedEvent.Kind.FLEET_ACTIVE)
+        )
+        factions = sorted(
+            (event.payload or {}).get("faction") for event in events
+        )
+        self.assertEqual(factions, ["amarr", "minmatar"])
+        for event in events:
+            payload = event.payload or {}
+            self.assertNotEqual(payload.get("faction"), None)
+            # Roster total is faction-scoped, not the mixed attacker blob.
+            self.assertLessEqual(payload.get("roster_total") or 0, 15)
+            self.assertLessEqual(payload.get("pilots") or 0, 15)


### PR DESCRIPTION
## Summary
- Faction-scope fleet engagement detection so Amarr and Minmatar on the same grid each get their own `fleet_active` cluster/event (fixes Militia Monday / Auga Cerb wipe being swallowed into one Minmatar blob).
- Pilot counts and killmail sets are filtered to that militia’s attackers; roster sampling no longer pads with the opposing faction.
- Rollup keeps stored militia labels when still supported by killmails, while still dropping stale wrong labels.

## Test plan
- [x] `pipenv run python manage.py test feed.tests.test_clusters feed.tests.test_fleet_active_rollup feed.tests.test_eve_names --settings=app.settings_test`
- [x] New Auga-style dual-fleet cluster test (separate Amarr + Minmatar clusters, disjoint attacker sets)
- [x] New dual-fleet rollup test (emits both `amarr` and `minmatar` events with faction-scoped pilot counts)
- [x] Roster padding regression test
- [ ] After deploy: rebuild recent feed clusters/rollups and confirm Militia Monday Auga shows a distinct Amarr fleet, not only Minmatar


Made with [Cursor](https://cursor.com)