### PR TITLE
Update SRP onboarding copy

### DIFF
--- a/frontend/app/src/markdown/srp-overview.md
+++ b/frontend/app/src/markdown/srp-overview.md
@@ -1,10 +1,8 @@
-Minmatar Fleet Alliance is against broad ship replacement programs. 
+Minmatar Fleet Alliance is against wide angle ship replacement programs. 
 
-They involve large structure empires, taxing corporations on their hard earned work, and unrealistic expectations for fleet commanders and leadership that cause burnout.
-
-*   **No alliance tax** – We don’t take from our corporations or tribes. Their taxes are theirs, their structure taxes are theirs, and their moon drills are theirs. We help them grow high-yield income strategies and let them decide how to support their members. Local autonomy, not top-down control.
+*   **No alliance tax** – We don’t take from our corporations or tribes. Their taxes are theirs, their structure taxes are theirs, and their moon drills are theirs.
     
-*   **No endless drill / rental defense** – We're not interested in burning out members defending or repairing Metenox drills and babysitting skyhooks for a few billion ISK a month per structure. We'd rather have folks run battlefields and combat sites and fill their wallet. It's a better, more sustainable long term strategy.
+*   **No structure empire** – We're not interested in burning out members defending or repairing Metenox drills and babysitting skyhooks for a few billion ISK a month per structure.
 
 *   **Self sufficient players** – We want to teach our players to be self sufficient, not rely on the tit of our alliance to undock spaceships. 
 

--- a/frontend/app/src/markdown/srp-source.md
+++ b/frontend/app/src/markdown/srp-source.md
@@ -2,10 +2,8 @@ The alliance does generate income, and has a desire to allocate this income to i
 
 These sources of income are,
 
-*   Purchases of PLEX using **coupon code "MINMATAR"** on Markeedragon
+*   Purchases of PLEX and Omega subscription using **coupon code "MINMATAR"** on [Markeedragon](https://store.markeedragon.com/affiliate.php?id=992)
     
-*   Loot from strategic fleets (contract to **Minmatar Fleet Holdings**)
-    
-*   Temporary holdings (moons), service income (structures), and one-off mercenary contracts
+*   Temporary holdings from deployments (moons, structures, mercenary contracts)
     
 These aren't consistent, babysitted income sources. If they go away, they go away- along with certain programs that they support.


### PR DESCRIPTION
## Summary
- Shorten SRP philosophy copy (wide-angle framing, no structure empire, fewer explanatory sentences)
- Refresh funding-source bullets: PLEX/Omega with Markeedragon affiliate link; drop strategic-fleet loot; clarify temporary deployment holdings

## Test plan
- [ ] Open `/ships/srp/onboarding` and confirm overview + funding sections match the new copy
- [ ] Confirm Markeedragon link opens `https://store.markeedragon.com/affiliate.php?id=992`


Made with [Cursor](https://cursor.com)