### PR TITLE
Fix Discord role sync Sentry failures and ESI 906 noise

### DIFF
--- a/backend/discord/helpers.py
+++ b/backend/discord/helpers.py
@@ -111,8 +111,10 @@ def get_expected_nickname(user: User):
 
 def get_discord_user(user: User, notify=False):
     """
-    Fetches a user based on their discord user
-    If they don't exist, notifies people team if notify=True
+    Fetches a user based on their discord user.
+
+    If Discord returns Unknown Member (10007), the site account is offboarded.
+    When notify=True, posts an offboard notice to the people-team channel.
     """
     external_discord_user = None
     if not DiscordUser.objects.filter(user_id=user.id).exists():
@@ -134,10 +136,15 @@ def get_discord_user(user: User, notify=False):
                     )
                 ]
             )
+            username = user.username
             offboard_user(user.id)
 
-            message = f":white_check_mark: {user.username} ({characters}) was promoted to Ushra'Khant"
-            discord.create_message(DISCORD_PEOPLE_TEAM_CHANNEL_ID, message)
+            if notify:
+                message = (
+                    f":wave: {username} ({characters}) was offboarded "
+                    "(not a member of the Discord server)"
+                )
+                discord.create_message(DISCORD_PEOPLE_TEAM_CHANNEL_ID, message)
             return None
 
     return external_discord_user

--- a/backend/discord/signals.py
+++ b/backend/discord/signals.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.contrib.auth.models import Group, User
+from django.db import IntegrityError
 from django.db.models import signals
 from django.dispatch import receiver
 
@@ -24,24 +25,75 @@ discord = DiscordClient()
 def resolve_existing_discord_role_from_server(
     sender, instance, *args, **kwargs
 ):
-    existing_role = False
-    if not instance.role_id:  # skip when importing a role
-        roles = discord.get_roles()
-        for role in roles:
-            if role["name"] == instance.name:
-                logger.info("Found existing role with name %s", instance.name)
-                instance.role_id = role["id"]
-                existing_role = True
-                break
+    if instance.role_id:
+        # Already linked to a Discord role (create or later updates).
+        return
 
-    if not existing_role:
-        logger.info(
-            "No role_id, creating role based on group name %s",
-            instance.group.name,
-        )
-        role = discord.create_role(instance.group.name)
-        logger.info("External role created: %s", role.json())
-        instance.role_id = role.json()["id"]
+    roles = discord.get_roles()
+    for role in roles:
+        if role["name"] == instance.name:
+            logger.info("Found existing role with name %s", instance.name)
+            instance.role_id = role["id"]
+            return
+
+    logger.info(
+        "No role_id, creating role based on group name %s",
+        instance.group.name,
+    )
+    role = discord.create_role(instance.group.name)
+    logger.info("External role created: %s", role.json())
+    instance.role_id = role.json()["id"]
+
+
+def _discord_role_id_for_name(name: str):
+    """Return Discord role id for a role name if it already exists on the server."""
+    for role in discord.get_roles():
+        if role["name"] == name:
+            return role["id"]
+    return None
+
+
+def _ensure_discord_role_for_group(group: Group) -> DiscordRole:
+    """
+    Ensure a DiscordRole row exists for this auth group.
+
+    If Discord already has a role with this name and a DiscordRole row owns that
+    role_id (e.g. leftover from a deleted/recreated group), re-point it instead
+    of inserting a duplicate unique role_id.
+    """
+    existing = DiscordRole.objects.filter(group=group).first()
+    if existing is not None:
+        return existing
+
+    role_id = _discord_role_id_for_name(group.name)
+    if role_id is not None:
+        claimed = DiscordRole.objects.filter(role_id=role_id).first()
+        if claimed is not None:
+            logger.info(
+                "Re-linking DiscordRole role_id=%s from group %s to %s",
+                role_id,
+                claimed.group_id,
+                group.id,
+            )
+            claimed.group = group
+            claimed.name = group.name
+            claimed.save(update_fields=["group", "name", "updated_at"])
+            return claimed
+
+    try:
+        return DiscordRole.objects.create(name=group.name, group=group)
+    except IntegrityError:
+        # Concurrent create or race with role_id uniqueness — recover by role_id.
+        role_id = role_id or _discord_role_id_for_name(group.name)
+        if role_id is None:
+            raise
+        claimed = DiscordRole.objects.filter(role_id=role_id).first()
+        if claimed is None:
+            raise
+        claimed.group = group
+        claimed.name = group.name
+        claimed.save(update_fields=["group", "name", "updated_at"])
+        return claimed
 
 
 @receiver(signals.post_save, sender=Group, dispatch_uid="group_post_save")
@@ -49,11 +101,7 @@ def group_post_save(
     sender, instance, created, **kwargs
 ):  # pylint: disable=unused-argument
     logger.info("Group saved, creating / updating role")
-    if not DiscordRole.objects.filter(group=instance).exists():
-        DiscordRole.objects.create(
-            name=instance.name,
-            group=instance,
-        )
+    _ensure_discord_role_for_group(instance)
 
 
 def _discord_role_call(
@@ -78,7 +126,7 @@ def _add_user_to_group_discord_role(user, group):
     logger.info("User added to group, adding to discord role")
     discord_user = _discord_user_for(user)
     if discord_user is None:
-        logger.error("Group change without discord user")
+        logger.info("Group change without discord user")
         return
     logger.debug("Checking group %s", group.name)
     if not DiscordRole.objects.filter(group=group).exists():
@@ -104,7 +152,7 @@ def _remove_user_from_group_discord_role(user, group):
     logger.info("User removed from group, removing from discord role")
     discord_user = _discord_user_for(user)
     if discord_user is None:
-        logger.error("Group change without discord user")
+        logger.info("Group change without discord user")
         return
     if not DiscordRole.objects.filter(group=group).exists():
         logger.warning("No discord role for group %s", group.name)
@@ -134,7 +182,7 @@ def _user_group_pre_clear(user):
     logger.info("User removed from all groups, removing from discord roles")
     discord_user = _discord_user_for(user)
     if discord_user is None:
-        logger.error("Group change without discord user")
+        logger.info("Group change without discord user")
         return
     for role in discord_user.groups.all():
         if not _discord_role_call(
@@ -167,7 +215,7 @@ def user_group_changed(
         else:
             user = instance
             if _discord_user_for(user) is None:
-                logger.error("Group change without discord user")
+                logger.info("Group change without discord user")
                 return
             _user_group_pre_add(user, model, pk_set)
     elif action == "pre_remove":
@@ -179,7 +227,7 @@ def user_group_changed(
         else:
             user = instance
             if _discord_user_for(user) is None:
-                logger.error("Group change without discord user")
+                logger.info("Group change without discord user")
                 return
             _user_group_pre_remove(user, model, pk_set)
     elif action == "pre_clear":
@@ -190,7 +238,7 @@ def user_group_changed(
         else:
             user = instance
             if _discord_user_for(user) is None:
-                logger.error("Group change without discord user")
+                logger.info("Group change without discord user")
                 return
             _user_group_pre_clear(user)
 

--- a/backend/discord/tasks.py
+++ b/backend/discord/tasks.py
@@ -74,7 +74,14 @@ def sync_discord_user_nicknames():
 
 def sync_discord_nickname(user: User | int, force_update: bool):
     if isinstance(user, int):
-        user = User.objects.get(id=user)
+        user_id = user
+        user = User.objects.filter(id=user_id).first()
+        if user is None:
+            logger.info(
+                "Skipping discord nickname sync; user %s no longer exists",
+                user_id,
+            )
+            return
 
     logger.debug("Syncing discord nickname user %s", user.username)
     discord_user = DiscordUser.objects.filter(user_id=user.id).first()
@@ -109,12 +116,20 @@ def sync_discord_nickname(user: User | int, force_update: bool):
 
 @app.task(rate_limit="1/s")
 def sync_discord_user(user_id: int):
-    user = User.objects.get(id=user_id)
+    user = User.objects.filter(id=user_id).first()
+    if user is None:
+        logger.info(
+            "Skipping discord user sync; user %s no longer exists", user_id
+        )
+        return
     discord_user = DiscordUser.objects.filter(user_id=user.id).first()
     if discord_user is None:
         return
     external_discord_user = get_discord_user(user, notify=True)
     if external_discord_user is None:
+        return
+    # User may have been offboarded during get_discord_user
+    if not User.objects.filter(id=user_id).exists():
         return
     expected_discord_roles = DiscordRole.objects.filter(
         group__in=user.groups.all()

--- a/backend/discord/tests.py
+++ b/backend/discord/tests.py
@@ -682,8 +682,8 @@ class DiscordOffboardSyncTests(TestCase):
     ):
         user_id = self.user.id
 
-        def delete_user(_user_id):
-            User.objects.filter(id=user_id).delete()
+        def delete_user(synced_user_id):
+            User.objects.filter(id=synced_user_id).delete()
 
         mock_sync.side_effect = delete_user
         client = Client()

--- a/backend/discord/tests.py
+++ b/backend/discord/tests.py
@@ -26,10 +26,15 @@ from discord.views import discord_login_redirect, fake_login
 
 from discord.tasks import sync_discord_nickname, sync_discord_user
 from discord.helpers import (
+    get_discord_user,
     handle_discord_guild_member_error,
     is_discord_unknown_guild_member_error,
     remove_all_roles_from_guild_member,
     find_unregistered_guild_members,
+)
+from discord.signals import (
+    group_post_save,
+    resolve_existing_discord_role_from_server,
 )
 
 from requests.exceptions import HTTPError
@@ -110,6 +115,47 @@ class DiscordSignalTests(TestCase):
 
             discord_mock.get_roles.assert_called()
             discord_mock.create_role.assert_called_with("reversegroup")
+
+    @patch("discord.signals.discord")
+    def test_group_post_save_relinks_existing_role_id(self, discord_mock):
+        """HF: recreating a group with an existing Discord role_id must not IntegrityError."""
+        discord_mock.get_roles.return_value = [
+            {"id": 1486197729745965067, "name": "Tribe - Chief"},
+        ]
+        signals.post_save.disconnect(
+            sender=Group, dispatch_uid="group_post_save"
+        )
+        signals.pre_save.disconnect(
+            sender=DiscordRole,
+            dispatch_uid="resolve_existing_discord_role_from_server",
+        )
+        old_group = Group.objects.create(name="Old Chief Group")
+        DiscordRole.objects.create(
+            role_id=1486197729745965067,
+            name="Tribe - Chief",
+            group=old_group,
+        )
+        signals.pre_save.connect(
+            resolve_existing_discord_role_from_server,
+            sender=DiscordRole,
+            dispatch_uid="resolve_existing_discord_role_from_server",
+        )
+        signals.post_save.connect(
+            group_post_save,
+            sender=Group,
+            dispatch_uid="group_post_save",
+        )
+
+        new_group = Group.objects.create(name="Tribe - Chief")
+
+        role = DiscordRole.objects.get(role_id=1486197729745965067)
+        self.assertEqual(role.group_id, new_group.id)
+        self.assertEqual(role.name, "Tribe - Chief")
+        self.assertEqual(
+            DiscordRole.objects.filter(role_id=1486197729745965067).count(),
+            1,
+        )
+        discord_mock.create_role.assert_not_called()
 
 
 class DiscordTests(TestCase):
@@ -579,6 +625,74 @@ class DiscordChannelAdminFormTestCase(TestCase):
 
         self.assertFalse(form.is_valid())
         self.assertIn("receive_capital_pings", form.errors)
+
+
+class DiscordOffboardSyncTests(TestCase):
+    """A5/MG: offboard during sync must not 500, and message must be correct."""
+
+    def _unknown_member_error(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.json.return_value = {
+            "message": "Unknown Member",
+            "code": 10007,
+        }
+        return HTTPError(response=mock_response)
+
+    @patch("discord.helpers.discord")
+    @patch("discord.helpers.offboard_user")
+    def test_get_discord_user_posts_offboard_message_when_notify(
+        self, mock_offboard, mock_discord
+    ):
+        DiscordUser.objects.create(id=999, user=self.user, discord_tag="x")
+        mock_discord.get_user.side_effect = self._unknown_member_error()
+
+        result = get_discord_user(self.user, notify=True)
+
+        self.assertIsNone(result)
+        mock_offboard.assert_called_once_with(self.user.id)
+        message = mock_discord.create_message.call_args[0][1]
+        self.assertIn("offboarded", message)
+        self.assertNotIn("Ushra'Khant", message)
+
+    @patch("discord.helpers.discord")
+    @patch("discord.helpers.offboard_user")
+    def test_get_discord_user_skips_message_when_notify_false(
+        self, mock_offboard, mock_discord
+    ):
+        DiscordUser.objects.create(id=998, user=self.user, discord_tag="x")
+        mock_discord.get_user.side_effect = self._unknown_member_error()
+
+        result = get_discord_user(self.user, notify=False)
+
+        self.assertIsNone(result)
+        mock_offboard.assert_called_once_with(self.user.id)
+        mock_discord.create_message.assert_not_called()
+
+    def test_sync_discord_nickname_missing_user_is_noop(self):
+        sync_discord_nickname(999999, force_update=True)
+
+    def test_sync_discord_user_missing_user_is_noop(self):
+        sync_discord_user(999999)
+
+    @patch("users.router.sync_discord_user")
+    @patch("users.router.update_affiliation")
+    def test_sync_user_endpoint_returns_410_after_offboard(
+        self, mock_affiliation, mock_sync
+    ):
+        user_id = self.user.id
+
+        def delete_user(_user_id):
+            User.objects.filter(id=user_id).delete()
+
+        mock_sync.side_effect = delete_user
+        client = Client()
+        response = client.post(
+            f"/api/users/{user_id}/sync",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        self.assertEqual(response.status_code, 410)
+        self.assertIn(b"offboarded", response.content)
 
 
 if __name__ == "__main__":

--- a/backend/eveonline/client.py
+++ b/backend/eveonline/client.py
@@ -106,7 +106,10 @@ class EsiResponse:
         if self.response_code == 905:
             return f"No valid ESI token ({self.response_code})"
         if self.response_code == 906:
-            return f"Error calling ESI ({self.response_code})"
+            detail = f"Error calling ESI ({self.response_code})"
+            if self.response is not None:
+                return f"{detail}: {self.response}"
+            return detail
         if self.response_code < 500:
             return f"HTTP client error ({self.response_code})"
         if self.response_code < 600:

--- a/backend/eveonline/helpers/characters/skills.py
+++ b/backend/eveonline/helpers/characters/skills.py
@@ -28,7 +28,12 @@ def upsert_character_skills(character_id: int):
     character = EveCharacter.objects.get(character_id=character_id)
     response = EsiClient(character).get_character_skills()
     if not response.success():
-        logger.error(
+        log = (
+            logger.warning
+            if response.response_code in (902, 904, 905, 906)
+            else logger.error
+        )
+        log(
             "Error %s getting skills for %s",
             response.error_text(),
             character.summary(),

--- a/backend/eveonline/helpers/characters/update.py
+++ b/backend/eveonline/helpers/characters/update.py
@@ -51,7 +51,14 @@ def update_character_assets(eve_character_id: int) -> tuple[int, int, int]:
 
     response = EsiClient(character).get_character_assets()
     if not response.success():
-        logger.error(
+        # Expected ESI/token failures (opaque 906, suspended, missing token)
+        # are per-character and should not dominate Sentry as errors.
+        log = (
+            logger.warning
+            if response.response_code in (902, 904, 905, 906)
+            else logger.error
+        )
+        log(
             "Error %s fetching assets for %s",
             response.error_text(),
             character.summary(),

--- a/backend/eveonline/tests/test_client.py
+++ b/backend/eveonline/tests/test_client.py
@@ -227,3 +227,26 @@ class EsiClientTest(SimpleTestCase):
         self.assertIsInstance(response.response, AttributeError)
         self.assertIn("character_id", str(response.response))
         operation.result.assert_called_once_with(use_etag=False)
+
+    def test_error_text_includes_underlying_exception_for_906(self):
+        response = EsiResponse(
+            response_code=ERROR_CALLING_ESI,
+            response=RuntimeError("upstream boom"),
+        )
+        text = response.error_text()
+        self.assertIn("906", text)
+        self.assertIn("upstream boom", text)
+
+    def test_operation_result_unwraps_one_element_list(self):
+        client = EsiClient(634915984)
+        operation = MagicMock()
+        operation.result.return_value = [
+            {"name": "Gankproof Dex", "corporation_id": 1}
+        ]
+
+        # pylint: disable-next=protected-access
+        response = client._operation_result(operation)
+
+        self.assertEqual(response.response_code, SUCCESS)
+        self.assertEqual(response.results()["name"], "Gankproof Dex")
+        self.assertIsInstance(response.results(), dict)

--- a/backend/users/router.py
+++ b/backend/users/router.py
@@ -286,14 +286,22 @@ def delete_account(request):
     summary="Sync user with Discord",
     description="This will sync the user with Discord. You can only sync your own account.",
     auth=AuthBearer(),
-    response={200: str, 403: ErrorResponse},
+    response={200: str, 403: ErrorResponse, 410: ErrorResponse},
 )
 def sync_user(request, user_id: int):
     if request.user.id != user_id:
         return 403, ErrorResponse(detail="You can only sync your own account.")
     update_affiliation(user_id)
     sync_discord_user(user_id)
-    sync_discord_nickname(user_id, True)
+    # sync_discord_user may offboard the account when Discord returns Unknown Member
+    if not User.objects.filter(id=user_id).exists():
+        return 410, ErrorResponse(
+            detail=(
+                "Account was offboarded because the Discord member "
+                "was not found on the server."
+            )
+        )
+    sync_discord_nickname(request.user, True)
     return "User synced successfully"
 
 


### PR DESCRIPTION
## Summary
- Fix `/api/users/{id}/sync` 500s (A5/MG): when Discord returns Unknown Member, offboarding no longer continues into nickname sync; endpoint returns 410 with a clear message, and the people-team notice says offboarded instead of the false “promoted to Ushra'Khant”
- Fix Tribe Chief `DiscordRole` unique `role_id` collisions (HF) by re-linking existing rows; also stop `pre_save` from creating a new Discord role when `role_id` is already set
- Downgrade expected “Group change without discord user” logs from error → info (KY)
- ESI: include underlying exception in 906 `error_text`, demote expected 902/904/905/906 asset/skills failures to warning, and add a regression test for one-element list unwrap (HV/HW/J5)

## Test plan
- [x] `pipenv run python manage.py test discord eveonline.tests.test_client --settings=app.settings_test` (46 passed)
- [ ] Confirm after deploy: A5/MG no longer fire on refresh-roles for missing Discord members; `#internal-affairs` shows offboard wording
- [ ] Confirm HF quiet on next `sync_tribe_chief_group` run
- [ ] Confirm BD/BC drop in Sentry error volume (warnings still OK for bad tokens)


Made with [Cursor](https://cursor.com)