### PR TITLE
Add Amarr fleet Discord pings (capital-ping style)

### DIFF
--- a/backend/discord/admin.py
+++ b/backend/discord/admin.py
@@ -76,6 +76,7 @@ class DiscordChannelAdmin(admin.ModelAdmin):
         "channel_type",
         "track_voice_activity",
         "receive_capital_pings",
+        "receive_amarr_fleet_pings",
         "channel_id",
         "updated_at",
     )
@@ -84,6 +85,7 @@ class DiscordChannelAdmin(admin.ModelAdmin):
         "channel_type",
         "track_voice_activity",
         "receive_capital_pings",
+        "receive_amarr_fleet_pings",
     )
     search_fields = ("name", "channel_id", "guild__name")
     readonly_fields = (
@@ -103,6 +105,7 @@ class DiscordChannelAdmin(admin.ModelAdmin):
                 "channel_type",
                 "track_voice_activity",
                 "receive_capital_pings",
+                "receive_amarr_fleet_pings",
                 "created_at",
                 "updated_at",
             )
@@ -110,6 +113,7 @@ class DiscordChannelAdmin(admin.ModelAdmin):
             "discord_channel_pick",
             "track_voice_activity",
             "receive_capital_pings",
+            "receive_amarr_fleet_pings",
         )
 
     def save_model(self, request, obj, form, change):

--- a/backend/discord/channels.py
+++ b/backend/discord/channels.py
@@ -11,6 +11,7 @@ discord = DiscordClient()
 ADMIN_PICKER_CHANNEL_TYPES = {"text", "voice", "stage", "forum"}
 VOICE_TRACKING_CHANNEL_TYPES = {"voice", "stage"}
 CAPITAL_PING_CHANNEL_TYPES = {"text", "forum"}
+AMARR_FLEET_PING_CHANNEL_TYPES = {"text", "forum"}
 
 
 def fetch_guild_channels(guild_id=None):

--- a/backend/discord/forms.py
+++ b/backend/discord/forms.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError
 
 from discord.channels import (
     ADMIN_PICKER_CHANNEL_TYPES,
+    AMARR_FLEET_PING_CHANNEL_TYPES,
     CAPITAL_PING_CHANNEL_TYPES,
     VOICE_TRACKING_CHANNEL_TYPES,
     fetch_active_guild_channels,
@@ -21,7 +22,11 @@ class DiscordChannelAdminForm(forms.ModelForm):
 
     class Meta:
         model = DiscordChannel
-        fields = ("track_voice_activity", "receive_capital_pings")
+        fields = (
+            "track_voice_activity",
+            "receive_capital_pings",
+            "receive_amarr_fleet_pings",
+        )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -77,6 +82,9 @@ class DiscordChannelAdminForm(forms.ModelForm):
         receive_capital_pings = cleaned_data.get(
             "receive_capital_pings", False
         )
+        receive_amarr_fleet_pings = cleaned_data.get(
+            "receive_amarr_fleet_pings", False
+        )
 
         if self.instance.pk:
             channel_type = self.instance.channel_type
@@ -128,6 +136,18 @@ class DiscordChannelAdminForm(forms.ModelForm):
                 {
                     "receive_capital_pings": (
                         "Capital pings are only supported for text and forum channels."
+                    )
+                }
+            )
+
+        if (
+            receive_amarr_fleet_pings
+            and channel_type not in AMARR_FLEET_PING_CHANNEL_TYPES
+        ):
+            raise ValidationError(
+                {
+                    "receive_amarr_fleet_pings": (
+                        "Amarr fleet pings are only supported for text and forum channels."
                     )
                 }
             )

--- a/backend/discord/migrations/0020_discordchannel_receive_amarr_fleet_pings.py
+++ b/backend/discord/migrations/0020_discordchannel_receive_amarr_fleet_pings.py
@@ -1,0 +1,23 @@
+# Generated manually for Amarr fleet Discord channel flag
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("discord", "0019_discordchannel_receive_capital_pings"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="discordchannel",
+            name="receive_amarr_fleet_pings",
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    "When enabled, Amarr fleet_active feed events are posted here."
+                ),
+            ),
+        ),
+    ]

--- a/backend/discord/models.py
+++ b/backend/discord/models.py
@@ -163,6 +163,12 @@ class DiscordChannel(models.Model):
             "When enabled, capital kills within 8 LY of Amamake are posted here."
         ),
     )
+    receive_amarr_fleet_pings = models.BooleanField(
+        default=False,
+        help_text=(
+            "When enabled, Amarr fleet_active feed events are posted here."
+        ),
+    )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/backend/discord/tests.py
+++ b/backend/discord/tests.py
@@ -626,6 +626,31 @@ class DiscordChannelAdminFormTestCase(TestCase):
         self.assertFalse(form.is_valid())
         self.assertIn("receive_capital_pings", form.errors)
 
+    @patch("discord.forms.fetch_active_guild_channels")
+    @patch("discord.forms.get_guild_channel")
+    def test_receive_amarr_fleet_pings_rejected_for_voice_channel(
+        self, mock_get_channel, mock_fetch_active
+    ):
+        mock_fetch_active.return_value = [
+            {
+                "id": 456,
+                "name": "comms",
+                "type": "voice",
+                "guild_id": self.guild.guild_id,
+            },
+        ]
+        mock_get_channel.return_value = mock_fetch_active.return_value[0]
+        form = DiscordChannelAdminForm(
+            data={
+                "discord_channel_pick": "456",
+                "track_voice_activity": False,
+                "receive_amarr_fleet_pings": True,
+            }
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("receive_amarr_fleet_pings", form.errors)
+
 
 class DiscordOffboardSyncTests(TestCase):
     """A5/MG: offboard during sync must not 500, and message must be correct."""

--- a/backend/feed/constants.py
+++ b/backend/feed/constants.py
@@ -142,6 +142,9 @@ CAPITAL_PING_MAX_LIGHT_YEARS = 8.0
 CAPITAL_PING_MAX_AGE_SECONDS = 180
 # Reuse one Discord message for further capital-related kills in the same system.
 CAPITAL_PING_SESSION_SECONDS = 30 * 60
+# Amarr fleet Discord pings (fleet_active rollups). Reuse one Discord message
+# for further updates to the same system engagement within the session TTL.
+AMARR_FLEET_PING_SESSION_SECONDS = 30 * 60
 METERS_PER_LIGHT_YEAR = 9_460_528_400_000_000
 CAPITAL_SHIP_GROUPS = frozenset(
     {

--- a/backend/feed/helpers/amarr_fleet_pings.py
+++ b/backend/feed/helpers/amarr_fleet_pings.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from typing import Any
+
+from django.utils import timezone
+
+from discord.client import DiscordClient
+from discord.models import DiscordChannel
+from feed.constants import AMARR_FLEET_PING_SESSION_SECONDS
+from feed.models import FeedAmarrFleetAlert, FeedAmarrFleetPing, FeedEvent
+
+logger = logging.getLogger(__name__)
+
+AMARR_FLEET_ALERT_TITLE = "Amarr fleet spotted"
+# Matches mobile fleetYellow (#f1d9a0) used for Amarr feed accents.
+AMARR_FLEET_ALERT_COLOR = 0xF1D9A0
+ZKILL_CHARACTER_URL = "https://zkillboard.com/character/{character_id}/"
+
+
+def _amarr_fleet_ping_channel_ids() -> list[int]:
+    return list(
+        DiscordChannel.objects.filter(
+            receive_amarr_fleet_pings=True,
+            guild__is_active=True,
+        ).values_list("channel_id", flat=True)
+    )
+
+
+def _zkill_character_link(character_id: int, name: str) -> str:
+    url = ZKILL_CHARACTER_URL.format(character_id=int(character_id))
+    return f"[{name}]({url})"
+
+
+def _system_entry(
+    *,
+    solar_system_id: int,
+    system_name: str,
+) -> dict[str, Any]:
+    return {
+        "solar_system_id": int(solar_system_id),
+        "system_name": system_name,
+    }
+
+
+def _append_system(
+    systems: list[dict[str, Any]] | None,
+    *,
+    solar_system_id: int,
+    system_name: str,
+) -> list[dict[str, Any]]:
+    """Extend the sighting chain; refresh tip if still in the same system."""
+    entry = _system_entry(
+        solar_system_id=solar_system_id,
+        system_name=system_name,
+    )
+    chain = list(systems or [])
+    if chain and int(chain[-1]["solar_system_id"]) == int(solar_system_id):
+        chain[-1] = entry
+        return chain
+    chain.append(entry)
+    return chain
+
+
+def _systems_for_alert(alert: FeedAmarrFleetAlert) -> list[dict[str, Any]]:
+    if alert.systems:
+        return list(alert.systems)
+    return [
+        _system_entry(
+            solar_system_id=int(alert.solar_system_id),
+            system_name=alert.system_name,
+        )
+    ]
+
+
+def _format_system_line(
+    systems: list[dict[str, Any]] | None,
+    fallback_name: str,
+) -> str:
+    names = [
+        str(entry["system_name"])
+        for entry in systems or []
+        if entry.get("system_name")
+    ]
+    if not names:
+        return fallback_name
+    return " → ".join(names)
+
+
+def _roster_links(roster: list[dict[str, Any]] | None) -> str:
+    links: list[str] = []
+    for entry in roster or []:
+        character_id = entry.get("character_id")
+        name = entry.get("name")
+        if not character_id or not name:
+            continue
+        links.append(_zkill_character_link(int(character_id), str(name)))
+    return ", ".join(links)
+
+
+def build_amarr_fleet_alert_payload(
+    *,
+    system_name: str,
+    title: str,
+    subheader: str,
+    preview: str,
+    kills: int,
+    pilots: int,
+    roster: list[dict[str, Any]] | None = None,
+    roster_total: int = 0,
+    systems: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build Discord payload for an Amarr fleet presence alert."""
+    description_lines = [
+        f"**System:** {_format_system_line(systems, system_name)}",
+        f"**Fleet:** {title}",
+    ]
+    if subheader:
+        description_lines.append(f"**Summary:** {subheader}")
+    elif kills or pilots:
+        parts: list[str] = []
+        if kills:
+            parts.append(f"{kills} kills")
+        if pilots:
+            parts.append(f"{pilots} pilots")
+        description_lines.append(f"**Summary:** {' · '.join(parts)}")
+    if preview:
+        description_lines.append(preview)
+    roster_line = _roster_links(roster)
+    if roster_line:
+        shown = len(roster or [])
+        total = max(int(roster_total or 0), shown)
+        suffix = f" (+{total - shown} more)" if total > shown else ""
+        description_lines.append(f"**Pilots:** {roster_line}{suffix}")
+
+    embed: dict[str, Any] = {
+        "type": "rich",
+        "title": AMARR_FLEET_ALERT_TITLE,
+        "description": "\n".join(description_lines),
+        "color": AMARR_FLEET_ALERT_COLOR,
+    }
+    return {"embeds": [embed]}
+
+
+def _event_snapshot(event: FeedEvent) -> dict[str, Any]:
+    payload = event.payload or {}
+    system_id = payload.get("system_id")
+    system_name = (
+        payload.get("system_name") or event.subheader.split("·")[0].strip()
+    )
+    if not system_id:
+        raise ValueError("Amarr fleet event missing system_id")
+    return {
+        "solar_system_id": int(system_id),
+        "system_name": str(system_name or f"System {system_id}"),
+        "title": event.title,
+        "subheader": event.subheader or "",
+        "preview": event.preview or "",
+        "kills": int(payload.get("kills") or 0),
+        "pilots": int(payload.get("pilots") or 0),
+        "roster": list(payload.get("roster") or []),
+        "roster_total": int(payload.get("roster_total") or 0),
+        "cluster_key": event.cluster_key or "",
+    }
+
+
+def _active_alert(solar_system_id: int) -> FeedAmarrFleetAlert | None:
+    """Find a live Amarr fleet alert for this system within the session TTL."""
+    cutoff = timezone.now() - timedelta(
+        seconds=AMARR_FLEET_PING_SESSION_SECONDS
+    )
+    return (
+        FeedAmarrFleetAlert.objects.filter(
+            last_activity_at__gte=cutoff,
+            solar_system_id=int(solar_system_id),
+        )
+        .order_by("-last_activity_at")
+        .first()
+    )
+
+
+def _post_alert_messages(
+    payload: dict[str, Any],
+    *,
+    discord_client: DiscordClient,
+) -> list[dict[str, int]]:
+    messages: list[dict[str, int]] = []
+    for channel_id in _amarr_fleet_ping_channel_ids():
+        response = discord_client.create_message(
+            channel_id=channel_id, payload=payload
+        )
+        message_id = response.json().get("id")
+        if message_id:
+            messages.append(
+                {
+                    "channel_id": int(channel_id),
+                    "message_id": int(message_id),
+                }
+            )
+    return messages
+
+
+def _edit_alert_messages(
+    alert: FeedAmarrFleetAlert,
+    payload: dict[str, Any],
+    *,
+    discord_client: DiscordClient,
+) -> None:
+    for entry in alert.discord_messages or []:
+        channel_id = entry.get("channel_id")
+        message_id = entry.get("message_id")
+        if not channel_id or not message_id:
+            continue
+        discord_client.update_message(
+            channel_id=int(channel_id),
+            message_id=int(message_id),
+            payload=payload,
+        )
+
+
+def _create_amarr_fleet_alert(
+    *,
+    snapshot: dict[str, Any],
+    discord_client: DiscordClient,
+) -> FeedAmarrFleetAlert | None:
+    systems = [
+        _system_entry(
+            solar_system_id=snapshot["solar_system_id"],
+            system_name=snapshot["system_name"],
+        )
+    ]
+    discord_payload = build_amarr_fleet_alert_payload(
+        system_name=snapshot["system_name"],
+        title=snapshot["title"],
+        subheader=snapshot["subheader"],
+        preview=snapshot["preview"],
+        kills=snapshot["kills"],
+        pilots=snapshot["pilots"],
+        roster=snapshot["roster"],
+        roster_total=snapshot["roster_total"],
+        systems=systems,
+    )
+    discord_messages = _post_alert_messages(
+        discord_payload, discord_client=discord_client
+    )
+    if not discord_messages:
+        return None
+    return FeedAmarrFleetAlert.objects.create(
+        solar_system_id=snapshot["solar_system_id"],
+        system_name=snapshot["system_name"],
+        systems=systems,
+        title=snapshot["title"],
+        subheader=snapshot["subheader"],
+        preview=snapshot["preview"],
+        kills=snapshot["kills"],
+        pilots=snapshot["pilots"],
+        roster=snapshot["roster"],
+        roster_total=snapshot["roster_total"],
+        cluster_key=snapshot["cluster_key"],
+        discord_messages=discord_messages,
+        last_activity_at=timezone.now(),
+    )
+
+
+def _update_amarr_fleet_alert(
+    alert: FeedAmarrFleetAlert,
+    *,
+    snapshot: dict[str, Any],
+    discord_client: DiscordClient,
+) -> FeedAmarrFleetAlert:
+    alert.systems = _append_system(
+        _systems_for_alert(alert),
+        solar_system_id=snapshot["solar_system_id"],
+        system_name=snapshot["system_name"],
+    )
+    alert.solar_system_id = snapshot["solar_system_id"]
+    alert.system_name = snapshot["system_name"]
+    alert.title = snapshot["title"]
+    alert.subheader = snapshot["subheader"]
+    alert.preview = snapshot["preview"]
+    alert.kills = snapshot["kills"]
+    alert.pilots = snapshot["pilots"]
+    alert.roster = snapshot["roster"]
+    alert.roster_total = snapshot["roster_total"]
+    alert.cluster_key = snapshot["cluster_key"] or alert.cluster_key
+    alert.last_activity_at = timezone.now()
+    discord_payload = build_amarr_fleet_alert_payload(
+        system_name=alert.system_name,
+        title=alert.title,
+        subheader=alert.subheader,
+        preview=alert.preview,
+        kills=alert.kills,
+        pilots=alert.pilots,
+        roster=alert.roster,
+        roster_total=alert.roster_total,
+        systems=alert.systems,
+    )
+    _edit_alert_messages(alert, discord_payload, discord_client=discord_client)
+    alert.save(
+        update_fields=[
+            "solar_system_id",
+            "system_name",
+            "systems",
+            "title",
+            "subheader",
+            "preview",
+            "kills",
+            "pilots",
+            "roster",
+            "roster_total",
+            "cluster_key",
+            "last_activity_at",
+        ]
+    )
+    return alert
+
+
+def _record_amarr_fleet_ping(
+    *,
+    cluster_key: str,
+    alert: FeedAmarrFleetAlert,
+    solar_system_id: int,
+    created: bool,
+) -> None:
+    if not cluster_key:
+        return
+    first_message_id = None
+    if alert.discord_messages:
+        first_message_id = alert.discord_messages[0].get("message_id")
+    FeedAmarrFleetPing.objects.update_or_create(
+        cluster_key=cluster_key,
+        defaults={
+            "alert": alert,
+            "solar_system_id": solar_system_id,
+            "discord_message_id": first_message_id,
+        },
+    )
+    action = "created" if created else "updated"
+    logger.info(
+        "Amarr fleet alert %s for cluster %s in system %s",
+        action,
+        cluster_key,
+        solar_system_id,
+    )
+
+
+def _is_amarr_fleet_event(event: FeedEvent) -> bool:
+    return (
+        event.kind == FeedEvent.Kind.FLEET_ACTIVE
+        and event.accent == FeedEvent.Accent.AMARR
+        and bool(event.cluster_key)
+    )
+
+
+def _upsert_amarr_fleet_alert(
+    *,
+    snapshot: dict[str, Any],
+    existing: FeedAmarrFleetAlert | None,
+    discord_client: DiscordClient,
+) -> tuple[FeedAmarrFleetAlert | None, bool]:
+    """Create or update an alert. Returns (alert, created)."""
+    if existing is None:
+        alert = _create_amarr_fleet_alert(
+            snapshot=snapshot, discord_client=discord_client
+        )
+        return alert, True
+    alert = _update_amarr_fleet_alert(
+        existing, snapshot=snapshot, discord_client=discord_client
+    )
+    return alert, False
+
+
+def maybe_notify_amarr_fleet(
+    event: FeedEvent,
+    *,
+    discord_client: DiscordClient | None = None,
+) -> bool:
+    """Create or update a Discord Amarr fleet alert from a feed event.
+
+    Returns True if a Discord message was created or edited, False if skipped.
+    """
+    if not _amarr_fleet_ping_channel_ids() or not _is_amarr_fleet_event(event):
+        return False
+
+    try:
+        snapshot = _event_snapshot(event)
+    except (TypeError, ValueError):
+        logger.exception(
+            "Amarr fleet ping skipped: invalid event payload id=%s", event.pk
+        )
+        return False
+
+    client = discord_client or DiscordClient()
+    existing = _active_alert(snapshot["solar_system_id"])
+    try:
+        alert, created = _upsert_amarr_fleet_alert(
+            snapshot=snapshot,
+            existing=existing,
+            discord_client=client,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to send/update Amarr fleet ping for cluster %s",
+            snapshot["cluster_key"],
+        )
+        return False
+    if alert is None:
+        return False
+
+    _record_amarr_fleet_ping(
+        cluster_key=snapshot["cluster_key"],
+        alert=alert,
+        solar_system_id=snapshot["solar_system_id"],
+        created=created,
+    )
+    return True

--- a/backend/feed/management/commands/test_amarr_fleet_ping.py
+++ b/backend/feed/management/commands/test_amarr_fleet_ping.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from feed.helpers.amarr_fleet_pings import (
+    build_amarr_fleet_alert_payload,
+    maybe_notify_amarr_fleet,
+)
+from feed.models import FeedEvent
+
+
+def sample_amarr_fleet_event() -> FeedEvent:
+    """Synthetic Amarr fleet_active event for Discord smoke tests."""
+    return FeedEvent(
+        kind=FeedEvent.Kind.FLEET_ACTIVE,
+        occurred_at=timezone.now(),
+        title="Medium Amarr fleet active",
+        subheader="Amamake · 12 kills · 15 pilots · ~10m",
+        preview="Medium fleet involving battlecruisers and frigates.",
+        body="",
+        accent=FeedEvent.Accent.AMARR,
+        payload={
+            "faction": "amarr",
+            "system_id": 30002537,
+            "system_name": "Amamake",
+            "kills": 12,
+            "pilots": 15,
+            "roster": [
+                {"character_id": 2111000001, "name": "Amarr Pilot"},
+            ],
+            "roster_total": 15,
+            "engagement_tier": "medium",
+        },
+        rollup_code="fleet_active",
+        rollup_version=1,
+        cluster_key=(
+            f"fleet_active:30002537:500003:"
+            f"{timezone.now().strftime('%Y-%m-%dT%H:%M')}"
+        ),
+        is_active=True,
+    )
+
+
+class Command(BaseCommand):
+    help = "Send a sample Amarr-fleet Discord ping (smoke test)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Build and print the payload without posting to Discord.",
+        )
+
+    def handle(self, *args, **options):
+        event = sample_amarr_fleet_event()
+        if options["dry_run"]:
+            built = build_amarr_fleet_alert_payload(
+                system_name="Amamake",
+                title=event.title,
+                subheader=event.subheader,
+                preview=event.preview,
+                kills=12,
+                pilots=15,
+                roster=event.payload["roster"],
+                roster_total=15,
+            )
+            self.stdout.write(self.style.SUCCESS(str(built)))
+            return
+
+        event.save()
+        sent = maybe_notify_amarr_fleet(event)
+        if sent:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "Amarr fleet ping posted to the configured Discord channel."
+                )
+            )
+        else:
+            self.stdout.write(
+                self.style.ERROR(
+                    "Amarr fleet ping was not sent. Enable "
+                    "receive_amarr_fleet_pings on a Discord channel in admin, "
+                    "and check bot permissions."
+                )
+            )

--- a/backend/feed/migrations/0013_feed_amarr_fleet_pings.py
+++ b/backend/feed/migrations/0013_feed_amarr_fleet_pings.py
@@ -1,0 +1,90 @@
+# Generated manually for Amarr fleet Discord pings
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("feed", "0012_feedcapitalalert_systems"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="FeedAmarrFleetAlert",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("solar_system_id", models.BigIntegerField(db_index=True)),
+                ("system_name", models.CharField(max_length=64)),
+                ("systems", models.JSONField(default=list)),
+                ("title", models.CharField(max_length=256)),
+                (
+                    "subheader",
+                    models.CharField(blank=True, default="", max_length=512),
+                ),
+                ("preview", models.TextField(blank=True, default="")),
+                ("kills", models.PositiveIntegerField(default=0)),
+                ("pilots", models.PositiveIntegerField(default=0)),
+                ("roster", models.JSONField(default=list)),
+                ("roster_total", models.PositiveIntegerField(default=0)),
+                (
+                    "cluster_key",
+                    models.CharField(db_index=True, max_length=256),
+                ),
+                ("discord_messages", models.JSONField(default=list)),
+                ("last_activity_at", models.DateTimeField(db_index=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+            ],
+            options={
+                "ordering": ["-last_activity_at"],
+            },
+        ),
+        migrations.CreateModel(
+            name="FeedAmarrFleetPing",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "cluster_key",
+                    models.CharField(
+                        db_index=True, max_length=256, unique=True
+                    ),
+                ),
+                ("solar_system_id", models.BigIntegerField()),
+                (
+                    "discord_message_id",
+                    models.BigIntegerField(blank=True, null=True),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "alert",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="pings",
+                        to="feed.feedamarrfleetalert",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created_at"],
+            },
+        ),
+    ]

--- a/backend/feed/models.py
+++ b/backend/feed/models.py
@@ -311,3 +311,58 @@ class FeedCapitalPing(models.Model):
 
     def __str__(self) -> str:
         return f"Capital ping {self.killmail_id}"
+
+
+class FeedAmarrFleetAlert(models.Model):
+    """One Discord message for an Amarr fleet engagement.
+
+    Further ``fleet_active`` rollup updates for the same system (within the
+    session TTL) edit this message instead of posting new ones. ``systems``
+    holds the ordered sighting chain when the fight moves.
+    """
+
+    solar_system_id = models.BigIntegerField(db_index=True)
+    system_name = models.CharField(max_length=64)
+    # [{solar_system_id, system_name}, ...] ordered sighting chain
+    systems = models.JSONField(default=list)
+    title = models.CharField(max_length=256)
+    subheader = models.CharField(max_length=512, blank=True, default="")
+    preview = models.TextField(blank=True, default="")
+    kills = models.PositiveIntegerField(default=0)
+    pilots = models.PositiveIntegerField(default=0)
+    # [{character_id, name}, ...]
+    roster = models.JSONField(default=list)
+    roster_total = models.PositiveIntegerField(default=0)
+    cluster_key = models.CharField(max_length=256, db_index=True)
+    # [{channel_id, message_id}, ...]
+    discord_messages = models.JSONField(default=list)
+    last_activity_at = models.DateTimeField(db_index=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["-last_activity_at"]
+
+    def __str__(self) -> str:
+        return f"Amarr fleet alert {self.system_name} ({self.solar_system_id})"
+
+
+class FeedAmarrFleetPing(models.Model):
+    """Per-cluster_key dedup / audit for Amarr fleet alerts."""
+
+    cluster_key = models.CharField(max_length=256, unique=True, db_index=True)
+    alert = models.ForeignKey(
+        FeedAmarrFleetAlert,
+        on_delete=models.CASCADE,
+        related_name="pings",
+        null=True,
+        blank=True,
+    )
+    solar_system_id = models.BigIntegerField()
+    discord_message_id = models.BigIntegerField(null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    def __str__(self) -> str:
+        return f"Amarr fleet ping {self.cluster_key}"

--- a/backend/feed/rollups/writer.py
+++ b/backend/feed/rollups/writer.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import logging
 from datetime import timedelta
 
 from django.utils import timezone
 
+from feed.helpers.amarr_fleet_pings import maybe_notify_amarr_fleet
 from feed.models import (
     FeedEvent,
     FeedEventKillmailLink,
@@ -11,6 +13,8 @@ from feed.models import (
 )
 from feed.rollups.config import get_rollup_config
 from feed.rollups.types import RollupResult
+
+logger = logging.getLogger(__name__)
 
 FLEET_ACTIVE_ROLLUP = "fleet_active"
 # Ordered smallest -> largest; index is used to detect tier upgrades.
@@ -22,8 +26,24 @@ def write_rollup_results(results: list[RollupResult]) -> int:
     for result in results:
         event = _upsert_event(result)
         _sync_killmail_links(event, result.killmail_ids)
+        _maybe_notify_amarr_fleet(event)
         written += 1
     return written
+
+
+def _maybe_notify_amarr_fleet(event: FeedEvent) -> None:
+    if (
+        event.rollup_code != FLEET_ACTIVE_ROLLUP
+        or event.accent != FeedEvent.Accent.AMARR
+    ):
+        return
+    try:
+        maybe_notify_amarr_fleet(event)
+    except Exception:
+        # Discord failures must not roll back feed event writes.
+        logger.exception(
+            "Amarr fleet Discord notify failed for event %s", event.pk
+        )
 
 
 def _event_lookup(result: RollupResult) -> dict:

--- a/backend/feed/tests/test_amarr_fleet_pings.py
+++ b/backend/feed/tests/test_amarr_fleet_pings.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from discord.models import DiscordChannel, DiscordGuild
+from feed.helpers.amarr_fleet_pings import (
+    AMARR_FLEET_ALERT_TITLE,
+    build_amarr_fleet_alert_payload,
+    maybe_notify_amarr_fleet,
+)
+from feed.models import FeedAmarrFleetAlert, FeedAmarrFleetPing, FeedEvent
+from feed.rollups.types import RollupResult
+from feed.rollups.writer import write_rollup_results
+
+
+def make_amarr_fleet_ping_channel(
+    *, channel_id: int = 555002
+) -> DiscordChannel:
+    guild, _ = DiscordGuild.objects.get_or_create(
+        guild_id=999888778,
+        defaults={"name": "Test Guild", "is_active": True},
+    )
+    return DiscordChannel.objects.create(
+        channel_id=channel_id,
+        guild=guild,
+        name="amarr-fleets",
+        channel_type=DiscordChannel.TEXT,
+        receive_amarr_fleet_pings=True,
+    )
+
+
+def _amarr_event(
+    *,
+    cluster_key: str = "fleet_active:30002537:500003:2026-07-29T21:00",
+    system_id: int = 30002537,
+    system_name: str = "Amamake",
+    title: str = "Medium Amarr fleet active",
+    kills: int = 12,
+    pilots: int = 15,
+) -> FeedEvent:
+    return FeedEvent.objects.create(
+        kind=FeedEvent.Kind.FLEET_ACTIVE,
+        occurred_at=timezone.now(),
+        title=title,
+        subheader=f"{system_name} · {kills} kills · {pilots} pilots · ~10m",
+        preview="Medium fleet involving battlecruisers and frigates.",
+        body="",
+        accent=FeedEvent.Accent.AMARR,
+        payload={
+            "faction": "amarr",
+            "system_id": system_id,
+            "system_name": system_name,
+            "kills": kills,
+            "pilots": pilots,
+            "roster": [
+                {"character_id": 2111000001, "name": "Amarr Pilot"},
+            ],
+            "roster_total": pilots,
+            "engagement_tier": "medium",
+        },
+        rollup_code="fleet_active",
+        rollup_version=1,
+        cluster_key=cluster_key,
+        is_active=True,
+    )
+
+
+class AmarrFleetPingTestCase(TestCase):
+    def setUp(self):
+        make_amarr_fleet_ping_channel()
+
+    def test_build_amarr_fleet_alert_payload(self):
+        built = build_amarr_fleet_alert_payload(
+            system_name="Amamake",
+            title="Medium Amarr fleet active",
+            subheader="Amamake · 12 kills · 15 pilots · ~10m",
+            preview="Medium fleet involving battlecruisers.",
+            kills=12,
+            pilots=15,
+            roster=[
+                {"character_id": 2111000001, "name": "Amarr Pilot"},
+            ],
+            roster_total=15,
+            systems=[
+                {
+                    "solar_system_id": 30002537,
+                    "system_name": "Amamake",
+                }
+            ],
+        )
+        embed = built["embeds"][0]
+        self.assertEqual(embed["title"], AMARR_FLEET_ALERT_TITLE)
+        self.assertIn("**System:** Amamake", embed["description"])
+        self.assertIn("Medium Amarr fleet active", embed["description"])
+        self.assertIn(
+            "[Amarr Pilot](https://zkillboard.com/character/2111000001/)",
+            embed["description"],
+        )
+        self.assertIn("(+14 more)", embed["description"])
+
+    @patch("feed.helpers.amarr_fleet_pings.DiscordClient")
+    def test_maybe_notify_creates_once_then_edits(self, mock_client_cls):
+        mock_client = MagicMock()
+        create_response = MagicMock()
+        create_response.json.return_value = {"id": "999888701"}
+        mock_client.create_message.return_value = create_response
+        mock_client_cls.return_value = mock_client
+
+        first = _amarr_event(kills=12, pilots=15)
+        self.assertTrue(maybe_notify_amarr_fleet(first))
+
+        first.title = "Large Amarr fleet active"
+        first.subheader = "Amamake · 20 kills · 22 pilots · ~18m"
+        first.payload = {
+            **first.payload,
+            "kills": 20,
+            "pilots": 22,
+        }
+        first.save()
+        self.assertTrue(maybe_notify_amarr_fleet(first))
+
+        self.assertEqual(FeedAmarrFleetAlert.objects.count(), 1)
+        self.assertEqual(FeedAmarrFleetPing.objects.count(), 1)
+        mock_client.create_message.assert_called_once()
+        mock_client.update_message.assert_called_once()
+
+        alert = FeedAmarrFleetAlert.objects.get()
+        self.assertEqual(alert.kills, 20)
+        self.assertEqual(alert.title, "Large Amarr fleet active")
+        edit_payload = mock_client.update_message.call_args.kwargs["payload"]
+        self.assertIn(
+            "Large Amarr fleet active",
+            edit_payload["embeds"][0]["description"],
+        )
+
+    @patch("feed.helpers.amarr_fleet_pings.DiscordClient")
+    def test_same_system_coalesces_different_cluster_keys(
+        self, mock_client_cls
+    ):
+        mock_client = MagicMock()
+        create_response = MagicMock()
+        create_response.json.return_value = {"id": "999888702"}
+        mock_client.create_message.return_value = create_response
+        mock_client_cls.return_value = mock_client
+
+        first = _amarr_event(
+            cluster_key="fleet_active:30002537:500003:2026-07-29T21:00",
+            kills=8,
+            pilots=10,
+        )
+        second = _amarr_event(
+            cluster_key="fleet_active:30002537:500003:2026-07-29T21:15",
+            title="Heavy Amarr fleet active",
+            kills=19,
+            pilots=34,
+        )
+
+        self.assertTrue(maybe_notify_amarr_fleet(first))
+        self.assertTrue(maybe_notify_amarr_fleet(second))
+
+        self.assertEqual(FeedAmarrFleetAlert.objects.count(), 1)
+        self.assertEqual(FeedAmarrFleetPing.objects.count(), 2)
+        mock_client.create_message.assert_called_once()
+        mock_client.update_message.assert_called_once()
+
+    @patch("feed.helpers.amarr_fleet_pings.DiscordClient")
+    def test_skips_minmatar_and_non_fleet_events(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+
+        militia = _amarr_event()
+        militia.accent = FeedEvent.Accent.MILITIA
+        militia.save()
+        self.assertFalse(maybe_notify_amarr_fleet(militia))
+
+        combat = _amarr_event(
+            cluster_key="kill_burst:30002537:2026-07-29T21:00"
+        )
+        combat.kind = FeedEvent.Kind.KILLMAIL_BATCH
+        combat.rollup_code = "kill_burst"
+        combat.save()
+        self.assertFalse(maybe_notify_amarr_fleet(combat))
+        mock_client.create_message.assert_not_called()
+
+    @patch("feed.helpers.amarr_fleet_pings.DiscordClient")
+    def test_skips_when_no_channel_configured(self, mock_client_cls):
+        DiscordChannel.objects.all().delete()
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        event = _amarr_event()
+        self.assertFalse(maybe_notify_amarr_fleet(event))
+        mock_client.create_message.assert_not_called()
+        self.assertEqual(FeedAmarrFleetAlert.objects.count(), 0)
+
+    @patch("feed.helpers.amarr_fleet_pings.DiscordClient")
+    def test_writer_notifies_amarr_fleet_active(self, mock_client_cls):
+        mock_client = MagicMock()
+        create_response = MagicMock()
+        create_response.json.return_value = {"id": "999888703"}
+        mock_client.create_message.return_value = create_response
+        mock_client_cls.return_value = mock_client
+
+        cluster_key = "fleet_active:30002539:500003:2026-07-29T21:00"
+        write_rollup_results(
+            [
+                RollupResult(
+                    kind=FeedEvent.Kind.FLEET_ACTIVE,
+                    occurred_at=timezone.now(),
+                    title="Medium Amarr gang active",
+                    subheader="Siseide · 16 kills · 15 pilots · ~11m",
+                    preview="Medium gang involving frigates.",
+                    body="",
+                    accent=FeedEvent.Accent.AMARR,
+                    payload={
+                        "faction": "amarr",
+                        "system_id": 30002539,
+                        "system_name": "Siseide",
+                        "kills": 16,
+                        "pilots": 15,
+                        "roster": [],
+                        "roster_total": 15,
+                    },
+                    rollup_code="fleet_active",
+                    rollup_version=1,
+                    cluster_key=cluster_key,
+                    is_active=True,
+                )
+            ]
+        )
+
+        self.assertEqual(FeedEvent.objects.count(), 1)
+        self.assertEqual(FeedAmarrFleetAlert.objects.count(), 1)
+        self.assertEqual(FeedAmarrFleetPing.objects.count(), 1)
+        mock_client.create_message.assert_called_once()


### PR DESCRIPTION
## Summary
- Discord notifications for Amarr `fleet_active` feed events, mirroring capital pings: channel opt-in, create-then-edit session coalesce (30m TTL), and per-`cluster_key` dedup.
- New `FeedAmarrFleetAlert` / `FeedAmarrFleetPing` models, `receive_amarr_fleet_pings` channel flag, and smoke-test management command.
- Wired into rollup writes so Discord failures cannot roll back feed event persistence.

## Test plan
- [x] `pipenv run python manage.py test feed.tests.test_amarr_fleet_pings discord.tests.DiscordChannelAdminFormTestCase --settings=app.settings_test`
- [ ] Enable `receive_amarr_fleet_pings` on a text/forum Discord channel in admin
- [ ] `pipenv run python manage.py test_amarr_fleet_ping --dry-run` then live smoke send
- [ ] Confirm an Amarr `fleet_active` rollup creates a Discord message and a later update edits it instead of posting a new one


Made with [Cursor](https://cursor.com)