### PR TITLE
Fix Amarr fleet ping spam from rollup catch-up

### DIFF
--- a/backend/feed/constants.py
+++ b/backend/feed/constants.py
@@ -145,6 +145,9 @@ CAPITAL_PING_SESSION_SECONDS = 30 * 60
 # Amarr fleet Discord pings (fleet_active rollups). Reuse one Discord message
 # for further updates to the same system engagement within the session TTL.
 AMARR_FLEET_PING_SESSION_SECONDS = 30 * 60
+# Skip rollup catch-up / historical rewrites. Only live fleets whose tip is
+# fresher than this should create Discord traffic.
+AMARR_FLEET_PING_MAX_AGE_SECONDS = 20 * 60
 METERS_PER_LIGHT_YEAR = 9_460_528_400_000_000
 CAPITAL_SHIP_GROUPS = frozenset(
     {

--- a/backend/feed/helpers/amarr_fleet_pings.py
+++ b/backend/feed/helpers/amarr_fleet_pings.py
@@ -8,7 +8,10 @@ from django.utils import timezone
 
 from discord.client import DiscordClient
 from discord.models import DiscordChannel
-from feed.constants import AMARR_FLEET_PING_SESSION_SECONDS
+from feed.constants import (
+    AMARR_FLEET_PING_MAX_AGE_SECONDS,
+    AMARR_FLEET_PING_SESSION_SECONDS,
+)
 from feed.models import FeedAmarrFleetAlert, FeedAmarrFleetPing, FeedEvent
 
 logger = logging.getLogger(__name__)
@@ -162,7 +165,17 @@ def _event_snapshot(event: FeedEvent) -> dict[str, Any]:
         "roster": list(payload.get("roster") or []),
         "roster_total": int(payload.get("roster_total") or 0),
         "cluster_key": event.cluster_key or "",
+        "is_active": bool(event.is_active),
+        "occurred_at": event.occurred_at,
     }
+
+
+def _is_fresh_fleet(event: FeedEvent) -> bool:
+    """True when the fleet tip is recent enough to warrant Discord traffic."""
+    if event.occurred_at is None:
+        return False
+    age_seconds = (timezone.now() - event.occurred_at).total_seconds()
+    return age_seconds <= AMARR_FLEET_PING_MAX_AGE_SECONDS
 
 
 def _active_alert(solar_system_id: int) -> FeedAmarrFleetAlert | None:
@@ -178,6 +191,25 @@ def _active_alert(solar_system_id: int) -> FeedAmarrFleetAlert | None:
         .order_by("-last_activity_at")
         .first()
     )
+
+
+def _alert_for_cluster(cluster_key: str) -> FeedAmarrFleetAlert | None:
+    """Return the alert previously used for this cluster, if still in session."""
+    if not cluster_key:
+        return None
+    ping = (
+        FeedAmarrFleetPing.objects.select_related("alert")
+        .filter(cluster_key=cluster_key, alert__isnull=False)
+        .first()
+    )
+    if ping is None or ping.alert is None:
+        return None
+    cutoff = timezone.now() - timedelta(
+        seconds=AMARR_FLEET_PING_SESSION_SECONDS
+    )
+    if ping.alert.last_activity_at < cutoff:
+        return None
+    return ping.alert
 
 
 def _post_alert_messages(
@@ -379,6 +411,11 @@ def maybe_notify_amarr_fleet(
     """Create or update a Discord Amarr fleet alert from a feed event.
 
     Returns True if a Discord message was created or edited, False if skipped.
+
+    Guards against rollup catch-up spam:
+    - Only active fleets with a fresh ``occurred_at`` may create new messages.
+    - Cluster keys that were already pinged never create a second message;
+      they only edit an in-session alert when one still exists.
     """
     if not _amarr_fleet_ping_channel_ids() or not _is_amarr_fleet_event(event):
         return False
@@ -392,7 +429,18 @@ def maybe_notify_amarr_fleet(
         return False
 
     client = discord_client or DiscordClient()
-    existing = _active_alert(snapshot["solar_system_id"])
+    existing = _alert_for_cluster(snapshot["cluster_key"]) or _active_alert(
+        snapshot["solar_system_id"]
+    )
+    already_pinged = FeedAmarrFleetPing.objects.filter(
+        cluster_key=snapshot["cluster_key"]
+    ).exists()
+
+    # Historical / inactive rollup rewrites: never open a new Discord thread.
+    if existing is None:
+        if already_pinged or not event.is_active or not _is_fresh_fleet(event):
+            return False
+
     try:
         alert, created = _upsert_amarr_fleet_alert(
             snapshot=snapshot,

--- a/backend/feed/tests/test_amarr_fleet_pings.py
+++ b/backend/feed/tests/test_amarr_fleet_pings.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
@@ -196,6 +197,50 @@ class AmarrFleetPingTestCase(TestCase):
         self.assertEqual(FeedAmarrFleetAlert.objects.count(), 0)
 
     @patch("feed.helpers.amarr_fleet_pings.DiscordClient")
+    def test_skips_inactive_and_stale_fleets(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+
+        inactive = _amarr_event(
+            cluster_key="fleet_active:30002537:500003:2026-07-29T10:00"
+        )
+        inactive.is_active = False
+        inactive.save()
+        self.assertFalse(maybe_notify_amarr_fleet(inactive))
+
+        stale = _amarr_event(
+            cluster_key="fleet_active:30002537:500003:2026-07-29T11:00"
+        )
+        stale.occurred_at = timezone.now() - timedelta(hours=3)
+        stale.save()
+        self.assertFalse(maybe_notify_amarr_fleet(stale))
+        mock_client.create_message.assert_not_called()
+
+    @patch("feed.helpers.amarr_fleet_pings.DiscordClient")
+    def test_skips_already_pinged_cluster_without_session(
+        self, mock_client_cls
+    ):
+        mock_client = MagicMock()
+        create_response = MagicMock()
+        create_response.json.return_value = {"id": "999888704"}
+        mock_client.create_message.return_value = create_response
+        mock_client_cls.return_value = mock_client
+
+        event = _amarr_event()
+        self.assertTrue(maybe_notify_amarr_fleet(event))
+        alert = FeedAmarrFleetAlert.objects.get()
+        # Expire the session so catch-up cannot open a second message.
+        alert.last_activity_at = timezone.now() - timedelta(hours=2)
+        alert.save(update_fields=["last_activity_at"])
+
+        mock_client.create_message.reset_mock()
+        mock_client.update_message.reset_mock()
+        self.assertFalse(maybe_notify_amarr_fleet(event))
+        mock_client.create_message.assert_not_called()
+        mock_client.update_message.assert_not_called()
+        self.assertEqual(FeedAmarrFleetAlert.objects.count(), 1)
+
+    @patch("feed.helpers.amarr_fleet_pings.DiscordClient")
     def test_writer_notifies_amarr_fleet_active(self, mock_client_cls):
         mock_client = MagicMock()
         create_response = MagicMock()
@@ -235,3 +280,39 @@ class AmarrFleetPingTestCase(TestCase):
         self.assertEqual(FeedAmarrFleetAlert.objects.count(), 1)
         self.assertEqual(FeedAmarrFleetPing.objects.count(), 1)
         mock_client.create_message.assert_called_once()
+
+    @patch("feed.helpers.amarr_fleet_pings.DiscordClient")
+    def test_writer_skips_historical_amarr_catchup(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+
+        write_rollup_results(
+            [
+                RollupResult(
+                    kind=FeedEvent.Kind.FLEET_ACTIVE,
+                    occurred_at=timezone.now() - timedelta(hours=5),
+                    title="Large Amarr gang active",
+                    subheader="Vard · 14 kills · 23 pilots · ~19m",
+                    preview="Large gang involving battlecruisers.",
+                    body="",
+                    accent=FeedEvent.Accent.AMARR,
+                    payload={
+                        "faction": "amarr",
+                        "system_id": 30002538,
+                        "system_name": "Vard",
+                        "kills": 14,
+                        "pilots": 23,
+                        "roster": [],
+                        "roster_total": 23,
+                    },
+                    rollup_code="fleet_active",
+                    rollup_version=1,
+                    cluster_key="fleet_active:30002538:500003:2026-07-29T12:00",
+                    is_active=False,
+                )
+            ]
+        )
+
+        self.assertEqual(FeedEvent.objects.count(), 1)
+        self.assertEqual(FeedAmarrFleetAlert.objects.count(), 0)
+        mock_client.create_message.assert_not_called()


### PR DESCRIPTION
## Summary
- Rollup rewrites were notifying on every Amarr `fleet_active` event in the lookback window (including inactive/historical ones), which flooded Discord on deploy/catch-up.
- New Discord messages now require `is_active` and `occurred_at` within 20 minutes.
- Already-pinged cluster keys never create a second message; they only edit an in-session alert.

## Test plan
- [x] `pipenv run python manage.py test feed.tests.test_amarr_fleet_pings --settings=app.settings_test`
- [ ] After deploy, confirm the next `run_feed_rollups` cycle does not post a burst of historical Amarr fleet embeds
- [ ] Confirm a live Amarr fleet still creates one message and subsequent updates edit it


Made with [Cursor](https://cursor.com)