### PR TITLE
Hide FW guide matchup charts on mobile

### DIFF
--- a/frontend/app/src/components/blocks/faction-warfare-cruiser-guide/FactionWarfareCruiserGuide.astro
+++ b/frontend/app/src/components/blocks/faction-warfare-cruiser-guide/FactionWarfareCruiserGuide.astro
@@ -87,28 +87,34 @@ try {
             <section id="matchups" data-section-id="matchups" class="fwc-section fwc-panel" aria-labelledby="fwc-matchups-title">
                 <h2 id="fwc-matchups-title" class="fwc-section__title">Matchup Charts</h2>
 
-                <div class="fwc-legend" aria-label="Matchup rating legend">
-                    {
-                        matchupLegend.map((item) => (
-                            <div class="fwc-legend__item">
-                                <span class:list={['fwc-legend__symbol', `fwc-legend__symbol--${item.rating === '?' ? 'unknown' : item.rating.replace(/\+/g, 'plus').replace(/-/g, 'minus').replace(/=/g, 'even')}`]}>
-                                    {item.rating}
-                                </span>
-                                <span class="fwc-legend__label">
-                                    <strong>{item.label}</strong>
-                                    <span>{item.description}</span>
-                                </span>
-                            </div>
-                        ))
-                    }
-                </div>
+                <p class="fwc-charts-mobile-note">
+                    Matchup charts are available on desktop.
+                </p>
 
-                <div class="fwc-charts-grid">
-                    {
-                        matchupCharts.map((chart) => (
-                            <FactionWarfareCruiserGuideMatchupChart chart={chart} />
-                        ))
-                    }
+                <div class="fwc-charts-desktop">
+                    <div class="fwc-legend" aria-label="Matchup rating legend">
+                        {
+                            matchupLegend.map((item) => (
+                                <div class="fwc-legend__item">
+                                    <span class:list={['fwc-legend__symbol', `fwc-legend__symbol--${item.rating === '?' ? 'unknown' : item.rating.replace(/\+/g, 'plus').replace(/-/g, 'minus').replace(/=/g, 'even')}`]}>
+                                        {item.rating}
+                                    </span>
+                                    <span class="fwc-legend__label">
+                                        <strong>{item.label}</strong>
+                                        <span>{item.description}</span>
+                                    </span>
+                                </div>
+                            ))
+                        }
+                    </div>
+
+                    <div class="fwc-charts-grid">
+                        {
+                            matchupCharts.map((chart) => (
+                                <FactionWarfareCruiserGuideMatchupChart chart={chart} />
+                            ))
+                        }
+                    </div>
                 </div>
             </section>
 
@@ -384,6 +390,30 @@ try {
 
         .fwc-legend__label span {
             font-size: var(--step--1);
+        }
+    }
+
+    .fwc-charts-mobile-note {
+        margin: 0;
+        padding: var(--space-s);
+        border: 1px solid color-mix(in srgb, var(--border-color) 55%, transparent);
+        background: color-mix(in srgb, var(--component-background) 55%, transparent);
+        font-size: var(--step--1);
+        line-height: 1.55;
+        color: var(--text-color-secondary, var(--faded));
+    }
+
+    .fwc-charts-desktop {
+        display: none;
+    }
+
+    @media (min-width: 48rem) {
+        .fwc-charts-mobile-note {
+            display: none;
+        }
+
+        .fwc-charts-desktop {
+            display: contents;
         }
     }
 

--- a/frontend/app/src/components/blocks/navy-destroyer-metagame/NavyDestroyerMetagame.astro
+++ b/frontend/app/src/components/blocks/navy-destroyer-metagame/NavyDestroyerMetagame.astro
@@ -87,28 +87,34 @@ try {
             <section id="matchups" data-section-id="matchups" class="ndm-section ndm-panel" aria-labelledby="ndm-matchups-title">
                 <h2 id="ndm-matchups-title" class="ndm-section__title">Matchup Charts</h2>
 
-                <div class="ndm-legend" aria-label="Matchup rating legend">
-                    {
-                        matchupLegend.map((item) => (
-                            <div class="ndm-legend__item">
-                                <span class:list={['ndm-legend__symbol', `ndm-legend__symbol--${item.rating === '?' ? 'unknown' : item.rating.replace(/\+/g, 'plus').replace(/-/g, 'minus').replace(/=/g, 'even')}`]}>
-                                    {item.rating}
-                                </span>
-                                <span class="ndm-legend__label">
-                                    <strong>{item.label}</strong>
-                                    <span>{item.description}</span>
-                                </span>
-                            </div>
-                        ))
-                    }
-                </div>
+                <p class="ndm-charts-mobile-note">
+                    Matchup charts are available on desktop.
+                </p>
 
-                <div class="ndm-charts-grid">
-                    {
-                        matchupCharts.map((chart) => (
-                            <NavyDestroyerMetagameMatchupChart chart={chart} />
-                        ))
-                    }
+                <div class="ndm-charts-desktop">
+                    <div class="ndm-legend" aria-label="Matchup rating legend">
+                        {
+                            matchupLegend.map((item) => (
+                                <div class="ndm-legend__item">
+                                    <span class:list={['ndm-legend__symbol', `ndm-legend__symbol--${item.rating === '?' ? 'unknown' : item.rating.replace(/\+/g, 'plus').replace(/-/g, 'minus').replace(/=/g, 'even')}`]}>
+                                        {item.rating}
+                                    </span>
+                                    <span class="ndm-legend__label">
+                                        <strong>{item.label}</strong>
+                                        <span>{item.description}</span>
+                                    </span>
+                                </div>
+                            ))
+                        }
+                    </div>
+
+                    <div class="ndm-charts-grid">
+                        {
+                            matchupCharts.map((chart) => (
+                                <NavyDestroyerMetagameMatchupChart chart={chart} />
+                            ))
+                        }
+                    </div>
                 </div>
             </section>
 
@@ -446,6 +452,30 @@ try {
 
         .ndm-legend__label span {
             font-size: var(--step--1);
+        }
+    }
+
+    .ndm-charts-mobile-note {
+        margin: 0;
+        padding: var(--space-s);
+        border: 1px solid color-mix(in srgb, var(--border-color) 55%, transparent);
+        background: color-mix(in srgb, var(--component-background) 55%, transparent);
+        font-size: var(--step--1);
+        line-height: 1.55;
+        color: var(--text-color-secondary, var(--faded));
+    }
+
+    .ndm-charts-desktop {
+        display: none;
+    }
+
+    @media (min-width: 48rem) {
+        .ndm-charts-mobile-note {
+            display: none;
+        }
+
+        .ndm-charts-desktop {
+            display: contents;
         }
     }
 

--- a/frontend/app/src/components/blocks/navy-frigate-guide/NavyFrigateGuide.astro
+++ b/frontend/app/src/components/blocks/navy-frigate-guide/NavyFrigateGuide.astro
@@ -86,28 +86,34 @@ try {
             <section id="matchups" data-section-id="matchups" class="nfg-section nfg-panel" aria-labelledby="nfg-matchups-title">
                 <h2 id="nfg-matchups-title" class="nfg-section__title">Matchup Charts</h2>
 
-                <div class="nfg-legend" aria-label="Matchup rating legend">
-                    {
-                        matchupLegend.map((item) => (
-                            <div class="nfg-legend__item">
-                                <span class:list={['nfg-legend__symbol', `nfg-legend__symbol--${item.rating === '?' ? 'unknown' : item.rating.replace(/\+/g, 'plus').replace(/-/g, 'minus').replace(/=/g, 'even')}`]}>
-                                    {item.rating}
-                                </span>
-                                <span class="nfg-legend__label">
-                                    <strong>{item.label}</strong>
-                                    <span>{item.description}</span>
-                                </span>
-                            </div>
-                        ))
-                    }
-                </div>
+                <p class="nfg-charts-mobile-note">
+                    Matchup charts are available on desktop.
+                </p>
 
-                <div class="nfg-charts-grid">
-                    {
-                        matchupCharts.map((chart) => (
-                            <NavyFrigateGuideMatchupChart chart={chart} />
-                        ))
-                    }
+                <div class="nfg-charts-desktop">
+                    <div class="nfg-legend" aria-label="Matchup rating legend">
+                        {
+                            matchupLegend.map((item) => (
+                                <div class="nfg-legend__item">
+                                    <span class:list={['nfg-legend__symbol', `nfg-legend__symbol--${item.rating === '?' ? 'unknown' : item.rating.replace(/\+/g, 'plus').replace(/-/g, 'minus').replace(/=/g, 'even')}`]}>
+                                        {item.rating}
+                                    </span>
+                                    <span class="nfg-legend__label">
+                                        <strong>{item.label}</strong>
+                                        <span>{item.description}</span>
+                                    </span>
+                                </div>
+                            ))
+                        }
+                    </div>
+
+                    <div class="nfg-charts-grid">
+                        {
+                            matchupCharts.map((chart) => (
+                                <NavyFrigateGuideMatchupChart chart={chart} />
+                            ))
+                        }
+                    </div>
                 </div>
             </section>
 
@@ -361,6 +367,30 @@ try {
 
         .nfg-legend__label span {
             font-size: var(--step--1);
+        }
+    }
+
+    .nfg-charts-mobile-note {
+        margin: 0;
+        padding: var(--space-s);
+        border: 1px solid color-mix(in srgb, var(--border-color) 55%, transparent);
+        background: color-mix(in srgb, var(--component-background) 55%, transparent);
+        font-size: var(--step--1);
+        line-height: 1.55;
+        color: var(--text-color-secondary, var(--faded));
+    }
+
+    .nfg-charts-desktop {
+        display: none;
+    }
+
+    @media (min-width: 48rem) {
+        .nfg-charts-mobile-note {
+            display: none;
+        }
+
+        .nfg-charts-desktop {
+            display: contents;
         }
     }
 


### PR DESCRIPTION
## Summary
- Hide the matchup chart legend and matrices on viewports under 48rem for the frigate, destroyer, and cruiser guides
- Show a short note that matchup charts are available on desktop
- Leave per-ship matchup notes unchanged

## Test plan
- [ ] Open frigate, destroyer, and cruiser guides on a narrow viewport and confirm charts are replaced by the desktop note
- [ ] Widen past ~768px and confirm legend + charts render as before
- [ ] Confirm per-ship matchup cards still appear on mobile


Made with [Cursor](https://cursor.com)