### PR TITLE
Add executor notes to corporation learn-more

### DIFF
--- a/backend/eveonline/endpoints/corporations/get_corporation_by_id.py
+++ b/backend/eveonline/endpoints/corporations/get_corporation_by_id.py
@@ -24,6 +24,7 @@ def get_corporation_by_id(request, corporation_id: int):
         "corporation_name": corporation.name,
         "introduction": corporation.introduction,
         "biography": corporation.biography,
+        "executor_notes": corporation.executor_notes,
         "timezones": (
             corporation.timezones.strip().split(",")
             if corporation.timezones

--- a/backend/eveonline/endpoints/corporations/get_corporation_info.py
+++ b/backend/eveonline/endpoints/corporations/get_corporation_info.py
@@ -26,6 +26,7 @@ def get_corporation_info(request, corporation_id: int):
         "corporation_name": corporation.name,
         "introduction": corporation.introduction,
         "biography": corporation.biography,
+        "executor_notes": corporation.executor_notes,
         "timezones": (
             corporation.timezones.strip().split(",")
             if corporation.timezones

--- a/backend/eveonline/endpoints/corporations/get_corporations.py
+++ b/backend/eveonline/endpoints/corporations/get_corporations.py
@@ -55,6 +55,7 @@ def get_corporations(
             payload["faction_name"] = corporation.faction.name
         payload["introduction"] = corporation.introduction
         payload["biography"] = corporation.biography
+        payload["executor_notes"] = corporation.executor_notes
         payload["timezones"] = (
             corporation.timezones.strip().split(",")
             if corporation.timezones

--- a/backend/eveonline/endpoints/corporations/schemas.py
+++ b/backend/eveonline/endpoints/corporations/schemas.py
@@ -37,6 +37,7 @@ class CorporationResponse(Schema):
     type: CorporationType
     introduction: Optional[str] = None
     biography: Optional[str] = None
+    executor_notes: Optional[str] = None
     timezones: Optional[List[str]] = None
     requirements: Optional[List[str]] = None
     members: List[CorporationMemberResponse] = []
@@ -56,6 +57,7 @@ class CorporationInfoResponse(Schema):
     type: CorporationType
     introduction: Optional[str] = None
     biography: Optional[str] = None
+    executor_notes: Optional[str] = None
     timezones: Optional[List[str]] = None
     requirements: Optional[List[str]] = None
     active: bool

--- a/backend/eveonline/migrations/0099_evecorporation_executor_notes.py
+++ b/backend/eveonline/migrations/0099_evecorporation_executor_notes.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("eveonline", "0098_unique_active_staging_location"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="evecorporation",
+            name="executor_notes",
+            field=models.TextField(blank=True),
+        ),
+    ]

--- a/backend/eveonline/models/corporations.py
+++ b/backend/eveonline/models/corporations.py
@@ -16,6 +16,7 @@ class EveCorporation(models.Model):
     corporation_id = models.IntegerField(unique=True)
     introduction = models.TextField(blank=True)
     biography = models.TextField(blank=True)
+    executor_notes = models.TextField(blank=True)
     timezones = models.TextField(blank=True)
     requirements = models.TextField(blank=True)
     name = models.CharField(max_length=255, blank=True)

--- a/backend/eveonline/tests/routers/test_corps.py
+++ b/backend/eveonline/tests/routers/test_corps.py
@@ -43,6 +43,7 @@ class CorporationRouterTestCase(TestCase):
             corporation_id=corp_id,
             introduction="Intro",
             biography="Bio",
+            executor_notes="Executor notes",
             timezones="TZ",
             requirements="Req",
             name=corp_name,
@@ -84,6 +85,21 @@ class CorporationRouterTestCase(TestCase):
         corp = response.json()
         self.assertEqual(12345, corp["corporation_id"])
         self.assertEqual("TestCorp", corp["corporation_name"])
+        self.assertEqual("Executor notes", corp["executor_notes"])
+
+    def test_get_corporation_info(self):
+        self.create_corp(12345, "TestCorp")
+
+        response = self.client.get(
+            BASE_URL + "corporations/12345/info",
+        )
+
+        self.assertEqual(200, response.status_code)
+        corp = response.json()
+        self.assertEqual(12345, corp["corporation_id"])
+        self.assertEqual("TestCorp", corp["corporation_name"])
+        self.assertEqual("Executor notes", corp["executor_notes"])
+        self.assertEqual("Bio", corp["biography"])
 
     def test_update_affiliations(self):
         EveCharacter.objects.create(

--- a/frontend/app/src/components/blocks/ButtonCeoToken.astro
+++ b/frontend/app/src/components/blocks/ButtonCeoToken.astro
@@ -39,6 +39,7 @@ const params:Params = {
     corporation_type: corporation.corporation_type,
     active: corporation.active,
     biography: corporation.biography,
+    executor_notes: corporation.executor_notes,
     introduction: corporation.introduction,
     requirements: corporation.requirements,
     timezones: corporation.timezones,

--- a/frontend/app/src/components/blocks/CorporationInfo.astro
+++ b/frontend/app/src/components/blocks/CorporationInfo.astro
@@ -132,13 +132,6 @@ const timezones = corporation?.timezones?.length ?? 0 > 0 ? corporation?.timezon
                     </SectionH4>
                 </ComponentBlock>
             }
-            {corporation?.executor_notes !== '' &&
-                <ComponentBlock>
-                    <SectionH4 heading_text={t('executor_notes')}>
-                        <Markdown markdown={corporation?.executor_notes as string} />
-                    </SectionH4>
-                </ComponentBlock>
-            }
             {(corporation?.timezones.length ?? 0) > 0 &&
                 <ComponentBlock>
                     <SectionH4 heading_text={t('timezones')}>
@@ -150,6 +143,13 @@ const timezones = corporation?.timezones?.length ?? 0 > 0 ? corporation?.timezon
                 <ComponentBlock>
                     <SectionH4 heading_text={t('requirements')}>
                         <Markdown markdown={corporation?.requirements.join('') as string} />
+                    </SectionH4>
+                </ComponentBlock>
+            }
+            {corporation?.executor_notes !== '' &&
+                <ComponentBlock>
+                    <SectionH4 heading_text={t('executor_notes')}>
+                        <Markdown markdown={corporation?.executor_notes as string} />
                     </SectionH4>
                 </ComponentBlock>
             }

--- a/frontend/app/src/components/blocks/CorporationInfo.astro
+++ b/frontend/app/src/components/blocks/CorporationInfo.astro
@@ -132,6 +132,13 @@ const timezones = corporation?.timezones?.length ?? 0 > 0 ? corporation?.timezon
                     </SectionH4>
                 </ComponentBlock>
             }
+            {corporation?.executor_notes !== '' &&
+                <ComponentBlock>
+                    <SectionH4 heading_text={t('executor_notes')}>
+                        <Markdown markdown={corporation?.executor_notes as string} />
+                    </SectionH4>
+                </ComponentBlock>
+            }
             {(corporation?.timezones.length ?? 0) > 0 &&
                 <ComponentBlock>
                     <SectionH4 heading_text={t('timezones')}>

--- a/frontend/app/src/helpers/fetching/corporations.ts
+++ b/frontend/app/src/helpers/fetching/corporations.ts
@@ -17,21 +17,22 @@ const MINMATAR_EXTRACTION_COMPANY_ID = 98838663
 // fetched separately and appended to the list.
 const append_extraction_corporation = async (api_corporations:Corporation[]) => {
     try {
-        const extractions_info = await get_corporation_info(MINMATAR_EXTRACTION_COMPANY_ID)
+        const extraction_info = await get_corporation_info(MINMATAR_EXTRACTION_COMPANY_ID)
 
         api_corporations.push({
-            active: extractions_info.active,
-            alliance_id: extractions_info.alliance_id,
-            alliance_name: extractions_info.alliance_name,
-            biography: extractions_info.biography,
-            corporation_id: extractions_info.corporation_id,
-            corporation_name: extractions_info.corporation_name,
-            faction_id: extractions_info.faction_id,
-            faction_name: extractions_info.faction_name,
-            introduction: extractions_info.introduction,
-            requirements: extractions_info.requirements,
-            timezones: extractions_info.timezones,
-            type: extractions_info.type,
+            active: extraction_info.active,
+            alliance_id: extraction_info.alliance_id,
+            alliance_name: extraction_info.alliance_name,
+            biography: extraction_info.biography,
+            executor_notes: extraction_info.executor_notes,
+            corporation_id: extraction_info.corporation_id,
+            corporation_name: extraction_info.corporation_name,
+            faction_id: extraction_info.faction_id,
+            faction_name: extraction_info.faction_name,
+            introduction: extraction_info.introduction,
+            requirements: extraction_info.requirements,
+            timezones: extraction_info.timezones,
+            type: extraction_info.type,
             members: [],
         })
     } catch (error) {
@@ -71,6 +72,7 @@ export async function get_corporations_list(corporation_type:CorporationType) {
             corporation_type: i.type,
             active: i.active,
             biography: i.biography,
+            executor_notes: i.executor_notes,
             introduction: i.introduction,
             requirements: i.requirements,
             timezones: i.timezones,
@@ -101,6 +103,7 @@ const add_status_to_corporation = async (access_token:string, api_corporation:Co
         active: api_corporation.active,
         status: 'available',
         biography: api_corporation.biography,
+        executor_notes: api_corporation.executor_notes,
         introduction: api_corporation.introduction,
         requirements: api_corporation.requirements,
         timezones: api_corporation.timezones,

--- a/frontend/app/src/i18n/ui.ts
+++ b/frontend/app/src/i18n/ui.ts
@@ -1062,6 +1062,7 @@ export const ui = {
         'waiting_fleet_time': 'Waiting for fleet time',
         'create': 'Create',
         'description': 'Description',
+        'executor_notes': 'Executor notes',
         'confirm': 'Confirm',
         'fleet_submit': 'Fleet submit',
         'push_button': 'Push the button!',

--- a/frontend/app/src/pages/partials/corporation_request_status_item.astro
+++ b/frontend/app/src/pages/partials/corporation_request_status_item.astro
@@ -88,6 +88,7 @@ if (create_corporation_application_error) {
             corporation_type: corporation.corporation_type,
             active: corporation.active,
             biography: corporation.biography,
+            executor_notes: corporation.executor_notes,
             introduction: corporation.introduction,
             requirements: corporation.requirements,
             timezones: corporation.timezones,

--- a/frontend/app/src/pages/partials/corporation_slide_request_status_item.astro
+++ b/frontend/app/src/pages/partials/corporation_slide_request_status_item.astro
@@ -85,6 +85,7 @@ if (create_corporation_application_error) {
             corporation_type: corporation.corporation_type,
             active: corporation.active,
             biography: corporation.biography,
+            executor_notes: corporation.executor_notes,
             introduction: corporation.introduction,
             requirements: corporation.requirements,
             timezones: corporation.timezones,

--- a/frontend/app/src/types/api.minmatar.org.ts
+++ b/frontend/app/src/types/api.minmatar.org.ts
@@ -295,6 +295,7 @@ export interface Corporation {
     type:               CorporationType;
     introduction:       string;
     biography:          string;
+    executor_notes:     string;
     timezones:          string[];
     requirements:       string[];
     members:            CharacterCorp[];
@@ -311,6 +312,7 @@ export interface CorporationInfo {
     type:               CorporationType;
     introduction:       string;
     biography:          string;
+    executor_notes:     string;
     timezones:          string[];
     requirements:       string[];
     active:             boolean;

--- a/frontend/app/src/types/layout_components.ts
+++ b/frontend/app/src/types/layout_components.ts
@@ -347,6 +347,7 @@ export interface CorporationObject {
     application_updated?:   Date;
     introduction?:          string;
     biography?:             string;
+    executor_notes?:        string;
     timezones?:             string[];
     requirements?:          string[];
 }

--- a/frontend/app/testing/components/blocks/CorporationInfo.test.ts
+++ b/frontend/app/testing/components/blocks/CorporationInfo.test.ts
@@ -18,6 +18,7 @@ test("CorporationInfo defaults", async () => {
     faction_name: "minmatar",
     requirements: ["chicken"],
     biography: "",
+    executor_notes: "",
     introduction: "",
     timezones: [],
     type: "alliance",


### PR DESCRIPTION
## Summary
- Add an `executor_notes` field on corporations (admin-editable) and expose it on corporation API responses.
- Show an **Executor notes** section at the bottom of the corporation learn-more modal when notes are present.

## Test plan
- [ ] Run migration `0099_evecorporation_executor_notes`
- [ ] Set executor notes on a corp in Django admin
- [ ] Open corporation learn-more and confirm notes render below description, timezones, and requirements
- [ ] Confirm corps without notes omit the section
- [ ] `pipenv run python manage.py test eveonline.tests.routers.test_corps --settings=app.settings_test`


Made with [Cursor](https://cursor.com)