### PR TITLE
Fix Sentry production errors for Discord rate limits and feed races

### DIFF
--- a/backend/discord/client.py
+++ b/backend/discord/client.py
@@ -49,6 +49,16 @@ class DiscordError(Exception):
         return e
 
 
+def _raise_discord_rate_limit(response: requests.Response) -> None:
+    """Raise RateLimitException with Discord Retry-After for backoff retries."""
+    raw = response.headers.get("Retry-After", "1")
+    try:
+        period_remaining = float(raw)
+    except (TypeError, ValueError):
+        period_remaining = 1.0
+    raise RateLimitException("Discord API rate limited", period_remaining)
+
+
 class DiscordBaseClient:
     """Base Discord API Client"""
 
@@ -73,7 +83,7 @@ class DiscordBaseClient:
             timeout=10,
         )
         if response.status_code == 429:
-            raise RateLimitException
+            _raise_discord_rate_limit(response)
         if response.status_code == 400:
             logger.error(response.json())
         response.raise_for_status()
@@ -91,7 +101,7 @@ class DiscordBaseClient:
             timeout=10,
         )
         if response.status_code == 429:
-            raise RateLimitException
+            _raise_discord_rate_limit(response)
         response.raise_for_status()
         return response
 
@@ -107,7 +117,7 @@ class DiscordBaseClient:
             timeout=10,
         )
         if response.status_code == 429:
-            raise RateLimitException
+            _raise_discord_rate_limit(response)
         response.raise_for_status()
         return response
 
@@ -123,7 +133,7 @@ class DiscordBaseClient:
             timeout=10,
         )
         if response.status_code == 429:
-            raise RateLimitException
+            _raise_discord_rate_limit(response)
         response.raise_for_status()
         return response.json()
 
@@ -138,7 +148,7 @@ class DiscordBaseClient:
             timeout=10,
         )
         if response.status_code == 429:
-            raise RateLimitException
+            _raise_discord_rate_limit(response)
         if response.status_code == 404:
             # Don't throw exception for failing to delete if it doesn't exist
             return response

--- a/backend/discord/tests.py
+++ b/backend/discord/tests.py
@@ -4,6 +4,8 @@ from unittest.mock import patch, Mock, MagicMock
 from django.contrib.auth.models import User, Group
 from django.test import SimpleTestCase, Client
 from django.db.models import signals
+from ratelimit import RateLimitException
+from requests.exceptions import HTTPError
 
 from eveonline.models import (
     EveCharacter,
@@ -12,19 +14,10 @@ from eveonline.models import (
 from eveonline.helpers.characters import set_primary_character
 
 from app.test import TestCase
+from discord.client import _raise_discord_rate_limit
 from discord.core import DISCORD_NICKNAME_MAX_LENGTH, make_nickname
-from discord.models import (
-    DiscordUser,
-    DiscordRole,
-    DiscordChannelActivityRecord,
-    DiscordChannel,
-    DiscordGuild,
-)
 from discord.forms import DiscordChannelAdminForm
 from discord.guilds import sync_discord_guilds
-from discord.views import discord_login_redirect, fake_login
-
-from discord.tasks import sync_discord_nickname, sync_discord_user
 from discord.helpers import (
     get_discord_user,
     handle_discord_guild_member_error,
@@ -32,12 +25,19 @@ from discord.helpers import (
     remove_all_roles_from_guild_member,
     find_unregistered_guild_members,
 )
+from discord.models import (
+    DiscordUser,
+    DiscordRole,
+    DiscordChannelActivityRecord,
+    DiscordChannel,
+    DiscordGuild,
+)
 from discord.signals import (
     group_post_save,
     resolve_existing_discord_role_from_server,
 )
-
-from requests.exceptions import HTTPError
+from discord.tasks import sync_discord_nickname, sync_discord_user
+from discord.views import discord_login_redirect, fake_login
 
 
 class DiscordSimpleTests(SimpleTestCase):
@@ -71,6 +71,30 @@ class DiscordSimpleTests(SimpleTestCase):
         )
         self.assertTrue(nickname.startswith("[L3ARN] "))
         self.assertTrue(nickname.endswith("…"))
+
+
+class DiscordRateLimitTests(SimpleTestCase):
+    def test_raise_discord_rate_limit_uses_retry_after(self):
+        response = MagicMock()
+        response.headers = {"Retry-After": "2.5"}
+        with self.assertRaises(RateLimitException) as ctx:
+            _raise_discord_rate_limit(response)
+        self.assertEqual(ctx.exception.period_remaining, 2.5)
+        self.assertIn("rate limited", str(ctx.exception).lower())
+
+    def test_raise_discord_rate_limit_defaults_when_header_invalid(self):
+        response = MagicMock()
+        response.headers = {"Retry-After": "soon"}
+        with self.assertRaises(RateLimitException) as ctx:
+            _raise_discord_rate_limit(response)
+        self.assertEqual(ctx.exception.period_remaining, 1.0)
+
+    def test_raise_discord_rate_limit_defaults_when_header_missing(self):
+        response = MagicMock()
+        response.headers = {}
+        with self.assertRaises(RateLimitException) as ctx:
+            _raise_discord_rate_limit(response)
+        self.assertEqual(ctx.exception.period_remaining, 1.0)
 
 
 class DiscordSignalTests(TestCase):
@@ -718,6 +742,21 @@ class DiscordOffboardSyncTests(TestCase):
         )
         self.assertEqual(response.status_code, 410)
         self.assertIn(b"offboarded", response.content)
+
+    @patch("users.router.sync_discord_user")
+    @patch("users.router.update_affiliation")
+    def test_sync_user_endpoint_returns_404_when_user_missing(
+        self, mock_affiliation, mock_sync
+    ):
+        mock_affiliation.side_effect = User.DoesNotExist
+        client = Client()
+        response = client.post(
+            f"/api/users/{self.user.id}/sync",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertIn(b"not found", response.content)
+        mock_sync.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/backend/feed/constants.py
+++ b/backend/feed/constants.py
@@ -148,6 +148,8 @@ AMARR_FLEET_PING_SESSION_SECONDS = 30 * 60
 # Skip rollup catch-up / historical rewrites. Only live fleets whose tip is
 # fresher than this should create Discord traffic.
 AMARR_FLEET_PING_MAX_AGE_SECONDS = 20 * 60
+# Skip no-op Discord message edits within this window (rollups run ~3m).
+AMARR_FLEET_PING_EDIT_MIN_SECONDS = 90
 METERS_PER_LIGHT_YEAR = 9_460_528_400_000_000
 CAPITAL_SHIP_GROUPS = frozenset(
     {

--- a/backend/feed/helpers/amarr_fleet_pings.py
+++ b/backend/feed/helpers/amarr_fleet_pings.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from discord.client import DiscordClient
 from discord.models import DiscordChannel
 from feed.constants import (
+    AMARR_FLEET_PING_EDIT_MIN_SECONDS,
     AMARR_FLEET_PING_MAX_AGE_SECONDS,
     AMARR_FLEET_PING_SESSION_SECONDS,
 )
@@ -295,12 +296,43 @@ def _create_amarr_fleet_alert(
     )
 
 
+def _alert_content_changed(
+    alert: FeedAmarrFleetAlert, snapshot: dict[str, Any]
+) -> bool:
+    return (
+        alert.solar_system_id != snapshot["solar_system_id"]
+        or alert.system_name != snapshot["system_name"]
+        or alert.title != snapshot["title"]
+        or alert.subheader != snapshot["subheader"]
+        or alert.preview != snapshot["preview"]
+        or alert.kills != snapshot["kills"]
+        or alert.pilots != snapshot["pilots"]
+        or alert.roster != snapshot["roster"]
+        or alert.roster_total != snapshot["roster_total"]
+    )
+
+
+def _should_edit_discord(
+    alert: FeedAmarrFleetAlert,
+    snapshot: dict[str, Any],
+    *,
+    now,
+) -> bool:
+    """Edit Discord when content changed, or after the min edit interval."""
+    if _alert_content_changed(alert, snapshot):
+        return True
+    age = (now - alert.last_activity_at).total_seconds()
+    return age >= AMARR_FLEET_PING_EDIT_MIN_SECONDS
+
+
 def _update_amarr_fleet_alert(
     alert: FeedAmarrFleetAlert,
     *,
     snapshot: dict[str, Any],
     discord_client: DiscordClient,
 ) -> FeedAmarrFleetAlert:
+    now = timezone.now()
+    should_edit = _should_edit_discord(alert, snapshot, now=now)
     alert.systems = _append_system(
         _systems_for_alert(alert),
         solar_system_id=snapshot["solar_system_id"],
@@ -316,19 +348,22 @@ def _update_amarr_fleet_alert(
     alert.roster = snapshot["roster"]
     alert.roster_total = snapshot["roster_total"]
     alert.cluster_key = snapshot["cluster_key"] or alert.cluster_key
-    alert.last_activity_at = timezone.now()
-    discord_payload = build_amarr_fleet_alert_payload(
-        system_name=alert.system_name,
-        title=alert.title,
-        subheader=alert.subheader,
-        preview=alert.preview,
-        kills=alert.kills,
-        pilots=alert.pilots,
-        roster=alert.roster,
-        roster_total=alert.roster_total,
-        systems=alert.systems,
-    )
-    _edit_alert_messages(alert, discord_payload, discord_client=discord_client)
+    if should_edit:
+        alert.last_activity_at = now
+        discord_payload = build_amarr_fleet_alert_payload(
+            system_name=alert.system_name,
+            title=alert.title,
+            subheader=alert.subheader,
+            preview=alert.preview,
+            kills=alert.kills,
+            pilots=alert.pilots,
+            roster=alert.roster,
+            roster_total=alert.roster_total,
+            systems=alert.systems,
+        )
+        _edit_alert_messages(
+            alert, discord_payload, discord_client=discord_client
+        )
     alert.save(
         update_fields=[
             "solar_system_id",

--- a/backend/feed/rollups/writer.py
+++ b/backend/feed/rollups/writer.py
@@ -203,7 +203,11 @@ def _apply_upgrade_metadata(
 
     if changed:
         event.payload = payload
-        event.save(update_fields=["payload", "updated_at"])
+        # Concurrent coalesce may delete this row; queryset.update is race-safe.
+        FeedEvent.objects.filter(pk=event.pk).update(
+            payload=payload,
+            updated_at=timezone.now(),
+        )
 
 
 def _coalesce_fleet_active_event(
@@ -231,8 +235,12 @@ def _sync_killmail_links(event: FeedEvent, killmail_ids: list[int]) -> None:
         )
     )
     killmails = FeedKillmail.objects.filter(killmail_id__in=killmail_ids)
-    for km in killmails:
-        if km.id not in existing:
-            FeedEventKillmailLink.objects.create(
-                feed_event=event, feed_killmail=km
-            )
+    to_create = [
+        FeedEventKillmailLink(feed_event=event, feed_killmail=km)
+        for km in killmails
+        if km.id not in existing
+    ]
+    if to_create:
+        FeedEventKillmailLink.objects.bulk_create(
+            to_create, ignore_conflicts=True
+        )

--- a/backend/feed/tests/test_amarr_fleet_pings.py
+++ b/backend/feed/tests/test_amarr_fleet_pings.py
@@ -241,6 +241,47 @@ class AmarrFleetPingTestCase(TestCase):
         self.assertEqual(FeedAmarrFleetAlert.objects.count(), 1)
 
     @patch("feed.helpers.amarr_fleet_pings.DiscordClient")
+    def test_skips_noop_discord_edit_within_min_interval(
+        self, mock_client_cls
+    ):
+        mock_client = MagicMock()
+        create_response = MagicMock()
+        create_response.json.return_value = {"id": "999888705"}
+        mock_client.create_message.return_value = create_response
+        mock_client_cls.return_value = mock_client
+
+        event = _amarr_event()
+        self.assertTrue(maybe_notify_amarr_fleet(event))
+        mock_client.create_message.assert_called_once()
+        mock_client.update_message.reset_mock()
+
+        # Same content shortly after create — no Discord PATCH.
+        self.assertTrue(maybe_notify_amarr_fleet(event))
+        mock_client.update_message.assert_not_called()
+        alert = FeedAmarrFleetAlert.objects.get()
+        self.assertEqual(alert.kills, 12)
+
+    @patch("feed.helpers.amarr_fleet_pings.DiscordClient")
+    def test_edits_discord_after_min_interval_even_if_unchanged(
+        self, mock_client_cls
+    ):
+        mock_client = MagicMock()
+        create_response = MagicMock()
+        create_response.json.return_value = {"id": "999888706"}
+        mock_client.create_message.return_value = create_response
+        mock_client_cls.return_value = mock_client
+
+        event = _amarr_event()
+        self.assertTrue(maybe_notify_amarr_fleet(event))
+        alert = FeedAmarrFleetAlert.objects.get()
+        alert.last_activity_at = timezone.now() - timedelta(minutes=3)
+        alert.save(update_fields=["last_activity_at"])
+
+        mock_client.update_message.reset_mock()
+        self.assertTrue(maybe_notify_amarr_fleet(event))
+        mock_client.update_message.assert_called_once()
+
+    @patch("feed.helpers.amarr_fleet_pings.DiscordClient")
     def test_writer_notifies_amarr_fleet_active(self, mock_client_cls):
         mock_client = MagicMock()
         create_response = MagicMock()

--- a/backend/feed/tests/test_writer.py
+++ b/backend/feed/tests/test_writer.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 from django.test import TestCase
 from django.utils import timezone
 
-from feed.models import FeedEvent
+from feed.models import FeedEvent, FeedEventKillmailLink, FeedKillmail
 from feed.rollups.types import RollupResult
-from feed.rollups.writer import write_rollup_results
+from feed.rollups.writer import (
+    _apply_upgrade_metadata,
+    _sync_killmail_links,
+    write_rollup_results,
+)
 
 
 class WriterTestCase(TestCase):
@@ -163,3 +167,56 @@ class WriterTestCase(TestCase):
         self.assertEqual(
             FeedEvent.objects.filter(rollup_code="fleet_active").count(), 2
         )
+
+    def test_sync_killmail_links_is_idempotent(self):
+        event = FeedEvent.objects.create(
+            kind=FeedEvent.Kind.FLEET_ACTIVE,
+            rollup_code="fleet_active",
+            cluster_key="fleet_active:30002542:500002:idempotent",
+            occurred_at=timezone.now(),
+            title="Fleet",
+            subheader="",
+            preview="",
+            body="",
+            accent=FeedEvent.Accent.MILITIA,
+            payload={},
+            rollup_version=1,
+        )
+        km = FeedKillmail.objects.create(
+            killmail_id=137371129,
+            hash="abc",
+            killmail_time=timezone.now(),
+            solar_system_id=30002542,
+            raw_killmail={},
+        )
+        _sync_killmail_links(event, [km.killmail_id])
+        _sync_killmail_links(event, [km.killmail_id])
+        # Concurrent create path: existing link + bulk_create ignore_conflicts
+        FeedEventKillmailLink.objects.bulk_create(
+            [FeedEventKillmailLink(feed_event=event, feed_killmail=km)],
+            ignore_conflicts=True,
+        )
+        self.assertEqual(
+            FeedEventKillmailLink.objects.filter(feed_event=event).count(), 1
+        )
+
+    def test_apply_upgrade_metadata_tolerates_deleted_event(self):
+        event = FeedEvent.objects.create(
+            kind=FeedEvent.Kind.FLEET_ACTIVE,
+            rollup_code="fleet_active",
+            cluster_key="fleet_active:30002542:500002:deleted",
+            occurred_at=timezone.now(),
+            title="Major fleet",
+            subheader="",
+            preview="",
+            body="",
+            accent=FeedEvent.Accent.MILITIA,
+            payload={"engagement_tier": "major", "kills": 60, "pilots": 40},
+            rollup_version=1,
+        )
+        prior = [{"engagement_tier": "medium", "kills": 14, "pilots": 12}]
+        event_pk = event.pk
+        FeedEvent.objects.filter(pk=event_pk).delete()
+        # Must not raise DatabaseError when the row was concurrently deleted.
+        _apply_upgrade_metadata(event, prior)
+        self.assertFalse(FeedEvent.objects.filter(pk=event_pk).exists())

--- a/backend/users/router.py
+++ b/backend/users/router.py
@@ -286,13 +286,21 @@ def delete_account(request):
     summary="Sync user with Discord",
     description="This will sync the user with Discord. You can only sync your own account.",
     auth=AuthBearer(),
-    response={200: str, 403: ErrorResponse, 410: ErrorResponse},
+    response={
+        200: str,
+        403: ErrorResponse,
+        404: ErrorResponse,
+        410: ErrorResponse,
+    },
 )
 def sync_user(request, user_id: int):
     if request.user.id != user_id:
         return 403, ErrorResponse(detail="You can only sync your own account.")
-    update_affiliation(user_id)
-    sync_discord_user(user_id)
+    try:
+        update_affiliation(user_id)
+        sync_discord_user(user_id)
+    except User.DoesNotExist:
+        return 404, ErrorResponse(detail="User not found.")
     # sync_discord_user may offboard the account when Discord returns Unknown Member
     if not User.objects.filter(id=user_id).exists():
         return 410, ErrorResponse(


### PR DESCRIPTION
## Summary
- Fix Discord `RateLimitException` construction so 429s retry with backoff instead of TypeError spam (MINMATAR-CELERY-JJ), and skip no-op Amarr fleet Discord message edits within 90s
- Harden feed rollup writes: `bulk_create(ignore_conflicts=True)` for killmail links (HC) and race-safe `queryset.update` for upgrade metadata (JG)
- Return 404 from `/api/users/{id}/sync` when the user disappears mid-request (A5/MG)

## Test plan
- [x] `pipenv run python manage.py test discord.tests.DiscordRateLimitTests feed.tests.test_amarr_fleet_pings feed.tests.test_writer --settings=app.settings_test`
- [x] `pipenv run python manage.py test discord.tests.DiscordOffboardSyncTests --settings=app.settings_test`
- [ ] Confirm Amarr fleet Discord pings still update on kills/system changes after deploy
- [ ] Watch MINMATAR-CELERY-JJ event volume drop after deploy


Made with [Cursor](https://cursor.com)