### PR TITLE
Fix attributed order sync duplicate order_id IntegrityError

### DIFF
--- a/backend/eveonline/helpers/db_sync.py
+++ b/backend/eveonline/helpers/db_sync.py
@@ -2,17 +2,19 @@
 
 import time
 
-from django.db import OperationalError, transaction
+from django.db import IntegrityError, OperationalError, transaction
 
 DEADLOCK_MAX_ATTEMPTS = 3
 BULK_CREATE_BATCH = 500
 MYSQL_DEADLOCK_ERRNO = 1213
+MYSQL_DUPLICATE_ERRNO = 1062
 
 
 def replace_with_bulk_create(*, delete_queryset, instances):
     """
     Delete rows matching delete_queryset, then bulk_create instances inside
-    one transaction. Retries on MySQL deadlock (1213).
+    one transaction. Retries on MySQL deadlock (1213) and duplicate-key
+    races (1062) from concurrent syncs.
     Returns the number of rows created.
     """
     model = delete_queryset.model
@@ -29,6 +31,13 @@ def replace_with_bulk_create(*, delete_queryset, instances):
         except OperationalError as exc:
             errno = exc.args[0] if exc.args else None
             if errno != MYSQL_DEADLOCK_ERRNO or attempt >= (
+                DEADLOCK_MAX_ATTEMPTS - 1
+            ):
+                raise
+            time.sleep(0.1 * (attempt + 1))
+        except IntegrityError as exc:
+            errno = exc.args[0] if exc.args else None
+            if errno != MYSQL_DUPLICATE_ERRNO or attempt >= (
                 DEADLOCK_MAX_ATTEMPTS - 1
             ):
                 raise

--- a/backend/market/helpers/attributed_orders.py
+++ b/backend/market/helpers/attributed_orders.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 from enum import Enum
 from typing import Callable, Iterable
 
+from django.db.models import Q
 from django.utils import timezone
 
 from eveonline.client import EsiClient
@@ -93,6 +94,15 @@ def _replace_orders_from_esi(
         )
         if order:
             instances.append(order)
+    # order_id is globally unique; personal and corp syncs use different
+    # delete scopes, so also clear any existing rows for these order_ids
+    # (ownership can move personal↔corp between syncs).
+    order_ids = [inst.order_id for inst in instances]
+    if order_ids:
+        model = delete_queryset.model
+        delete_queryset = model.objects.filter(
+            Q(pk__in=delete_queryset.values("pk")) | Q(order_id__in=order_ids)
+        )
     rows = replace_with_bulk_create(
         delete_queryset=delete_queryset,
         instances=instances,

--- a/backend/market/tests/test_character_statistics.py
+++ b/backend/market/tests/test_character_statistics.py
@@ -334,3 +334,58 @@ class AttributedOrderSyncTestCase(TestCase):
         order = EveMarketAttributedOrder.objects.get(order_id=300)
         self.assertEqual(777007, order.owner_character_id)
         self.assertEqual(98000099, order.corporation_id)
+
+    @patch("market.helpers.attributed_orders.get_director_with_scope")
+    @patch("market.helpers.attributed_orders.EsiClient")
+    def test_sync_corporation_orders_replaces_personal_same_order_id(
+        self, esi_cls, get_director
+    ):
+        """Personal↔corp ownership of the same ESI order_id must not IntegrityError."""
+        EveMarketAttributedOrder.objects.create(
+            order_id=400,
+            type_id=34,
+            location_esi_id=1,
+            price=Decimal("1"),
+            volume_remain=1,
+            is_buy_order=False,
+            owner_character_id=self.character.character_id,
+            corporation_id=None,
+        )
+        alliance = EveAlliance.objects.create(
+            alliance_id=99000002, name="Minmatar Fleet Alliance"
+        )
+        corp = EveCorporation.objects.create(
+            corporation_id=98000100,
+            name="Market Corp 2",
+            alliance=alliance,
+        )
+        get_director.return_value = self.character
+        client = MagicMock()
+        esi_cls.return_value = client
+        response = MagicMock()
+        response.success.return_value = True
+        response.results.return_value = [
+            {
+                "order_id": 400,
+                "type_id": 34,
+                "location_id": 60003760,
+                "price": 99.5,
+                "volume_remain": 5,
+                "is_buy_order": False,
+                "issued_by": self.character.character_id,
+                "issued": "2026-01-03T00:00:00Z",
+                "duration": 30,
+            }
+        ]
+        client.get_corporation_orders.return_value = response
+
+        result = sync_corporation_orders(corp.corporation_id)
+        self.assertEqual(OrderSyncStatus.OK, result.status)
+        self.assertEqual(1, result.rows)
+        order = EveMarketAttributedOrder.objects.get(order_id=400)
+        self.assertEqual(self.character.character_id, order.owner_character_id)
+        self.assertEqual(98000100, order.corporation_id)
+        self.assertEqual(Decimal("99.50"), order.price)
+        self.assertEqual(
+            1, EveMarketAttributedOrder.objects.filter(order_id=400).count()
+        )


### PR DESCRIPTION
## Summary
- Fixes [MINMATAR-CELERY-JS](https://minmatar-fleet.sentry.io/issues/MINMATAR-CELERY-JS): personal and corp attributed-order syncs hit `IntegrityError` on globally unique `order_id` when ownership moves between scopes or syncs race.
- Widen the delete scope to also clear any existing rows for the order IDs being inserted, and retry MySQL duplicate-key (1062) races in `replace_with_bulk_create`.

## Test plan
- [x] `pipenv run python manage.py test market.tests.test_character_statistics.AttributedOrderSyncTestCase --settings=app.settings_test`
- [ ] Confirm `sync_corporation_attributed_orders` no longer raises duplicate `order_id` in Sentry after deploy


Made with [Cursor](https://cursor.com)