### PR TITLE
Add on-leave Alliance hygiene skill

### DIFF
--- a/.cursor/skills/on-leave/SKILL.md
+++ b/.cursor/skills/on-leave/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: on-leave
+description: >-
+  Assess alliance members for On Leave community status using fleet attendance,
+  killmails, and Discord voice, then produce a reviewer report and admin upload
+  CSV. Use when putting people on leave, reviewing inactive alliance members,
+  stripping ping status for OPSEC or absence, auditing who is not participating
+  in alliance fleets, or running a leave hygiene pass.
+---
+
+# On Leave
+
+Imposed leave for Alliance members who are **not participating in alliance
+fleets**. Decide leave vs keep from metrics; deliver a **report + upload CSV**.
+Do not change status yourself — the executor uploads after review.
+
+Also read [debug-production-readonly-db](../debug-production-readonly-db/SKILL.md).
+
+## Policy
+
+Generally, if they're not participating in alliance fleets, we put them on leave.
+
+- **Away:** takes away ping status so they're not getting constant pings and feel
+  the guilt of logging in.
+- **OPSEC:** for people in alliance but not participating, removes ping status;
+  they have to talk to a CEO to restore it.
+
+Tag every recommend **Away** or **OPSEC**. Same `on_leave` status either way.
+
+`on_leave` → Django **On Leave** group only (affiliation role stripped) via
+`sync_user_community_groups`. Most PilotFeatures deny `on_leave`.
+
+Imposed leave only — do not invent declared LOA requests.
+
+## Quick start
+
+```bash
+cd backend
+pipenv run python ../.cursor/skills/on-leave/scripts/fetch_alliance_activity.py --json --max-fleets 6
+```
+
+Defaults: **90d** window; soft line **~1 fleet/month** (≈ **3 fleets / 90d**).
+Override only from session context (quiet war window, user-named exempts).
+
+## Workflow
+
+```
+Task Progress:
+- [ ] Fetch (--max-fleets 6)
+- [ ] Drop auto-exempts (staff, directors) + rejoin grace + named exempts
+- [ ] Decide leave/keep; Story + Conf + reason
+- [ ] Emit report + CSV
+- [ ] Stop for executor review/upload
+```
+
+## Scope
+
+| Filter | Value |
+|--------|--------|
+| Affiliation | `Alliance` (check prod name if fetch is empty) |
+| Status | `active` only (`previous_status` from fetch) |
+| Activity | All linked `EveCharacter`s (account-level) |
+
+**Auto-exempt** (omit from recommend):
+
+- Auth groups: `People Team`, `Technology Team`, `Tribe - Chief`
+- Corporation directors: any `Corp … Director` / `Corporation Director` auth
+  group, or user on `EveCorporation.directors`
+- Named CEOs / LTI this session
+
+**Recent rejoin grace** (omit from recommend): first fleet in the 90d window
+falls within the last **30 days**, and no fleets in the **30–180d** band before
+that (returning after a long gap). Example: one fleet yesterday after months
+dark → keep, do not flip.
+## Signals
+
+| Signal | Model | Roll-up |
+|--------|--------|---------|
+| Fleets | `EveFleetInstanceMember` | Distinct instances across linked EVE IDs |
+| Kills | `EveCharacterKillmailAttacker` | Attackers; exclude self-victim |
+| Voice | `DiscordChannelActivityRecord` | `voice_minute` by Django `username` → hours |
+
+Fleets are primary. Kills/voice set Away vs OPSEC and break ties. Login,
+mining, PI, industry do not clear the fleet bar unless this run expands
+participation. Note untracked fleets / ESI gaps / zero linked chars in reasons
+when they matter.
+
+## Decision rules (90d)
+
+1. Exempt / director / recent-rejoin grace → keep (omit).
+2. Fleets ≥ 6 → keep (even low kills).
+3. Fleets 0–2, weak support (under ~5 kills and under ~5h voice) → **recommend**.
+   Away if kills≈0 and voice≈0; else OPSEC. Conf **high**.
+4. Fleets 0–2, strong kills (~15+) or voice (~10h+) → **recommend** OPSEC.
+   Conf **medium** if killboard-heavy (untracked ops possible).
+5. Fleets 3–5 → **keep** if ~5+ kills, ~5h+ voice, or clear support pattern;
+   else **recommend**, Conf **medium**.
+6. No linked characters → **recommend**, Conf **medium**, caveat in reason.
+
+Bias: leave for 0–2 fleets; keep for 3+. Quiet alliance (already stated) → treat
+0–3 like 0–2. Resolve every case — no borderline dump, no per-pilot questions.
+
+Reason line: Story + 1–2 metrics (+ caveat if needed). See [examples.md](examples.md).
+
+## Deliverables
+
+Always both. Sort recommends by Conf (`high` then `medium`).
+
+**Summary:** `N recommended (H/M); K kept; E exempt. Window: 90d.`
+
+### Report
+
+| Username | Primary | Previous status | New status | Fleets (90d) | Kills (90d) | Voice | Story | Conf | Reason |
+|----------|---------|-----------------|------------|-------------:|------------:|------:|-------|------|--------|
+
+- Previous = fetch `previous_status` (normally `active`)
+- New = `on_leave`
+- Voice as hours (`12.5h`)
+- Kept/exempt: counts only unless asked
+
+### CSV (admin upload)
+
+Recommended rows only:
+
+```csv
+username,community_status,reason
+someuser,on_leave,Away — 0 fleets, 0 kills, 0h voice (90d)
+otheruser,on_leave,OPSEC — 0 fleets, 2 kills, 25h voice
+```
+
+`community_status` = `on_leave`. `reason` ≤255. Username = Django username.
+Previous/New are report-only.
+
+| Flag | Use |
+|------|-----|
+| `--days 90` | Lookback |
+| `--max-fleets 6` | At/below active-enough line |
+| `--affiliation Alliance` | `AffiliationType.name` |
+
+## Executor: apply CSV
+
+1. Review report (Previous → New, metrics, Story/Conf/Reason).
+2. Delete CSV rows you want to keep active; save `on_leave_YYYY-MM-DD.csv` (UTF-8).
+3. Admin: `/admin/groups/usercommunitystatus/bulk-upload/`
+4. Upload file; optional default reason (prefer per-row reasons).
+5. **Upload and apply** → Celery background; Discord role sync may take minutes.
+6. Spot-check Community Status (`on_leave`) and Discord.
+
+Bulk upload only (history + group sync). No prod shell writes.
+
+## Related
+
+- [debug-production-readonly-db](../debug-production-readonly-db/SKILL.md)
+- [academy-graduation](../academy-graduation/SKILL.md) (same behavior signals)
+- `docs/auth/authorization.md`

--- a/.cursor/skills/on-leave/examples.md
+++ b/.cursor/skills/on-leave/examples.md
@@ -1,0 +1,42 @@
+# On Leave — decision examples
+
+90d soft line ≈ 3 fleets (~1/month). Report always pairs with CSV.
+
+## Report + CSV pair
+
+| Username | Primary | Previous | New | Fleets | Kills | Voice | Story | Conf | Reason |
+|----------|---------|----------|-----|-------:|------:|------:|-------|------|--------|
+| alice | Alice Alt | active | on_leave | 0 | 0 | 0h | Away | high | Away — no fleets, kills, or tracked voice in 90d. |
+
+```csv
+alice,on_leave,Away — 0 fleets, 0 kills, 0h voice (90d)
+```
+
+## Recommend
+
+| Fleets | Kills | Voice | Story | Conf | Reason |
+|-------:|------:|------:|-------|------|--------|
+| 0 | 0 | 0h | Away | high | Away — no fleets, kills, or tracked voice in 90d. |
+| 1 | 0 | 1h | Away | high | Away — one fleet touch, no combat, almost no voice. |
+| 0 | 0 | 25h | OPSEC | high | OPSEC — Discord presence without tracked alliance fleets. |
+| 0 | 3 | 15h | OPSEC | high | OPSEC — rare kills, no fleets; ping status not earned. |
+| 0 | 40 | 10h | OPSEC | medium | OPSEC — strong killboard, zero tracked fleets (untracked ops possible). |
+| 2 | 0 | 0h | Away | high | Away — under ~1/month with no supporting signal. |
+| 3 | 0 | 0h | Away | medium | Away — on soft line, no kills/voice support. |
+
+## Keep
+
+| Fleets | Kills | Voice | Note |
+|-------:|------:|------:|------|
+| ≥6 | any | any | Active enough; low kills OK |
+| 4 | 8 | 2h | Soft line + kills |
+| 3 | 0 | 8h | Soft line + voice |
+| 0 | 20 | 2h | Still **recommend** OPSEC medium — not keep |
+
+## Exempt → omit
+
+People Team, Technology Team, Tribe - Chief; Corp / Corporation Director (auth
+group or `EveCorporation.directors`); named CEOs/LTI this session.
+
+**Rejoin grace:** first 90d fleet within last 30d and no fleets in 30–180d prior
+(e.g. `_obiwand` — one fleet after a long gap) → keep.

--- a/.cursor/skills/on-leave/scripts/fetch_alliance_activity.py
+++ b/.cursor/skills/on-leave/scripts/fetch_alliance_activity.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Fetch Alliance-affiliated active users with fleet / kill / voice metrics.
+
+Usage (from repo root):
+  cd backend && pipenv run python ../.cursor/skills/on-leave/scripts/fetch_alliance_activity.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from datetime import timedelta
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+BACKEND_DIR = REPO_ROOT / "backend"
+
+sys.path.insert(0, str(BACKEND_DIR))
+os.chdir(BACKEND_DIR)
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
+
+import django
+
+django.setup()
+
+from django.db.models import Count, F, Sum
+from django.utils import timezone
+
+from discord.models import DiscordChannelActivityRecord
+from eveonline.models import EveCharacter, EveCharacterKillmailAttacker, EvePlayer
+from fleets.models import EveFleetInstanceMember
+from groups.models import UserAffiliation, UserCommunityStatus
+
+PRODUCTION_DB = "production_readonly"
+
+
+def fetch_activity(
+    *,
+    days: int,
+    affiliation_name: str,
+    max_fleets: int | None,
+) -> dict:
+    now = timezone.now()
+    since = now - timedelta(days=days)
+
+    affiliations = list(
+        UserAffiliation.objects.using(PRODUCTION_DB)
+        .filter(affiliation__name=affiliation_name)
+        .select_related("user", "affiliation")
+    )
+    user_ids = [a.user_id for a in affiliations]
+    status_by_user = {
+        ucs.user_id: ucs.status
+        for ucs in UserCommunityStatus.objects.using(PRODUCTION_DB).filter(
+            user_id__in=user_ids
+        )
+    }
+
+    # Missing UCS is treated as active in app code.
+    active_user_ids = [
+        uid
+        for uid in user_ids
+        if status_by_user.get(uid, UserCommunityStatus.STATUS_ACTIVE)
+        == UserCommunityStatus.STATUS_ACTIVE
+    ]
+    active_set = set(active_user_ids)
+    username_by_id = {
+        a.user_id: a.user.username
+        for a in affiliations
+        if a.user_id in active_set
+    }
+
+    primary_by_user = {
+        ep.user_id: ep.primary_character.character_name
+        for ep in (
+            EvePlayer.objects.using(PRODUCTION_DB)
+            .filter(user_id__in=active_user_ids, primary_character__isnull=False)
+            .select_related("primary_character")
+        )
+    }
+
+    user_by_eve: dict[int, int] = {}
+    eve_ids_by_user: dict[int, list[int]] = defaultdict(list)
+    for user_id, character_id in (
+        EveCharacter.objects.using(PRODUCTION_DB)
+        .filter(user_id__in=active_user_ids, character_id__isnull=False)
+        .values_list("user_id", "character_id")
+    ):
+        user_by_eve[character_id] = user_id
+        eve_ids_by_user[user_id].append(character_id)
+    all_eve_ids = list(user_by_eve)
+
+    fleets_by_user: dict[int, set[int]] = defaultdict(set)
+    if all_eve_ids:
+        for character_id, instance_id in (
+            EveFleetInstanceMember.objects.using(PRODUCTION_DB)
+            .filter(character_id__in=all_eve_ids, join_time__gte=since)
+            .values_list("character_id", "eve_fleet_instance_id")
+            .iterator(chunk_size=5000)
+        ):
+            uid = user_by_eve.get(character_id)
+            if uid is not None:
+                fleets_by_user[uid].add(instance_id)
+
+    kills_by_char = {}
+    if all_eve_ids:
+        kills_by_char = {
+            row["character_id"]: row["n"]
+            for row in (
+                EveCharacterKillmailAttacker.objects.using(PRODUCTION_DB)
+                .filter(
+                    character_id__in=all_eve_ids,
+                    killmail__killmail_time__gte=since,
+                )
+                .exclude(character_id=F("killmail__victim_character_id"))
+                .values("character_id")
+                .annotate(n=Count("id"))
+            )
+        }
+
+    usernames = list(username_by_id.values())
+    voice_by_username = {}
+    if usernames:
+        voice_by_username = {
+            row["username"]: int(row["total"] or 0)
+            for row in (
+                DiscordChannelActivityRecord.objects.using(PRODUCTION_DB)
+                .filter(
+                    username__in=usernames,
+                    activity_type="voice_minute",
+                    created_on__gte=since,
+                )
+                .values("username")
+                .annotate(total=Sum("quantity"))
+            )
+        }
+
+    members = []
+    for user_id in active_user_ids:
+        username = username_by_id.get(user_id)
+        if not username:
+            continue
+        char_ids = eve_ids_by_user.get(user_id, [])
+        fleets = len(fleets_by_user.get(user_id, ()))
+        if max_fleets is not None and fleets >= max_fleets:
+            continue
+        voice_min = voice_by_username.get(username, 0)
+        members.append(
+            {
+                "username": username,
+                "primary_character": primary_by_user.get(user_id),
+                "previous_status": status_by_user.get(
+                    user_id, UserCommunityStatus.STATUS_ACTIVE
+                ),
+                "linked_character_count": len(char_ids),
+                "fleets": fleets,
+                "kills": sum(kills_by_char.get(cid, 0) for cid in char_ids),
+                "voice_minutes": voice_min,
+                "voice_hours": round(voice_min / 60, 1),
+            }
+        )
+
+    members.sort(key=lambda m: (m["fleets"], m["kills"], m["voice_minutes"]))
+
+    return {
+        "as_of": now.strftime("%Y-%m-%d"),
+        "window_days": days,
+        "affiliation": affiliation_name,
+        "community_status": "active",
+        "member_count": len(members),
+        "members": members,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fetch Alliance member fleet/kill/voice activity"
+    )
+    parser.add_argument("--json", action="store_true", help="Print JSON to stdout")
+    parser.add_argument("--days", type=int, default=90, help="Lookback window")
+    parser.add_argument(
+        "--affiliation",
+        default="Alliance",
+        help="AffiliationType.name to include",
+    )
+    parser.add_argument(
+        "--max-fleets",
+        type=int,
+        default=None,
+        help="Only include members with fewer than this many fleets",
+    )
+    args = parser.parse_args()
+    payload = fetch_activity(
+        days=args.days,
+        affiliation_name=args.affiliation,
+        max_fleets=args.max_fleets,
+    )
+    print(json.dumps(payload, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `.cursor/skills/on-leave/` for imposed leave passes: fleet-first assessment of Alliance + active members using fleets / kills / Discord voice
- Agent produces a reviewer report (Previous → New status + metrics) and an admin bulk-upload CSV; executor applies via `/admin/groups/usercommunitystatus/bulk-upload/`
- Includes `scripts/fetch_alliance_activity.py` for `production_readonly` metrics, with auto-exempts (staff, corp directors) and recent-rejoin grace

## Test plan
- [ ] From `backend/`: `pipenv run python ../.cursor/skills/on-leave/scripts/fetch_alliance_activity.py --json --max-fleets 6`
- [ ] Confirm JSON includes `previous_status`, fleets, kills, `voice_hours`
- [ ] Dry-run the skill workflow against prod readonly and review report + CSV shape (do not upload unless intentional)
- [ ] Confirm skill docs match bulk CSV columns: `username`, `community_status`, `reason`


Made with [Cursor](https://cursor.com)