### PR TITLE
Add trial-approval skill for full membership review

### DIFF
--- a/.cursor/skills/trial-approval/SKILL.md
+++ b/.cursor/skills/trial-approval/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: trial-approval
+description: >-
+  Assess trial Alliance members for promotion to active (full members) using
+  fleet attendance, solo/small-gang kills, and Discord voice, then produce a
+  reviewer report and admin upload CSV. Use when approving trial, moving people
+  off trial, graduating trial to active, reviewing who earned full membership,
+  or running a trial hygiene pass.
+---
+
+# Trial Approval
+
+Promote trial Alliance members to **`active`** when they are **participating in
+the alliance** — not fleets alone. Solo / small-gang kills and Discord voice
+count alongside fleet attendance. Deliver a **report + upload CSV**. Do not
+change status yourself — the executor uploads after review.
+
+Also read [debug-production-readonly-db](../debug-production-readonly-db/SKILL.md).
+
+## Policy
+
+Trial is provisional. Full membership means they show up as part of the
+alliance: alliance fleets, solo / small-gang combat, voice with the community,
+or a clear mix.
+
+We do **not** care just about fleets. We care about them doing things like solo
+/ small gang kills, being in voice, etc. Participating in the alliance.
+
+`active` → affiliation group only (Trial Discord role stripped) via
+`sync_user_community_groups`.
+
+Bias: when unsure, **hold trial**. Resolve every case — no borderline dump.
+
+Wrong-affiliation trials (Guest / Militia / `requires_trial=False`) are **not**
+this pass — note them for `fix_trial_status_by_affiliation`.
+
+This is not [on-leave](../on-leave/SKILL.md). Leave is fleet-primary (pings /
+OPSEC). Trial approval is co-equal participation paths.
+
+## Quick start
+
+```bash
+cd backend
+pipenv run python ../.cursor/skills/trial-approval/scripts/fetch_trial_activity.py --json
+```
+
+Defaults: **90d** window; affiliation **Alliance**; status **trial**.
+
+## Workflow
+
+```
+Task Progress:
+- [ ] Fetch trial Alliance activity (--json)
+- [ ] Split wrong-affiliation (fix command) vs real trial
+- [ ] Decide approve / hold; Path + Conf + reason
+- [ ] Emit report + CSV (approve rows only)
+- [ ] Stop for executor review/upload
+```
+
+## Scope
+
+| Filter | Value |
+|--------|--------|
+| Affiliation | `Alliance` (check prod name if fetch is empty) |
+| Status | `trial` only |
+| Activity | All linked `EveCharacter`s (account-level) |
+
+## Signals
+
+| Signal | Model | Roll-up |
+|--------|--------|---------|
+| Fleets | `EveFleetInstanceMember` | Distinct instances across linked EVE IDs |
+| Kills | `EveCharacterKillmailAttacker` | Attackers; exclude self-victim; gang buckets |
+| Voice | `DiscordChannelActivityRecord` | `voice_minute` by Django `username` → hours |
+
+**Gang buckets** (attacker count on the killmail): small ≤10, medium 11–24,
+large 25–39, blob 40+. Solo / small-gang = **small** bucket.
+
+Login, mining, PI, industry alone do not clear the bar. Note ESI gaps / zero
+linked chars / untracked ops in reasons when they matter.
+
+## Decision rules (90d)
+
+Paths are co-equal. Approve when **one strong path** or **two medium paths**.
+
+**Strong path (approve, Conf high):**
+
+1. Fleets ≥ 4
+2. Small-gang kills ≥ 8 (small bucket)
+3. Voice ≥ 10h **and** (fleets ≥ 1 or kills ≥ 3)
+
+**Medium path — combine two for approve (Conf medium), or one strong + weak support:**
+
+| Path | Medium bar |
+|------|------------|
+| Fleets | 2–3 |
+| Small-gang | 4–7 |
+| Total kills (any gang) | ≥ 10 with some small-gang (≥ 3) |
+| Voice | ≥ 5h with any fleet or kill touch |
+
+**Hold trial:**
+
+- Dark: fleets ≤ 1, kills ≈ 0, voice ≈ 0
+- Voice-only social ghost: high voice, no fleets, no kills
+- Blob-only killboard with no fleets / no small-gang / no voice (unclear alliance play)
+- No linked characters (caveat; Conf medium if somehow recommending — prefer hold)
+
+Tag approve **Path**: `Fleet`, `Small-gang`, `Voice`, or `Mixed`.
+
+Reason line: Path + 1–2 metrics. See [examples.md](examples.md).
+
+## Deliverables
+
+Always both. Sort approves by Conf (`high` then `medium`).
+
+**Summary:** `N approve (H/M); H held; W wrong-affiliation. Window: 90d.`
+
+### Report
+
+| Username | Primary | Previous | New | Fleets | Kills | Small | Voice | Path | Conf | Reason |
+|----------|---------|----------|-----|-------:|------:|------:|------:|------|------|--------|
+
+- Previous = `trial`; New = `active`
+- Voice as hours (`12.5h`)
+- Small = small-gang kill count
+- Held / wrong-affiliation: counts only unless asked
+
+### CSV (admin upload)
+
+Approve rows only:
+
+```csv
+username,community_status,reason
+someuser,active,Mixed — 5 fleets, 9 small-gang, 6h voice (90d)
+otheruser,active,Small-gang — 0 fleets, 14 small-gang kills (90d)
+```
+
+`community_status` = `active`. `reason` ≤255. Username = Django username.
+
+| Flag | Use |
+|------|-----|
+| `--days 90` | Lookback |
+| `--affiliation Alliance` | `AffiliationType.name` |
+
+## Executor: apply CSV
+
+1. Review report (metrics, Path/Conf/Reason).
+2. Delete rows you want to keep on trial; save `trial_approve_YYYY-MM-DD.csv` (UTF-8).
+3. Admin: `/admin/groups/usercommunitystatus/bulk-upload/`
+4. Upload; prefer per-row reasons.
+5. **Upload and apply** → Celery; Discord role sync may take minutes.
+6. Spot-check: status `active`, Trial role gone, Alliance role kept.
+
+Bulk upload only. No prod shell writes. Small batches may use admin **Approve trial**.
+
+Wrong-affiliation list → `pipenv run python manage.py fix_trial_status_by_affiliation` (with `--dry-run` first) on an environment that can write — not this skill’s CSV.
+
+## Related
+
+- [on-leave](../on-leave/SKILL.md) (fleet-primary; different question)
+- [academy-graduation](../academy-graduation/SKILL.md) (same signals, corp routing)
+- [debug-production-readonly-db](../debug-production-readonly-db/SKILL.md)
+- `docs/auth/authorization.md`

--- a/.cursor/skills/trial-approval/examples.md
+++ b/.cursor/skills/trial-approval/examples.md
@@ -1,0 +1,41 @@
+# Trial Approval — decision examples
+
+90d window. Paths co-equal: fleets, solo/small-gang, voice. Report always pairs
+with CSV.
+
+## Report + CSV pair
+
+| Username | Primary | Previous | New | Fleets | Kills | Small | Voice | Path | Conf | Reason |
+|----------|---------|----------|-----|-------:|------:|------:|------:|------|------|--------|
+| bob | Bob Main | trial | active | 5 | 12 | 9 | 6h | Mixed | high | Mixed — 5 fleets, 9 small-gang, 6h voice (90d). |
+
+```csv
+bob,active,Mixed — 5 fleets, 9 small-gang, 6h voice (90d)
+```
+
+## Approve
+
+| Fleets | Kills | Small | Voice | Path | Conf | Reason |
+|-------:|------:|------:|------:|------|------|--------|
+| 6 | 2 | 1 | 1h | Fleet | high | Fleet — 6 alliance fleets in 90d. |
+| 4 | 0 | 0 | 0h | Fleet | high | Fleet — 4 fleets; clear ops participation. |
+| 0 | 18 | 14 | 2h | Small-gang | high | Small-gang — 14 small-gang kills, almost no PAP. |
+| 1 | 10 | 8 | 0h | Small-gang | high | Small-gang — 8 small-gang kills with one fleet touch. |
+| 2 | 4 | 3 | 12h | Voice | high | Voice — 12h voice with fleet + kill touch. |
+| 3 | 6 | 5 | 5h | Mixed | medium | Mixed — medium fleets, small-gang, and voice. |
+| 2 | 12 | 4 | 6h | Mixed | medium | Mixed — 2 fleets, some small-gang, 6h voice. |
+
+## Hold
+
+| Fleets | Kills | Small | Voice | Note |
+|-------:|------:|------:|------:|------|
+| 0 | 0 | 0 | 0h | Dark — no alliance participation. |
+| 1 | 0 | 0 | 0.5h | Near-dark — one fleet blip. |
+| 0 | 0 | 0 | 20h | Voice-only social ghost — no combat or fleets. |
+| 0 | 25 | 0 | 0h | Blob-only board, no small-gang / fleets / voice. |
+| 2 | 2 | 1 | 1h | One medium path only — hold for more signal. |
+
+## Wrong affiliation (omit from approve CSV)
+
+Trial status but affiliation is Guest / Militia / `requires_trial=False` → list
+for `fix_trial_status_by_affiliation`, do not put in this skill’s active CSV.

--- a/.cursor/skills/trial-approval/scripts/fetch_trial_activity.py
+++ b/.cursor/skills/trial-approval/scripts/fetch_trial_activity.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""
+Fetch Alliance-affiliated trial users with fleet / kill / voice metrics.
+
+Does NOT decide who to approve — the agent applies SKILL.md reasoning.
+
+Usage (from repo root):
+  cd backend && pipenv run python ../.cursor/skills/trial-approval/scripts/fetch_trial_activity.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from datetime import timedelta
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+BACKEND_DIR = REPO_ROOT / "backend"
+
+sys.path.insert(0, str(BACKEND_DIR))
+os.chdir(BACKEND_DIR)
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
+
+import django
+
+django.setup()
+
+from django.db.models import Count, F, Sum
+from django.utils import timezone
+
+from discord.models import DiscordChannelActivityRecord
+from eveonline.models import EveCharacter, EveCharacterKillmailAttacker, EvePlayer
+from fleets.models import EveFleetInstanceMember
+from groups.models import UserAffiliation, UserCommunityStatus
+
+PRODUCTION_DB = "production_readonly"
+
+
+def gang_bucket(size: int) -> str:
+    if size <= 10:
+        return "small"
+    if size <= 24:
+        return "medium"
+    if size <= 39:
+        return "large"
+    return "blob"
+
+
+def fetch_activity(
+    *,
+    days: int,
+    affiliation_name: str,
+) -> dict:
+    now = timezone.now()
+    since = now - timedelta(days=days)
+
+    affiliations = list(
+        UserAffiliation.objects.using(PRODUCTION_DB)
+        .filter(affiliation__name=affiliation_name)
+        .select_related("user", "affiliation")
+    )
+    user_ids = [a.user_id for a in affiliations]
+    affiliation_meta = {
+        a.user_id: {
+            "affiliation": a.affiliation.name,
+            "requires_trial": bool(a.affiliation.requires_trial),
+        }
+        for a in affiliations
+    }
+    status_by_user = {
+        ucs.user_id: ucs.status
+        for ucs in UserCommunityStatus.objects.using(PRODUCTION_DB).filter(
+            user_id__in=user_ids
+        )
+    }
+
+    trial_user_ids = [
+        uid
+        for uid in user_ids
+        if status_by_user.get(uid) == UserCommunityStatus.STATUS_TRIAL
+    ]
+    trial_set = set(trial_user_ids)
+    username_by_id = {
+        a.user_id: a.user.username
+        for a in affiliations
+        if a.user_id in trial_set
+    }
+
+    primary_by_user = {
+        ep.user_id: ep.primary_character.character_name
+        for ep in (
+            EvePlayer.objects.using(PRODUCTION_DB)
+            .filter(user_id__in=trial_user_ids, primary_character__isnull=False)
+            .select_related("primary_character")
+        )
+    }
+
+    user_by_eve: dict[int, int] = {}
+    eve_ids_by_user: dict[int, list[int]] = defaultdict(list)
+    for user_id, character_id in (
+        EveCharacter.objects.using(PRODUCTION_DB)
+        .filter(user_id__in=trial_user_ids, character_id__isnull=False)
+        .values_list("user_id", "character_id")
+    ):
+        user_by_eve[character_id] = user_id
+        eve_ids_by_user[user_id].append(character_id)
+    all_eve_ids = list(user_by_eve)
+
+    fleets_by_user: dict[int, set[int]] = defaultdict(set)
+    if all_eve_ids:
+        for character_id, instance_id in (
+            EveFleetInstanceMember.objects.using(PRODUCTION_DB)
+            .filter(character_id__in=all_eve_ids, join_time__gte=since)
+            .values_list("character_id", "eve_fleet_instance_id")
+            .iterator(chunk_size=5000)
+        ):
+            uid = user_by_eve.get(character_id)
+            if uid is not None:
+                fleets_by_user[uid].add(instance_id)
+
+    gang_by_user: dict[int, dict[str, int]] = defaultdict(
+        lambda: {"small": 0, "medium": 0, "large": 0, "blob": 0}
+    )
+    kills_by_user: dict[int, int] = defaultdict(int)
+    if all_eve_ids:
+        kill_rows = (
+            EveCharacterKillmailAttacker.objects.using(PRODUCTION_DB)
+            .filter(
+                character_id__in=all_eve_ids,
+                killmail__killmail_time__gte=since,
+            )
+            .exclude(character_id=F("killmail__victim_character_id"))
+            .annotate(
+                gang_size=Count(
+                    "killmail__evecharacterkillmailattacker", distinct=True
+                )
+            )
+            .values_list("character_id", "gang_size")
+            .iterator(chunk_size=5000)
+        )
+        for character_id, gang_size in kill_rows:
+            uid = user_by_eve.get(character_id)
+            if uid is None:
+                continue
+            kills_by_user[uid] += 1
+            gang_by_user[uid][gang_bucket(gang_size)] += 1
+
+    usernames = list(username_by_id.values())
+    voice_by_username = {}
+    if usernames:
+        voice_by_username = {
+            row["username"]: int(row["total"] or 0)
+            for row in (
+                DiscordChannelActivityRecord.objects.using(PRODUCTION_DB)
+                .filter(
+                    username__in=usernames,
+                    activity_type="voice_minute",
+                    created_on__gte=since,
+                )
+                .values("username")
+                .annotate(total=Sum("quantity"))
+            )
+        }
+
+    members = []
+    for user_id in trial_user_ids:
+        username = username_by_id.get(user_id)
+        if not username:
+            continue
+        char_ids = eve_ids_by_user.get(user_id, [])
+        fleets = len(fleets_by_user.get(user_id, ()))
+        voice_min = voice_by_username.get(username, 0)
+        gangs = gang_by_user.get(
+            user_id, {"small": 0, "medium": 0, "large": 0, "blob": 0}
+        )
+        meta = affiliation_meta.get(
+            user_id, {"affiliation": affiliation_name, "requires_trial": True}
+        )
+        members.append(
+            {
+                "username": username,
+                "primary_character": primary_by_user.get(user_id),
+                "previous_status": UserCommunityStatus.STATUS_TRIAL,
+                "affiliation": meta["affiliation"],
+                "requires_trial": meta["requires_trial"],
+                "linked_character_count": len(char_ids),
+                "fleets": fleets,
+                "kills": kills_by_user.get(user_id, 0),
+                "kills_small": gangs["small"],
+                "kills_medium": gangs["medium"],
+                "kills_large": gangs["large"],
+                "kills_blob": gangs["blob"],
+                "voice_minutes": voice_min,
+                "voice_hours": round(voice_min / 60, 1),
+            }
+        )
+
+    members.sort(
+        key=lambda m: (
+            -(m["fleets"] + m["kills_small"] + int(m["voice_hours"])),
+            m["username"],
+        )
+    )
+
+    return {
+        "as_of": now.strftime("%Y-%m-%d"),
+        "window_days": days,
+        "affiliation": affiliation_name,
+        "community_status": "trial",
+        "member_count": len(members),
+        "members": members,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fetch trial Alliance member fleet/kill/voice activity"
+    )
+    parser.add_argument("--json", action="store_true", help="Print JSON to stdout")
+    parser.add_argument("--days", type=int, default=90, help="Lookback window")
+    parser.add_argument(
+        "--affiliation",
+        default="Alliance",
+        help="AffiliationType.name to include",
+    )
+    args = parser.parse_args()
+    payload = fetch_activity(
+        days=args.days,
+        affiliation_name=args.affiliation,
+    )
+    print(json.dumps(payload, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds a Cursor skill to promote trial Alliance members to `active` based on alliance participation (fleets, solo/small-gang kills, and Discord voice as co-equal signals).
- Includes a production_readonly fetch script plus decision examples, reviewer report, and admin bulk-upload CSV (`community_status=active`).
- Holds trial when unsure; wrong-affiliation trials are routed to `fix_trial_status_by_affiliation` instead of this CSV.

## Test plan
- [ ] Open `.cursor/skills/trial-approval/SKILL.md` and confirm workflow/decision rules match intent
- [ ] From `backend/`, run `pipenv run python ../.cursor/skills/trial-approval/scripts/fetch_trial_activity.py --json` against an env with `production_readonly`
- [ ] Spot-check JSON for trial-only members, gang buckets (`kills_small`, etc.), and voice hours
- [ ] Dry-run a sample approve CSV shape (`username,community_status,reason`) against admin bulk-upload docs


Made with [Cursor](https://cursor.com)