### PR TITLE
Add Fleet and Militia Discord links on Account details

### DIFF
--- a/frontend/app/src/i18n/ui.ts
+++ b/frontend/app/src/i18n/ui.ts
@@ -1941,6 +1941,8 @@ export const ui = {
         'timers_copied_dialog_text': 'Active structure timers copied to clipboard.',
         'copied': 'Copied!',
         'lastest_timers': 'Latest TIMERS structure timers',
+        'fleet_discord': 'Fleet Discord',
+        'militia_discord': 'Militia Discord',
         'refresh_discord_roles': 'Refresh Discord roles',
         'pilot_used': 'You will use in fleet',
         'lets_rock': 'Let’s rock!',

--- a/frontend/app/src/pages/account.astro
+++ b/frontend/app/src/pages/account.astro
@@ -159,6 +159,20 @@ const page_title = t('account.page_title');
             >
                 {t('troubleshooting')}
             </Button>
+            <Button
+                href="https://discord.com/invite/3hZfahmkFx"
+                size='sm'
+                external={true}
+            >
+                {t('fleet_discord')}
+            </Button>
+            <Button
+                href="https://discord.com/invite/fVQapuzmcb"
+                size='sm'
+                external={true}
+            >
+                {t('militia_discord')}
+            </Button>
         </PageSubheader>
         
         <Flexblock>            


### PR DESCRIPTION
## Summary
- Adds **Fleet Discord** and **Militia Discord** invite buttons to the Account details subheader
- Uses the existing Fleet invite and a permanent Militia (Minmatar Faction Warfare) invite
- Addresses open #help ticket from coachgarof requesting a Militia Discord link on Account details

## Test plan
- [ ] Open `/account/` while logged in
- [ ] Confirm Fleet Discord and Militia Discord buttons appear next to Referral links / Troubleshooting
- [ ] Confirm both buttons open the correct Discord invites in a new tab
- [ ] Confirm external-link disclaimer still works when enabled


Made with [Cursor](https://cursor.com)