### PR TITLE
Fix Learning Center Change experience button

### DIFF
--- a/frontend/app/src/components/partials/LearningAlpine.astro
+++ b/frontend/app/src/components/partials/LearningAlpine.astro
@@ -40,6 +40,9 @@
             completeError: '',
             // Match SSR so soft navigations don't depend on Alpine removing x-cloak first.
             showPicker: !!needsPersonaInitially,
+            // Button.astro nests empty x-data; $el from click handlers is the button.
+            // Capture hub root in init so syncPanels always toggles the right panels.
+            hubRoot: null,
             localApi() {
                 return window.__learningLocal || null
             },
@@ -58,7 +61,7 @@
                 return Math.round((100 * done) / list.length)
             },
             syncPanels() {
-                const root = this.$el
+                const root = this.hubRoot
                 if (!root) return
                 root.querySelectorAll('[data-hub-when-catalog]').forEach((el) => {
                     el.classList.toggle('is-hidden', this.showPicker)
@@ -84,6 +87,7 @@
                 }
             },
             async init() {
+                this.hubRoot = this.$el
                 const cfg = JSON.parse(this.$el.getAttribute('data-config') || '{}')
                 const apiUrl = this.$el.getAttribute('data-api-url') || ''
                 this.authToken = cfg.authToken || ''


### PR DESCRIPTION
## Summary
- **Change experience** / Cancel on the Learning Center hub did nothing after picking a persona (reported in Pulse Technology help: only ISK Generation visible for `other`, button unresponsive).
- `Button.astro` mounts nested empty `x-data`, so `syncPanels()` resolved `$el` to the button and found no panel nodes. Capture the hub root in `init` and use that for panel toggles.

## Test plan
- [ ] Open `/learning-center/`, confirm a persona, land on the certificate catalog
- [ ] Click **Change experience** — persona picker should appear (catalog hidden)
- [ ] Click **Cancel** — catalog should return
- [ ] Confirm a different persona — catalog should reload for that persona
- [ ] Soft-nav to Learning Center from another page and repeat Change experience


Made with [Cursor](https://cursor.com)