### PR TITLE
Redirect backend Discord OAuth failures to auth error page

### DIFF
--- a/backend/discord/tests.py
+++ b/backend/discord/tests.py
@@ -14,7 +14,7 @@ from eveonline.models import (
 from eveonline.helpers.characters import set_primary_character
 
 from app.test import TestCase
-from discord.client import _raise_discord_rate_limit
+from discord.client import DiscordError, _raise_discord_rate_limit
 from discord.core import DISCORD_NICKNAME_MAX_LENGTH, make_nickname
 from discord.forms import DiscordChannelAdminForm
 from discord.guilds import sync_discord_guilds
@@ -289,6 +289,32 @@ class DiscordTests(TestCase):
         ).first()
         self.assertIsNotNone(new_discord_user)
         self.assertEqual("http://avatar.gif", new_discord_user.avatar)
+
+    def test_discord_login_redirect_exchange_error(self):
+        """Backend OAuth failures redirect to the frontend auth error page."""
+        discord_response = MagicMock()
+        discord_response.status_code = 400
+        error = DiscordError.for_response(
+            "Error exchanging token", "EXCHG_CODE", discord_response
+        )
+
+        with patch("discord.views.discord") as discord_client_mock:
+            discord_client_mock.exchange_code.side_effect = error
+
+            redirect_request_mock = Mock()
+            redirect_request_mock.GET.get.return_value = "used-code"
+            redirect_request_mock.session = {}
+
+            redirect_response = discord_login_redirect(redirect_request_mock)
+
+        self.assertEqual(redirect_response.status_code, 302)
+        self.assertIn("error=EXCHG_CODE", redirect_response.url)
+        self.assertIn(f"id={error.id}", redirect_response.url)
+        self.assertTrue(
+            redirect_response.url.startswith(
+                "https://my.minmatar.org/auth/login"
+            )
+        )
 
     def test_discord_nickname_task(self):
         self.disconnect_signals()

--- a/backend/discord/views.py
+++ b/backend/discord/views.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import User
 from django.http import HttpRequest
 from django.shortcuts import redirect
 
-from .client import DiscordClient
+from .client import DiscordClient, DiscordError
 from users.helpers import make_user_objects
 
 discord = DiscordClient()
@@ -58,10 +58,16 @@ def discord_login_redirect(request: HttpRequest):
         request.GET.get("code"),
     )
     code = request.GET.get("code")
-    user = discord.exchange_code(code, settings.DISCORD_ADMIN_REDIRECT_URL)
-
-    if not user:
-        redirect_to_error_page(request, "exchange_token_failed")
+    try:
+        user = discord.exchange_code(code, settings.DISCORD_ADMIN_REDIRECT_URL)
+    except DiscordError as e:
+        logger.error(
+            "Error exchanging Discord code for backend login (%s): %d %s",
+            e.id,
+            e.status_code,
+            e.description,
+        )
+        return redirect_to_error_page(request, e.code, error_id=e.id)
 
     django_user = make_user_objects(user)
 
@@ -81,7 +87,7 @@ def discord_login_redirect(request: HttpRequest):
     return redirect(next_url)
 
 
-def redirect_to_error_page(request, error_code):
+def redirect_to_error_page(request, error_code, error_id=None):
     """Redirects to a frontend authentication error page"""
     try:
         redirect_url = request.session["authentication_redirect_url"]
@@ -89,6 +95,8 @@ def redirect_to_error_page(request, error_code):
         redirect_url = "https://my.minmatar.org/auth/login"
 
     redirect_url = redirect_url + "?error=" + error_code
+    if error_id:
+        redirect_url = redirect_url + "&id=" + error_id
     logger.info("Redirecting to error URL... %s", redirect_url)
     return redirect(redirect_url)
 


### PR DESCRIPTION
## Summary
- Catch `DiscordError` in `/oauth2/login/redirect` (used during ESI character-add session login) and redirect to the frontend auth error page instead of returning a bare 500
- Align with `/api/users/callback` error handling and include the error id for support
- Fixes the UX snag reported in the Pulse Technology help thread for `drdiamondh2o`

## Test plan
- [x] `pipenv run python manage.py test discord.tests.DiscordTests.test_discord_login_redirect_admin discord.tests.DiscordTests.test_discord_login_redirect_exchange_error users.tests.UserRouterTestCase.test_discord_login_redirect_error --settings=app.settings_test`
- [ ] After deploy: start Add Character while logged out of the Django session, complete Discord auth, confirm success still reaches ESI
- [ ] Force a reused/invalid Discord code on `/oauth2/login/redirect` and confirm redirect to `my.minmatar.org/auth/login?error=EXCHG_CODE&id=…` (no Server Error 500)


Made with [Cursor](https://cursor.com)