### PR TITLE
Fix buyback appraisals to use Forge market history as Jita guide

### DIFF
--- a/backend/buyback/helpers/pricing.py
+++ b/backend/buyback/helpers/pricing.py
@@ -35,8 +35,8 @@ def _fallback_buy_prices_by_type_id(
     """
     Region market-history average, then EveMarketPrice average.
 
-    Used when the price_baseline location has no station-range buy order
-    (common for Jita NPC station, which is prices_active but not market_active).
+    Used when the price_baseline location has no station-range buy order yet
+    (or none for that type). Keeps appraisals working between ESI syncs.
     """
     if not type_ids:
         return {}

--- a/backend/buyback/helpers/pricing.py
+++ b/backend/buyback/helpers/pricing.py
@@ -1,4 +1,4 @@
-"""Price buyback lines against price_baseline Jita buy orders."""
+"""Price buyback lines against Jita-region market history."""
 
 from __future__ import annotations
 
@@ -15,33 +15,26 @@ from industry.helpers.compressed_ore import (
     reprocess_output,
 )
 from market.helpers.pricing import JITA_REGION_ID
-from market.models import EveMarketItemHistory, EveMarketItemLocationPrice
+from market.models import EveMarketItemHistory
 
 from buyback.helpers.classify import BuybackCategory
 from buyback.models import DEFAULT_RATE_RULES
 
 
-def _baseline_region_id(baseline: EveLocation | None) -> int:
+def _baseline_region_id() -> int:
+    baseline = EveLocation.objects.filter(price_baseline=True).first()
     if baseline and baseline.region_id:
         return int(baseline.region_id)
     return JITA_REGION_ID
 
 
-def _fallback_buy_prices_by_type_id(
-    type_ids: list[int],
-    *,
-    region_id: int,
-) -> dict[int, Decimal]:
-    """
-    Region market-history average, then EveMarketPrice average.
-
-    Used when the price_baseline location has no station-range buy order yet
-    (or none for that type). Keeps appraisals working between ESI syncs.
-    """
+def _history_prices_by_type_id(type_ids: list[int]) -> dict[int, Decimal]:
+    """Latest region history average, then EveMarketPrice average."""
     if not type_ids:
         return {}
 
     unique_ids = list({int(tid) for tid in type_ids})
+    region_id = _baseline_region_id()
     prices: dict[int, Decimal] = {}
 
     latest_date = (
@@ -75,76 +68,31 @@ def get_baseline_buy_prices(
     type_ids: list[int] | None = None,
 ) -> dict[int, Decimal]:
     """
-    Highest buy order price per EveType at the price_baseline location.
+    Jita guide price per EveType from price_baseline region history.
 
-    Falls back to The Forge history / EveMarketPrice when the baseline
-    location has no stored station-range buy (e.g. Jita not market-synced).
+    Uses EveMarketItemHistory (The Forge when Jita is baseline), with
+    EveMarketPrice as a last resort — not live station order-book rows.
     """
-    baseline = EveLocation.objects.filter(price_baseline=True).first()
-    prices: dict[int, Decimal] = {}
-    if baseline:
-        qs = EveMarketItemLocationPrice.objects.filter(
-            location=baseline, buy_price__isnull=False
-        )
-        if type_ids is not None:
-            qs = qs.filter(item_id__in=type_ids)
-        prices = {
-            item_id: Decimal(str(buy_price))
-            for item_id, buy_price in qs.values_list("item_id", "buy_price")
-        }
-
-    if type_ids is None:
-        return prices
-
-    missing = [tid for tid in type_ids if tid not in prices]
-    if missing:
-        prices.update(
-            _fallback_buy_prices_by_type_id(
-                missing, region_id=_baseline_region_id(baseline)
-            )
-        )
-    return prices
+    if not type_ids:
+        return {}
+    return _history_prices_by_type_id(type_ids)
 
 
 def get_baseline_buy_prices_by_name(
     names: list[str] | None = None,
 ) -> dict[str, Decimal]:
-    """Buy prices by item name; same fallback as get_baseline_buy_prices."""
-    baseline = EveLocation.objects.filter(price_baseline=True).first()
-    prices: dict[str, Decimal] = {}
-    if baseline:
-        qs = EveMarketItemLocationPrice.objects.filter(
-            location=baseline, buy_price__isnull=False
-        )
-        if names is not None:
-            if not names:
-                return {}
-            qs = qs.filter(item__name__in=names)
-        prices = {
-            name: Decimal(str(buy))
-            for name, buy in qs.values_list("item__name", "buy_price")
-        }
-
-    if names is None:
-        return prices
-
-    missing_names = [name for name in names if name not in prices]
-    if not missing_names:
-        return prices
-
+    """Jita guide prices by item name; same source as get_baseline_buy_prices."""
+    if not names:
+        return {}
     name_to_id = dict(
-        EveType.objects.filter(name__in=missing_names).values_list(
-            "name", "id"
-        )
+        EveType.objects.filter(name__in=names).values_list("name", "id")
     )
-    fallback = _fallback_buy_prices_by_type_id(
-        list(name_to_id.values()),
-        region_id=_baseline_region_id(baseline),
-    )
-    for name, type_id in name_to_id.items():
-        if type_id in fallback:
-            prices[name] = fallback[type_id]
-    return prices
+    by_id = _history_prices_by_type_id(list(name_to_id.values()))
+    return {
+        name: by_id[type_id]
+        for name, type_id in name_to_id.items()
+        if type_id in by_id
+    }
 
 
 def merge_rate_rules(raw) -> dict[str, float]:

--- a/backend/buyback/helpers/pricing.py
+++ b/backend/buyback/helpers/pricing.py
@@ -6,16 +6,69 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import Optional
 
+from django.db.models import OuterRef, Subquery
 from eveonline.models import EveLocation
+from eveuniverse.models import EveMarketPrice, EveType
 from industry.helpers.compressed_ore import (
     ORE_BATCH_SIZE,
     ore_materials_per_portion,
     reprocess_output,
 )
-from market.models import EveMarketItemLocationPrice
+from market.helpers.pricing import JITA_REGION_ID
+from market.models import EveMarketItemHistory, EveMarketItemLocationPrice
 
 from buyback.helpers.classify import BuybackCategory
 from buyback.models import DEFAULT_RATE_RULES
+
+
+def _baseline_region_id(baseline: EveLocation | None) -> int:
+    if baseline and baseline.region_id:
+        return int(baseline.region_id)
+    return JITA_REGION_ID
+
+
+def _fallback_buy_prices_by_type_id(
+    type_ids: list[int],
+    *,
+    region_id: int,
+) -> dict[int, Decimal]:
+    """
+    Region market-history average, then EveMarketPrice average.
+
+    Used when the price_baseline location has no station-range buy order
+    (common for Jita NPC station, which is prices_active but not market_active).
+    """
+    if not type_ids:
+        return {}
+
+    unique_ids = list({int(tid) for tid in type_ids})
+    prices: dict[int, Decimal] = {}
+
+    latest_date = (
+        EveMarketItemHistory.objects.filter(
+            region_id=region_id,
+            item_id=OuterRef("item_id"),
+        )
+        .order_by("-date")
+        .values("date")[:1]
+    )
+    for type_id, average in EveMarketItemHistory.objects.filter(
+        region_id=region_id,
+        item_id__in=unique_ids,
+        date=Subquery(latest_date),
+    ).values_list("item_id", "average"):
+        if average is not None:
+            prices[int(type_id)] = Decimal(str(average))
+
+    missing = [tid for tid in unique_ids if tid not in prices]
+    if missing:
+        for type_id, average in EveMarketPrice.objects.filter(
+            eve_type_id__in=missing
+        ).values_list("eve_type_id", "average_price"):
+            if average is not None:
+                prices[int(type_id)] = Decimal(str(average))
+
+    return prices
 
 
 def get_baseline_buy_prices(
@@ -24,39 +77,74 @@ def get_baseline_buy_prices(
     """
     Highest buy order price per EveType at the price_baseline location.
 
-    Same baseline pattern as market sell-order endpoints.
+    Falls back to The Forge history / EveMarketPrice when the baseline
+    location has no stored station-range buy (e.g. Jita not market-synced).
     """
     baseline = EveLocation.objects.filter(price_baseline=True).first()
-    if not baseline:
-        return {}
-    qs = EveMarketItemLocationPrice.objects.filter(
-        location=baseline, buy_price__isnull=False
-    )
-    if type_ids is not None:
-        qs = qs.filter(item_id__in=type_ids)
-    return {
-        item_id: Decimal(str(buy_price))
-        for item_id, buy_price in qs.values_list("item_id", "buy_price")
-    }
+    prices: dict[int, Decimal] = {}
+    if baseline:
+        qs = EveMarketItemLocationPrice.objects.filter(
+            location=baseline, buy_price__isnull=False
+        )
+        if type_ids is not None:
+            qs = qs.filter(item_id__in=type_ids)
+        prices = {
+            item_id: Decimal(str(buy_price))
+            for item_id, buy_price in qs.values_list("item_id", "buy_price")
+        }
+
+    if type_ids is None:
+        return prices
+
+    missing = [tid for tid in type_ids if tid not in prices]
+    if missing:
+        prices.update(
+            _fallback_buy_prices_by_type_id(
+                missing, region_id=_baseline_region_id(baseline)
+            )
+        )
+    return prices
 
 
 def get_baseline_buy_prices_by_name(
     names: list[str] | None = None,
 ) -> dict[str, Decimal]:
+    """Buy prices by item name; same fallback as get_baseline_buy_prices."""
     baseline = EveLocation.objects.filter(price_baseline=True).first()
-    if not baseline:
-        return {}
-    qs = EveMarketItemLocationPrice.objects.filter(
-        location=baseline, buy_price__isnull=False
+    prices: dict[str, Decimal] = {}
+    if baseline:
+        qs = EveMarketItemLocationPrice.objects.filter(
+            location=baseline, buy_price__isnull=False
+        )
+        if names is not None:
+            if not names:
+                return {}
+            qs = qs.filter(item__name__in=names)
+        prices = {
+            name: Decimal(str(buy))
+            for name, buy in qs.values_list("item__name", "buy_price")
+        }
+
+    if names is None:
+        return prices
+
+    missing_names = [name for name in names if name not in prices]
+    if not missing_names:
+        return prices
+
+    name_to_id = dict(
+        EveType.objects.filter(name__in=missing_names).values_list(
+            "name", "id"
+        )
     )
-    if names is not None:
-        if not names:
-            return {}
-        qs = qs.filter(item__name__in=names)
-    return {
-        name: Decimal(str(buy))
-        for name, buy in qs.values_list("item__name", "buy_price")
-    }
+    fallback = _fallback_buy_prices_by_type_id(
+        list(name_to_id.values()),
+        region_id=_baseline_region_id(baseline),
+    )
+    for name, type_id in name_to_id.items():
+        if type_id in fallback:
+            prices[name] = fallback[type_id]
+    return prices
 
 
 def merge_rate_rules(raw) -> dict[str, float]:

--- a/backend/buyback/tests/test_appraisal.py
+++ b/backend/buyback/tests/test_appraisal.py
@@ -24,7 +24,7 @@ from buyback.helpers.pricing import (
 from buyback.models import BuybackAcceptedItem, EveBuybackSettings
 from eveonline.models import EveCharacter, EveLocation
 from industry.models import IndustryOrder, IndustryOrderItem, IndustryProduct
-from market.models import EveMarketItemHistory, EveMarketItemLocationPrice
+from market.models import EveMarketItemHistory
 
 BASE_URL = "/api/buyback"
 
@@ -227,9 +227,9 @@ class PriceBuybackTestCase(TestCase):
         )
 
 
-class BaselineBuyPriceFallbackTestCase(TestCase):
+class BaselineBuyPriceHistoryTestCase(TestCase):
     def setUp(self):
-        self.baseline = EveLocation.objects.create(
+        EveLocation.objects.create(
             location_id=60003760,
             location_name="Jita IV - Moon 4 - Caldari Navy Assembly Plant",
             solar_system_id=30000142,
@@ -256,13 +256,6 @@ class BaselineBuyPriceFallbackTestCase(TestCase):
             category_id=43,
             category_name="Planetary Commodities",
         )
-        EveMarketItemLocationPrice.objects.create(
-            location=self.baseline,
-            item=self.water,
-            sell_price=Decimal("110"),
-            buy_price=Decimal("100"),
-            split_price=Decimal("105"),
-        )
         EveMarketItemHistory.objects.create(
             region_id=10000002,
             item=self.trit,
@@ -272,18 +265,24 @@ class BaselineBuyPriceFallbackTestCase(TestCase):
             lowest=Decimal("3.89"),
             volume=1_000_000,
         )
+        EveMarketItemHistory.objects.create(
+            region_id=10000002,
+            item=self.water,
+            date=date(2026, 7, 31),
+            average=Decimal("100.00"),
+            highest=Decimal("110.00"),
+            lowest=Decimal("90.00"),
+            volume=50_000,
+        )
 
-    def test_uses_location_buy_when_present(self):
-        prices = get_baseline_buy_prices([self.water.id])
-        self.assertEqual(prices[self.water.id], Decimal("100"))
-
-    def test_falls_back_to_region_history_average(self):
-        prices = get_baseline_buy_prices([self.trit.id])
+    def test_uses_region_history_average(self):
+        prices = get_baseline_buy_prices([self.trit.id, self.water.id])
         self.assertEqual(prices[self.trit.id], Decimal("3.93"))
+        self.assertEqual(prices[self.water.id], Decimal("100.00"))
 
         by_name = get_baseline_buy_prices_by_name(["Tritanium", "Water"])
         self.assertEqual(by_name["Tritanium"], Decimal("3.93"))
-        self.assertEqual(by_name["Water"], Decimal("100"))
+        self.assertEqual(by_name["Water"], Decimal("100.00"))
 
 
 class AcceptedItemsSeedTestCase(TestCase):
@@ -412,6 +411,7 @@ class AppraiseEndpointTestCase(TestCase):
             solar_system_id=30000142,
             solar_system_name="Jita",
             short_name="Jita",
+            region_id=10000002,
             price_baseline=True,
         )
         self.ore = _ensure_type(
@@ -462,19 +462,23 @@ class AppraiseEndpointTestCase(TestCase):
             category_id=4,
             category_name="Material",
         )
-        EveMarketItemLocationPrice.objects.create(
-            location=self.baseline,
+        EveMarketItemHistory.objects.create(
+            region_id=10000002,
             item=self.p1,
-            sell_price=Decimal("110"),
-            buy_price=Decimal("100"),
-            split_price=Decimal("105"),
+            date=date(2026, 7, 31),
+            average=Decimal("100.00"),
+            highest=Decimal("110.00"),
+            lowest=Decimal("90.00"),
+            volume=50_000,
         )
-        EveMarketItemLocationPrice.objects.create(
-            location=self.baseline,
+        EveMarketItemHistory.objects.create(
+            region_id=10000002,
             item=self.p2,
-            sell_price=Decimal("10000"),
-            buy_price=Decimal("9000"),
-            split_price=Decimal("9500"),
+            date=date(2026, 7, 31),
+            average=Decimal("9000.00"),
+            highest=Decimal("10000.00"),
+            lowest=Decimal("8000.00"),
+            volume=10_000,
         )
         BuybackAcceptedItem.objects.create(
             eve_type=self.ore, category=BuybackAcceptedItem.Category.ORE
@@ -515,9 +519,7 @@ class AppraiseEndpointTestCase(TestCase):
         "buyback.helpers.pricing.reprocess_output",
         return_value={"Tritanium": 100},
     )
-    def test_appraise_ore_uses_history_when_jita_buy_missing(
-        self, unused_mock_reprocess
-    ):
+    def test_appraise_ore_uses_region_history(self, unused_mock_reprocess):
         trit = _ensure_type(
             type_id=34,
             name="Tritanium",
@@ -535,7 +537,6 @@ class AppraiseEndpointTestCase(TestCase):
             lowest=Decimal("3.90"),
             volume=1_000_000,
         )
-        # Baseline has no Tritanium location buy — production Jita case.
         response = self.client.post(
             f"{BASE_URL}/appraise",
             data={"paste": "Compressed Veldspar\t1000"},

--- a/backend/buyback/tests/test_appraisal.py
+++ b/backend/buyback/tests/test_appraisal.py
@@ -1,5 +1,6 @@
 """Tests for buyback paste parse, classify, price, and appraise endpoint."""
 
+from datetime import date
 from decimal import Decimal
 from unittest.mock import patch
 
@@ -14,6 +15,8 @@ from buyback.helpers.accepted_items import (
 from buyback.helpers.classify import BuybackCategory, classify_eve_type
 from buyback.helpers.paste import parse_eve_paste
 from buyback.helpers.pricing import (
+    get_baseline_buy_prices,
+    get_baseline_buy_prices_by_name,
     merge_rate_rules,
     price_flat_line,
     price_ore_line,
@@ -21,7 +24,7 @@ from buyback.helpers.pricing import (
 from buyback.models import BuybackAcceptedItem, EveBuybackSettings
 from eveonline.models import EveCharacter, EveLocation
 from industry.models import IndustryOrder, IndustryOrderItem, IndustryProduct
-from market.models import EveMarketItemLocationPrice
+from market.models import EveMarketItemHistory, EveMarketItemLocationPrice
 
 BASE_URL = "/api/buyback"
 
@@ -222,6 +225,65 @@ class PriceBuybackTestCase(TestCase):
         mock_reprocess.assert_called_once_with(
             "Compressed Veldspar", 100, refine_rate=0.85
         )
+
+
+class BaselineBuyPriceFallbackTestCase(TestCase):
+    def setUp(self):
+        self.baseline = EveLocation.objects.create(
+            location_id=60003760,
+            location_name="Jita IV - Moon 4 - Caldari Navy Assembly Plant",
+            solar_system_id=30000142,
+            solar_system_name="Jita",
+            short_name="Jita",
+            region_id=10000002,
+            price_baseline=True,
+            prices_active=True,
+            market_active=False,
+        )
+        self.trit = _ensure_type(
+            type_id=34,
+            name="Tritanium",
+            group_id=18,
+            group_name="Mineral",
+            category_id=4,
+            category_name="Material",
+        )
+        self.water = _ensure_type(
+            type_id=3645,
+            name="Water",
+            group_id=1042,
+            group_name="Basic Commodities - Tier 1",
+            category_id=43,
+            category_name="Planetary Commodities",
+        )
+        EveMarketItemLocationPrice.objects.create(
+            location=self.baseline,
+            item=self.water,
+            sell_price=Decimal("110"),
+            buy_price=Decimal("100"),
+            split_price=Decimal("105"),
+        )
+        EveMarketItemHistory.objects.create(
+            region_id=10000002,
+            item=self.trit,
+            date=date(2026, 7, 31),
+            average=Decimal("3.93"),
+            highest=Decimal("3.94"),
+            lowest=Decimal("3.89"),
+            volume=1_000_000,
+        )
+
+    def test_uses_location_buy_when_present(self):
+        prices = get_baseline_buy_prices([self.water.id])
+        self.assertEqual(prices[self.water.id], Decimal("100"))
+
+    def test_falls_back_to_region_history_average(self):
+        prices = get_baseline_buy_prices([self.trit.id])
+        self.assertEqual(prices[self.trit.id], Decimal("3.93"))
+
+        by_name = get_baseline_buy_prices_by_name(["Tritanium", "Water"])
+        self.assertEqual(by_name["Tritanium"], Decimal("3.93"))
+        self.assertEqual(by_name["Water"], Decimal("100"))
 
 
 class AcceptedItemsSeedTestCase(TestCase):
@@ -448,6 +510,43 @@ class AppraiseEndpointTestCase(TestCase):
         self.assertEqual(by_name["Coolant"]["rate"], 1.0)
         self.assertEqual(by_name["Coolant"]["jita_buy"], 9000.0)
         self.assertFalse(by_name["Compressed Blue Ice"]["accepted"])
+
+    @patch(
+        "buyback.helpers.pricing.reprocess_output",
+        return_value={"Tritanium": 100},
+    )
+    def test_appraise_ore_uses_history_when_jita_buy_missing(
+        self, unused_mock_reprocess
+    ):
+        trit = _ensure_type(
+            type_id=34,
+            name="Tritanium",
+            group_id=18,
+            group_name="Mineral",
+            category_id=4,
+            category_name="Material",
+        )
+        EveMarketItemHistory.objects.create(
+            region_id=10000002,
+            item=trit,
+            date=date(2026, 7, 31),
+            average=Decimal("4.00"),
+            highest=Decimal("4.10"),
+            lowest=Decimal("3.90"),
+            volume=1_000_000,
+        )
+        # Baseline has no Tritanium location buy — production Jita case.
+        response = self.client.post(
+            f"{BASE_URL}/appraise",
+            data={"paste": "Compressed Veldspar\t1000"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["accepted_count"], 1)
+        self.assertEqual(data["offer_total"], 400.0)
+        by_name = {line["name"]: line for line in data["lines"]}
+        self.assertTrue(by_name["Compressed Veldspar"]["accepted"])
 
     @patch(
         "buyback.helpers.pricing.reprocess_output",

--- a/backend/market/tasks.py
+++ b/backend/market/tasks.py
@@ -99,12 +99,15 @@ def process_structure_sell_orders_page_task(
 @app.task()
 def fetch_market_location_prices():
     """
-    For each market-active location, fetch market orders from ESI (structure
+    For each prices-active location, fetch market orders from ESI (structure
     or region API per location.is_structure), compute lowest sell / highest
     buy (station-range) / split per item, and update EveMarketItemLocationPrice.
     Does not touch EveMarketItemOrder.
+
+    Uses prices_active (not market_active) so baseline stations like Jita are
+    synced for appraisals without enabling alliance market sell-order flows.
     """
-    locations_list = list(EveLocation.objects.filter(market_active=True))
+    locations_list = list(EveLocation.objects.filter(prices_active=True))
     has_structure = any(loc.is_structure for loc in locations_list)
     character_id = (
         get_character_with_structure_markets_scope() if has_structure else None
@@ -136,7 +139,7 @@ def fetch_market_location_prices():
 @app.task()
 def fetch_market_location_prices_for_type(type_id: int) -> int:
     """
-    For each market-active location, fetch market orders for the given type_id
+    For each prices-active location, fetch market orders for the given type_id
     from ESI and update EveMarketItemLocationPrice for that item at that location.
     Returns total price rows updated.
     """
@@ -144,15 +147,15 @@ def fetch_market_location_prices_for_type(type_id: int) -> int:
         "fetch_market_location_prices_for_type type_id=%s — starting",
         type_id,
     )
-    locations_list = list(EveLocation.objects.filter(market_active=True))
+    locations_list = list(EveLocation.objects.filter(prices_active=True))
     if not locations_list:
         logger.info(
-            "fetch_market_location_prices_for_type type_id=%s — no market-active locations, skipping",
+            "fetch_market_location_prices_for_type type_id=%s — no prices-active locations, skipping",
             type_id,
         )
         return 0
     logger.info(
-        "fetch_market_location_prices_for_type type_id=%s — loaded %s market-active location(s): %s",
+        "fetch_market_location_prices_for_type type_id=%s — loaded %s prices-active location(s): %s",
         type_id,
         len(locations_list),
         [

--- a/backend/market/tests/test_tasks.py
+++ b/backend/market/tests/test_tasks.py
@@ -20,7 +20,45 @@ from market.helpers import (
 )
 from market.helpers.contracts import fitting_cache
 from market.models import EveMarketContract, EveMarketContractError
-from market.tasks import fetch_eve_market_contracts
+from market.tasks import (
+    fetch_eve_market_contracts,
+    fetch_market_location_prices,
+)
+
+
+class LocationPriceSyncTestCase(TestCase):
+    @patch("market.tasks.fetch_and_update_market_location_prices")
+    @patch("market.tasks.get_character_with_structure_markets_scope")
+    def test_syncs_prices_active_not_only_market_active(
+        self, scope_mock, update_mock
+    ):
+        scope_mock.return_value = None
+        update_mock.return_value = 1
+        EveLocation.objects.create(
+            location_id=60003760,
+            location_name="Jita IV - Moon 4 - Caldari Navy Assembly Plant",
+            solar_system_id=30000142,
+            solar_system_name="Jita",
+            short_name="Jita",
+            region_id=10000002,
+            prices_active=True,
+            market_active=False,
+            is_structure=False,
+        )
+        EveLocation.objects.create(
+            location_id=999,
+            location_name="Inactive",
+            solar_system_id=1,
+            solar_system_name="Sys",
+            short_name="x",
+            prices_active=False,
+            market_active=True,
+            is_structure=True,
+        )
+
+        fetch_market_location_prices()
+
+        update_mock.assert_called_once_with(None, 60003760)
 
 
 class MarketTaskTestCase(TestCase):

--- a/frontend/app/src/i18n/ui.ts
+++ b/frontend/app/src/i18n/ui.ts
@@ -495,7 +495,7 @@ export const ui = {
         'buyback.appraisal.unit_price': 'Our / unit',
         'buyback.appraisal.line_total': 'Line total',
         'buyback.appraisal.reason': 'Reason',
-        'buyback.appraisal.jita_note': 'Jita buy is the baseline market buy price. Ore is priced from refined minerals (no single Jita buy on the ore itself). Rate is the share of that baseline we pay.',
+        'buyback.appraisal.jita_note': 'Jita buy is the Forge market-history average (our price guide). Ore is priced from refined minerals (no single Jita price on the ore itself). Rate is the share of that baseline we pay.',
         'buyback.appraisal.again': 'New paste',
 
         'buyback.faq.title': 'FAQ',

--- a/frontend/app/src/pages/market/buyback/appraisal.astro
+++ b/frontend/app/src/pages/market/buyback/appraisal.astro
@@ -33,8 +33,8 @@ try {
 
     appraisal = await post_buyback_appraisal(paste)
 
-    if (!appraisal.accepted_count || appraisal.offer_total <= 0)
-        throw new Error(t('buyback.no_accepted_items'), { cause: 400 })
+    if (!appraisal.lines.length)
+        throw new Error(t('buyback.invalid_paste'), { cause: 400 })
 } catch (error) {
     data_fetching_error = error as Error
 }
@@ -47,6 +47,7 @@ if (data_fetching_error || !settings || !settings.location || !appraisal) {
 const price = Math.floor(appraisal.offer_total)
 const accepted = appraisal.lines.filter((line) => line.accepted)
 const rejected = appraisal.lines.filter((line) => !line.accepted)
+const can_continue = accepted.length > 0 && price > 0
 
 import {
     get_location_video_cover,
@@ -145,15 +146,23 @@ const format_isk = (value: number | null) => {
                                 </p>
                             </Flexblock>
 
-                            <ClipboardButton
-                                id="copy-buyback-offer"
-                                class="[ relative shrink-0 ]"
-                            >{price}</ClipboardButton>
+                            {can_continue &&
+                                <ClipboardButton
+                                    id="copy-buyback-offer"
+                                    class="[ relative shrink-0 ]"
+                                >{price}</ClipboardButton>
+                            }
                         </FlexInline>
 
-                        <Button type="submit">
-                            {t('buyback.form.continue')}
-                        </Button>
+                        {!can_continue &&
+                            <p class="[ buyback-appraisal-note ]">{t('buyback.no_accepted_items')}</p>
+                        }
+
+                        {can_continue &&
+                            <Button type="submit">
+                                {t('buyback.form.continue')}
+                            </Button>
+                        }
                     </Flexblock>
                 </form>
             </ComponentBlock>


### PR DESCRIPTION
## Summary
- Buyback was pricing against `EveMarketItemLocationPrice` at the Jita station baseline. That table has no Jita rows (sync only hit `market_active` locations), so every ore paste failed with `Missing Jita buy for minerals: Tritanium` and the UI showed an opaque “nothing accepted” toast.
- Price buyback from `EveMarketItemHistory` in the price-baseline region (The Forge / Jita guide), with `EveMarketPrice` as last resort — matching how the rest of the app treats Jita.
- Also sync `EveMarketItemLocationPrice` for `prices_active` locations (so Jita station books can populate when wanted).
- When nothing is accepted, show the appraisal + reject reasons instead of redirecting with a toast.

## Test plan
- [x] `pipenv run python manage.py test buyback.tests.test_appraisal --settings=app.settings_test`
- [x] Local appraisal of clandestinemonkey’s paste against prod history → ~1.96B ISK, 15 accepted
- [ ] Paste `Compressed Veldspar	1000` on buyback after deploy — expect a non-zero offer
- [ ] Full ore paste — expect accepted lines + continue CTA
- [ ] Ice / non-allowlisted only — appraisal page with reject reasons, no continue