### PR TITLE
Add admin LP store offer price tracking

### DIFF
--- a/backend/industry/admin.py
+++ b/backend/industry/admin.py
@@ -39,6 +39,11 @@ from industry.helpers.lp_ledger import (
     resolve_offer_isk_per_lp,
     weighted_average_cost_isk_per_lp,
 )
+from industry.helpers.lp_store_economics import (
+    offer_economics_for_queryset,
+    tracked_corporation_ids,
+)
+from industry.tasks import sync_loyalty_store_offers_task
 from industry.models import (
     IndustryContractAssociation,
     IndustryLoyaltyPoint,
@@ -670,20 +675,45 @@ class IndustryLoyaltyPointLedgerEntryAdmin(admin.ModelAdmin):
         return notes[:45] + "…"
 
 
+class IndustryLpStoreCurrencyListFilter(admin.SimpleListFilter):
+    title = "currency"
+    parameter_name = "currency"
+
+    def lookups(self, request, model_admin):
+        rows = IndustryLoyaltyPoint.objects.filter(is_active=True).order_by(
+            "name"
+        )
+        return [(str(r.corporation_id), r.name) for r in rows]
+
+    def queryset(self, request, queryset):
+        if self.value() is None:
+            return queryset
+        return queryset.filter(corporation_id=self.value())
+
+
 @admin.register(IndustryLpStoreOffer)
 class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
+    _request_stash = None
+
     list_display = (
-        "offer_id",
-        "corporation_id",
+        "type_name_display",
+        "currency_display",
+        "kind_display",
         "type_id",
         "lp_cost",
         "isk_cost",
         "quantity",
+        "isk_per_lp_display",
+        "jita_sell_display",
+        "jita_buy_display",
+        "cost_display",
+        "profit_vs_sell_display",
         "updated_at",
     )
-    list_filter = ("corporation_id",)
+    list_filter = (IndustryLpStoreCurrencyListFilter,)
     search_fields = ("offer_id", "type_id", "corporation_id")
     ordering = ("corporation_id", "type_id")
+    actions = ("sync_loyalty_store_offers_action",)
     readonly_fields = (
         "offer_id",
         "corporation_id",
@@ -707,12 +737,113 @@ class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
                     "updated_at",
                 ),
                 "description": (
-                    "Read-only ESI loyalty-store cache. Refreshed when navy "
-                    "industry products sync or on planner miss."
+                    "Read-only ESI cache for tracked LP currencies. "
+                    "Refresh via navy product sync, planner miss, or sync action."
                 ),
             },
         ),
     )
+
+    def get_queryset(self, request):
+        return (
+            super()
+            .get_queryset(request)
+            .filter(corporation_id__in=tracked_corporation_ids())
+        )
+
+    def get_changelist_instance(self, request):
+        cl = super().get_changelist_instance(request)
+        IndustryLpStoreOfferAdmin._request_stash = (
+            offer_economics_for_queryset(list(cl.result_list))
+        )
+        return cl
+
+    def changelist_view(self, request, extra_context=None):
+        try:
+            return super().changelist_view(
+                request, extra_context=extra_context
+            )
+        finally:
+            IndustryLpStoreOfferAdmin._request_stash = None
+
+    @classmethod
+    def _econ_for(cls, obj):
+        stash = cls._request_stash
+        if not stash:
+            return None
+        return stash.get(obj.offer_id)
+
+    @classmethod
+    def _format_isk(cls, obj, attr: str) -> str:
+        econ = cls._econ_for(obj)
+        if econ is None:
+            return "—"
+        value = getattr(econ, attr)
+        if value is None:
+            return "—"
+        return f"{value:,}"
+
+    @admin.display(description="Item")
+    def type_name_display(self, obj):
+        econ = self._econ_for(obj)
+        if econ is None:
+            return str(obj.type_id)
+        if econ.kind == "blueprint" and econ.market_type_id != econ.type_id:
+            return f"{econ.market_type_name} (BPC {econ.type_id})"
+        return econ.type_name
+
+    @admin.display(description="Currency")
+    def currency_display(self, obj):
+        econ = self._econ_for(obj)
+        return (
+            econ.currency_name if econ is not None else str(obj.corporation_id)
+        )
+
+    @admin.display(description="Kind")
+    def kind_display(self, obj):
+        econ = self._econ_for(obj)
+        return econ.kind if econ is not None else "—"
+
+    @admin.display(description="ISK/LP")
+    def isk_per_lp_display(self, obj):
+        econ = self._econ_for(obj)
+        if econ is None or econ.isk_per_lp is None:
+            return "—"
+        return f"{econ.isk_per_lp:,.0f}"
+
+    @admin.display(description="Jita sell")
+    def jita_sell_display(self, obj):
+        return self._format_isk(obj, "jita_sell")
+
+    @admin.display(description="Jita buy")
+    def jita_buy_display(self, obj):
+        return self._format_isk(obj, "jita_buy")
+
+    @admin.display(description="Cost")
+    def cost_display(self, obj):
+        return self._format_isk(obj, "cost_per_unit")
+
+    @admin.display(description="Profit vs sell")
+    def profit_vs_sell_display(self, obj):
+        return self._format_isk(obj, "profit_vs_sell")
+
+    @admin.action(description="Sync LP store offers from ESI now")
+    def sync_loyalty_store_offers_action(self, request, queryset):
+        del queryset  # whole-cache sync; selection unused
+        try:
+            count = sync_loyalty_store_offers_task()
+        except Exception as exc:  # noqa: BLE001 — surface ESI failures
+            self.message_user(
+                request,
+                f"LP store sync failed: {exc}",
+                level=messages.ERROR,
+            )
+            return
+        self.message_user(
+            request,
+            f"Synced {count} pure LP+ISK loyalty-store offer(s).",
+            level=messages.SUCCESS,
+        )
 
     def has_add_permission(self, request):
         return False

--- a/backend/industry/helpers/lp_store_economics.py
+++ b/backend/industry/helpers/lp_store_economics.py
@@ -1,0 +1,172 @@
+"""Economics helpers for admin LP store offer price tracking."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+
+from eveuniverse.models import EveType
+
+from industry.helpers.blueprint_efficiency import is_faction_navy_hull
+from industry.helpers.loyalty_store import resolve_isk_per_lp
+from industry.helpers.product_unit_cost import (
+    TALWAR_FI_BPC_TYPE_ID,
+    TALWAR_FI_TYPE_ID,
+    plan_product_unit_cost,
+)
+from industry.helpers.type_breakdown import get_blueprint_or_reaction_type_id
+from industry.models import (
+    IndustryLoyaltyPoint,
+    IndustryLpStoreOffer,
+    IndustryProduct,
+)
+from market.helpers.pricing import get_prices_by_type_id
+
+
+@dataclass(frozen=True)
+class LpStoreOfferEconomics:
+    offer_id: int
+    corporation_id: int
+    type_id: int
+    type_name: str
+    currency_name: str
+    isk_per_lp: Optional[float]
+    lp_cost: int
+    isk_cost: int
+    quantity: int
+    acquisition_isk_per_unit: Optional[int]
+    market_type_id: int
+    market_type_name: str
+    jita_sell: Optional[int]
+    jita_buy: Optional[int]
+    build_cost_per_unit: Optional[int]
+    cost_per_unit: Optional[int]
+    kind: str
+    profit_vs_sell: Optional[int]
+
+
+def tracked_corporation_ids() -> List[int]:
+    return list(
+        IndustryLoyaltyPoint.objects.filter(is_active=True).values_list(
+            "corporation_id", flat=True
+        )
+    )
+
+
+def tracked_currencies_by_corporation_id() -> Dict[int, IndustryLoyaltyPoint]:
+    return {
+        int(row.corporation_id): row
+        for row in IndustryLoyaltyPoint.objects.filter(is_active=True)
+    }
+
+
+def bpc_type_id_to_product_type_id() -> Dict[int, int]:
+    mapping: Dict[int, int] = {TALWAR_FI_BPC_TYPE_ID: TALWAR_FI_TYPE_ID}
+    products = IndustryProduct.objects.select_related(
+        "eve_type", "eve_type__eve_group", "eve_type__eve_group__eve_category"
+    ).filter(eve_type_id__isnull=False)
+    for product in products:
+        eve_type = product.eve_type
+        if not is_faction_navy_hull(eve_type):
+            continue
+        bpc_id = get_blueprint_or_reaction_type_id(eve_type)
+        if bpc_id is None:
+            continue
+        mapping[int(bpc_id)] = int(eve_type.id)
+    return mapping
+
+
+def _acquisition_isk_per_unit(
+    offer: IndustryLpStoreOffer, isk_per_lp: Optional[float]
+) -> Optional[int]:
+    if isk_per_lp is None or isk_per_lp <= 0:
+        return None
+    qty = max(offer.quantity, 1)
+    pack = int(round(offer.lp_cost * float(isk_per_lp) + offer.isk_cost))
+    return int(round(pack / qty))
+
+
+def offer_economics_for_queryset(
+    offers: Iterable[IndustryLpStoreOffer],
+) -> Dict[int, LpStoreOfferEconomics]:
+    rows = list(offers)
+    if not rows:
+        return {}
+
+    currencies = tracked_currencies_by_corporation_id()
+    bpc_to_product = bpc_type_id_to_product_type_id()
+
+    offer_type_ids = {o.type_id for o in rows}
+    product_type_ids = {
+        bpc_to_product[tid] for tid in offer_type_ids if tid in bpc_to_product
+    }
+    market_type_ids = sorted(offer_type_ids | product_type_ids)
+    prices = get_prices_by_type_id(market_type_ids)
+    type_names = {
+        tid: (name or str(tid))
+        for tid, name in EveType.objects.filter(
+            id__in=market_type_ids
+        ).values_list("id", "name")
+    }
+
+    build_costs: Dict[int, int] = {}
+    for product_type_id in sorted(product_type_ids):
+        try:
+            unit = plan_product_unit_cost(
+                product_type_id, use_production_lp=True
+            )
+        except ValueError:
+            continue
+        build_costs[product_type_id] = unit.cost_per
+
+    out: Dict[int, LpStoreOfferEconomics] = {}
+    for offer in rows:
+        corp_id = offer.corporation_id
+        type_id = offer.type_id
+        currency = currencies.get(corp_id)
+        currency_name = currency.name if currency is not None else str(corp_id)
+        isk_per_lp = resolve_isk_per_lp(requested=None, corporation_id=corp_id)
+        acquisition = _acquisition_isk_per_unit(offer, isk_per_lp)
+
+        product_type_id = bpc_to_product.get(type_id)
+        if product_type_id is not None:
+            kind = "blueprint"
+            market_type_id = product_type_id
+            build_cost = build_costs.get(product_type_id)
+            cost_per_unit = build_cost
+        else:
+            kind = "input"
+            market_type_id = type_id
+            build_cost = None
+            cost_per_unit = acquisition
+
+        jita = prices.get(market_type_id)
+        profit = (
+            jita - cost_per_unit
+            if jita is not None and cost_per_unit is not None
+            else None
+        )
+
+        out[offer.offer_id] = LpStoreOfferEconomics(
+            offer_id=offer.offer_id,
+            corporation_id=corp_id,
+            type_id=type_id,
+            type_name=type_names.get(type_id, str(type_id)),
+            currency_name=currency_name,
+            isk_per_lp=isk_per_lp,
+            lp_cost=offer.lp_cost,
+            isk_cost=offer.isk_cost,
+            quantity=offer.quantity,
+            acquisition_isk_per_unit=acquisition,
+            market_type_id=market_type_id,
+            market_type_name=type_names.get(
+                market_type_id, str(market_type_id)
+            ),
+            jita_sell=jita,
+            jita_buy=jita,
+            build_cost_per_unit=build_cost,
+            cost_per_unit=cost_per_unit,
+            kind=kind,
+            profit_vs_sell=profit,
+        )
+    return out

--- a/backend/industry/templates/admin/industry/loyalty_home.html
+++ b/backend/industry/templates/admin/industry/loyalty_home.html
@@ -35,7 +35,8 @@
       alliance stockpiles; post credits and debits from an account (or the ledger
       add form). Market orders are the public buyback book — completing a sell
       posts a stockpile ledger entry with seller and counterparty. Store offers
-      are read-only ESI cache used by navy blueprint costing.
+      are read-only ESI cache used by navy blueprint costing, with Jita
+      history prices and build/acquisition cost columns for tracking.
       {% endblocktranslate %}
     </p>
   {% include "admin/industry/_learn_more_end.html" %}
@@ -55,7 +56,7 @@
     <div class="industry-card-grid">
       {% include "admin/industry/_hub_card.html" with title=_("Ledger entries") count=sections.ledger.count description=_("Immutable credit/debit lots with ISK/LP, balances, and market-order counterparties when from buyback.") list_url=sections.ledger.list_url list_label=_("View ledger") add_url=sections.ledger.add_url add_label=_("Post entry") %}
       {% include "admin/industry/_hub_card.html" with title=_("Market orders") count=sections.market_orders.count description=_("Open Conversion Team buyback orders (count shows open status). Manage claims, settlement status, and Discord threads.") list_url=sections.market_orders.open_list_url list_label=_("View open orders") add_url=sections.market_orders.add_url add_label=_("Add order") %}
-      {% include "admin/industry/_hub_card.html" with title=_("LP store offers") count=sections.store_offers.count description=_("Cached pure LP+ISK loyalty-store offers used by the industry planner. Read-only; refreshed when navy products sync.") list_url=sections.store_offers.list_url list_label=_("View offers") readonly=1 %}
+      {% include "admin/industry/_hub_card.html" with title=_("LP store offers") count=sections.store_offers.count description=_("Cached pure LP+ISK offers for tracked currencies, with Jita history prices and planner+LP cost. Read-only; sync via navy products or admin action.") list_url=sections.store_offers.list_url list_label=_("View offers") readonly=1 %}
     </div>
     <p class="industry-section-desc">
       <a href="{{ sections.market_orders.list_url }}">{% translate "View all market orders" %}</a>

--- a/backend/industry/tests/test_lp_store_economics.py
+++ b/backend/industry/tests/test_lp_store_economics.py
@@ -1,0 +1,275 @@
+"""Tests for LP store offer economics (admin price tracking)."""
+
+from datetime import date
+from decimal import Decimal
+from unittest.mock import patch
+
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory, TestCase
+from eveonline.models import EveLocation
+from eveuniverse.models import (
+    EveCategory,
+    EveGroup,
+    EveIndustryActivityDuration,
+    EveIndustryActivityMaterial,
+    EveIndustryActivityProduct,
+    EveType,
+)
+from market.models import EveMarketItemHistory
+
+from industry.admin import IndustryLpStoreOfferAdmin
+from industry.helpers.lp_store_economics import (
+    bpc_type_id_to_product_type_id,
+    offer_economics_for_queryset,
+    tracked_corporation_ids,
+)
+from industry.helpers.loyalty_store import sync_loyalty_store_offers
+from industry.models import (
+    IndustryLoyaltyPoint,
+    IndustryLpStoreOffer,
+    IndustryProduct,
+    Strategy,
+)
+
+TLIB_CORP_ID = 1000182
+UNTRACKED_CORP_ID = 9999999
+HULL_TYPE_ID = 17740
+BPC_TYPE_ID = 32312
+INPUT_TYPE_ID = 42424
+JITA_REGION_ID = 10000002
+
+
+class LpStoreEconomicsHelperTestCase(TestCase):
+    def setUp(self):
+        EveLocation.objects.create(
+            location_id=60003760,
+            location_name="Jita IV - Moon 4 - Caldari Navy Assembly Plant",
+            solar_system_id=30000142,
+            solar_system_name="Jita",
+            short_name="Jita",
+            region_id=JITA_REGION_ID,
+            price_baseline=True,
+            prices_active=True,
+        )
+        IndustryLoyaltyPoint.objects.update_or_create(
+            corporation_id=TLIB_CORP_ID,
+            defaults={
+                "name": "Tribal Liberation Force",
+                "default_isk_per_lp": 800,
+                "is_active": True,
+            },
+        )
+        IndustryLoyaltyPoint.objects.exclude(
+            corporation_id=TLIB_CORP_ID
+        ).update(is_active=False)
+
+        category = EveCategory.objects.create(
+            id=6, name="Ship", published=True
+        )
+        group = EveGroup.objects.create(
+            id=27, name="Battleship", published=True, eve_category=category
+        )
+        self.hull = EveType.objects.create(
+            id=HULL_TYPE_ID,
+            name="Typhoon Fleet Issue",
+            published=True,
+            eve_group=group,
+        )
+        self.bpc = EveType.objects.create(
+            id=BPC_TYPE_ID,
+            name="Typhoon Fleet Issue Blueprint",
+            published=True,
+            eve_group=group,
+        )
+        self.input_type = EveType.objects.create(
+            id=INPUT_TYPE_ID,
+            name="LP Input Item",
+            published=True,
+            eve_group=group,
+        )
+        EveIndustryActivityProduct.objects.create(
+            eve_type=self.bpc,
+            activity_id=1,
+            product_eve_type=self.hull,
+            quantity=1,
+        )
+        EveIndustryActivityDuration.objects.create(
+            eve_type=self.bpc, activity_id=1, time=100
+        )
+        EveIndustryActivityMaterial.objects.create(
+            eve_type=self.bpc,
+            activity_id=1,
+            material_eve_type=self.input_type,
+            quantity=1,
+        )
+
+        with patch(
+            "industry.tasks.ensure_loyalty_store_offers_for_product_task.delay"
+        ):
+            IndustryProduct.objects.create(
+                eve_type=self.hull, strategy=Strategy.IMPORTED
+            )
+
+        sync_loyalty_store_offers(
+            corporation_ids=[TLIB_CORP_ID, UNTRACKED_CORP_ID],
+            offers=[
+                {
+                    "offer_id": 1001,
+                    "corporation_id": TLIB_CORP_ID,
+                    "type_id": BPC_TYPE_ID,
+                    "lp_cost": 100_000,
+                    "isk_cost": 20_000_000,
+                    "quantity": 1,
+                    "required_items": [],
+                },
+                {
+                    "offer_id": 1002,
+                    "corporation_id": TLIB_CORP_ID,
+                    "type_id": INPUT_TYPE_ID,
+                    "lp_cost": 1_000,
+                    "isk_cost": 500_000,
+                    "quantity": 1,
+                    "required_items": [],
+                },
+                {
+                    "offer_id": 1003,
+                    "corporation_id": UNTRACKED_CORP_ID,
+                    "type_id": INPUT_TYPE_ID,
+                    "lp_cost": 1_000,
+                    "isk_cost": 100_000,
+                    "quantity": 1,
+                    "required_items": [],
+                },
+            ],
+        )
+
+        EveMarketItemHistory.objects.create(
+            region_id=JITA_REGION_ID,
+            item=self.hull,
+            date=date(2026, 7, 30),
+            average=Decimal("250000000"),
+            highest=Decimal("260000000"),
+            lowest=Decimal("240000000"),
+            order_count=10,
+            volume=5,
+        )
+        EveMarketItemHistory.objects.create(
+            region_id=JITA_REGION_ID,
+            item=self.input_type,
+            date=date(2026, 7, 30),
+            average=Decimal("1500000"),
+            highest=Decimal("1600000"),
+            lowest=Decimal("1400000"),
+            order_count=20,
+            volume=100,
+        )
+
+    def test_tracked_corporation_ids_active_only(self):
+        self.assertEqual(tracked_corporation_ids(), [TLIB_CORP_ID])
+
+    def test_bpc_maps_to_navy_product(self):
+        mapping = bpc_type_id_to_product_type_id()
+        self.assertEqual(mapping[BPC_TYPE_ID], HULL_TYPE_ID)
+
+    @patch(
+        "industry.helpers.lp_store_economics.plan_product_unit_cost",
+        return_value=type(
+            "U",
+            (),
+            {"cost_per": 180_000_000},
+        )(),
+    )
+    def test_blueprint_row_uses_hull_market_and_build_cost(self, mock_plan):
+        offer = IndustryLpStoreOffer.objects.get(offer_id=1001)
+        rows = offer_economics_for_queryset([offer])
+        mock_plan.assert_called()
+        econ = rows[1001]
+        self.assertEqual(econ.kind, "blueprint")
+        self.assertEqual(econ.market_type_id, HULL_TYPE_ID)
+        self.assertEqual(econ.jita_sell, 250_000_000)
+        self.assertEqual(econ.jita_buy, 250_000_000)
+        self.assertEqual(econ.build_cost_per_unit, 180_000_000)
+        self.assertEqual(econ.cost_per_unit, 180_000_000)
+        self.assertEqual(econ.profit_vs_sell, 70_000_000)
+        self.assertEqual(econ.isk_per_lp, 800.0)
+        self.assertEqual(econ.acquisition_isk_per_unit, 100_000_000)
+
+    def test_input_row_uses_acquisition_and_own_type(self):
+        offer = IndustryLpStoreOffer.objects.get(offer_id=1002)
+        rows = offer_economics_for_queryset([offer])
+        econ = rows[1002]
+        self.assertEqual(econ.kind, "input")
+        self.assertEqual(econ.market_type_id, INPUT_TYPE_ID)
+        self.assertEqual(econ.jita_sell, 1_500_000)
+        self.assertEqual(econ.jita_buy, 1_500_000)
+        self.assertIsNone(econ.build_cost_per_unit)
+        self.assertEqual(econ.acquisition_isk_per_unit, 1_300_000)
+        self.assertEqual(econ.cost_per_unit, 1_300_000)
+        self.assertEqual(econ.profit_vs_sell, 200_000)
+
+    def test_untracked_corp_offer_still_computes_but_admin_filters(self):
+        offer = IndustryLpStoreOffer.objects.get(offer_id=1003)
+        rows = offer_economics_for_queryset([offer])
+        self.assertIn(1003, rows)
+        self.assertEqual(rows[1003].corporation_id, UNTRACKED_CORP_ID)
+
+
+class LpStoreOfferAdminTestCase(TestCase):
+    def setUp(self):
+        IndustryLoyaltyPoint.objects.update_or_create(
+            corporation_id=TLIB_CORP_ID,
+            defaults={
+                "name": "Tribal Liberation Force",
+                "default_isk_per_lp": 800,
+                "is_active": True,
+            },
+        )
+        IndustryLoyaltyPoint.objects.exclude(
+            corporation_id=TLIB_CORP_ID
+        ).update(is_active=False)
+        IndustryLpStoreOffer.objects.create(
+            offer_id=2001,
+            corporation_id=TLIB_CORP_ID,
+            type_id=INPUT_TYPE_ID,
+            lp_cost=1000,
+            isk_cost=500_000,
+            quantity=1,
+        )
+        IndustryLpStoreOffer.objects.create(
+            offer_id=2002,
+            corporation_id=UNTRACKED_CORP_ID,
+            type_id=INPUT_TYPE_ID,
+            lp_cost=1000,
+            isk_cost=100_000,
+            quantity=1,
+        )
+        self.site = AdminSite()
+        self.admin = IndustryLpStoreOfferAdmin(IndustryLpStoreOffer, self.site)
+        self.factory = RequestFactory()
+        user_model = get_user_model()
+        self.user = user_model.objects.create_superuser(
+            username="lp-admin",
+            email="lp-admin@example.com",
+            password="test",
+        )
+
+    def test_queryset_filters_to_tracked_corps(self):
+        request = self.factory.get("/admin/industry/industrylpstoreoffer/")
+        request.user = self.user
+        qs = self.admin.get_queryset(request)
+        self.assertEqual(list(qs.values_list("offer_id", flat=True)), [2001])
+
+    @patch(
+        "industry.admin.offer_economics_for_queryset",
+        return_value={},
+    )
+    def test_changelist_includes_price_columns(self, mock_econ):
+        request = self.factory.get("/admin/industry/industrylpstoreoffer/")
+        request.user = self.user
+        response = self.admin.changelist_view(request)
+        mock_econ.assert_called()
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("jita_sell_display", self.admin.list_display)
+        self.assertIn("jita_buy_display", self.admin.list_display)
+        self.assertIn("cost_display", self.admin.list_display)


### PR DESCRIPTION
## Summary
- Add staff admin columns on LP store offers for Forge-region Jita guide prices (same history source as buyback) plus planner+LP build cost for navy BPCs, or LP acquisition cost for other offers
- Scope the changelist to active `IndustryLoyaltyPoint` currencies, with a currency filter and optional ESI sync action
- Cover blueprint vs input economics and admin queryset filtering with unit tests

## Test plan
- [ ] Open Admin → Loyalty points → LP store offers and confirm tracked-corp offers show Jita sell/buy, cost, and profit columns
- [ ] Confirm navy BPC rows show hull market type and planner build cost; non-product offers show acquisition cost
- [ ] Run sync action and confirm offer cache refreshes without errors
- [ ] `pipenv run python manage.py test industry.tests.test_lp_store_economics --settings=app.settings_test`


Made with [Cursor](https://cursor.com)