### PR TITLE
Fix LP buyback Discord threads reopening after close

### DIFF
--- a/backend/industry/helpers/lp_buyback_discord.py
+++ b/backend/industry/helpers/lp_buyback_discord.py
@@ -143,12 +143,21 @@ def create_order_thread(order: IndustryLoyaltyPointMarketOrder) -> int | None:
         return None
 
 
+def close_order_thread(order: IndustryLoyaltyPointMarketOrder) -> None:
+    """Archive/lock the order thread without posting (avoids Discord reopen race)."""
+    if not order.discord_thread_id:
+        return
+    try:
+        discord.close_thread(channel_id=order.discord_thread_id)
+    except Exception as exc:
+        logger.error("Failed closing LP buyback Discord thread: %s", exc)
+
+
 def post_order_status_update(
     order: IndustryLoyaltyPointMarketOrder,
     *,
     message: str,
     components: list[dict] | None = None,
-    close: bool = False,
 ) -> None:
     if not order.discord_thread_id:
         return
@@ -161,12 +170,6 @@ def post_order_status_update(
         )
     except Exception as exc:
         logger.error("Failed posting LP buyback Discord update: %s", exc)
-        return
-    if close:
-        try:
-            discord.close_thread(channel_id=order.discord_thread_id)
-        except Exception as exc:
-            logger.error("Failed closing LP buyback Discord thread: %s", exc)
 
 
 def notify_order_created(order: IndustryLoyaltyPointMarketOrder) -> None:
@@ -276,15 +279,7 @@ def notify_order_status_changed(
             message=_awaiting_isk_message(order),
             components=isk_sent_components(order.pk),
         )
-    elif status == order.Status.COMPLETED:
-        post_order_status_update(
-            order,
-            message=f":white_check_mark: Completed\n{order_site_url(order)}",
-            close=True,
-        )
-    elif status == order.Status.CANCELLED:
-        post_order_status_update(
-            order,
-            message=f":x: Cancelled\n{order_site_url(order)}",
-            close=True,
-        )
+    elif status in (order.Status.COMPLETED, order.Status.CANCELLED):
+        # Do not post a close/status message — Discord unarchives threads when
+        # anything is sent (including after archive), same race as help tickets.
+        close_order_thread(order)

--- a/backend/industry/tests/test_loyalty_buyback.py
+++ b/backend/industry/tests/test_loyalty_buyback.py
@@ -815,6 +815,37 @@ class LpBuybackSideAwareMessagingTestCase(AppTestCase):
             f"lp_buyback:lp:{order.pk}",
         )
 
+    @patch("industry.helpers.lp_buyback_discord.discord")
+    def test_completed_closes_thread_without_message(self, discord_mock):
+        order = IndustryLoyaltyPointMarketOrder.objects.create(
+            loyalty_point=self.currency,
+            side=IndustryLoyaltyPointMarketOrder.Side.SELL,
+            quantity=1000,
+            isk_per_lp=800,
+            status=IndustryLoyaltyPointMarketOrder.Status.COMPLETED,
+            created_by=self.seller,
+            claimed_by=self.claimer,
+            discord_thread_id=555,
+        )
+        notify_order_status_changed(order)
+        discord_mock.create_message.assert_not_called()
+        discord_mock.close_thread.assert_called_once_with(channel_id=555)
+
+    @patch("industry.helpers.lp_buyback_discord.discord")
+    def test_cancelled_closes_thread_without_message(self, discord_mock):
+        order = IndustryLoyaltyPointMarketOrder.objects.create(
+            loyalty_point=self.currency,
+            side=IndustryLoyaltyPointMarketOrder.Side.SELL,
+            quantity=1000,
+            isk_per_lp=800,
+            status=IndustryLoyaltyPointMarketOrder.Status.CANCELLED,
+            created_by=self.seller,
+            discord_thread_id=777,
+        )
+        notify_order_status_changed(order)
+        discord_mock.create_message.assert_not_called()
+        discord_mock.close_thread.assert_called_once_with(channel_id=777)
+
 
 class LpBuybackDiscordAckApiTestCase(LoyaltyBuybackApiTestCase):
     def setUp(self):

--- a/bot/app/lp_buyback/views.py
+++ b/bot/app/lp_buyback/views.py
@@ -15,6 +15,22 @@ logger = logging.getLogger(__name__)
 LP_SENT_TEMPLATE = r"lp_buyback:lp:(?P<order_id>[0-9]+)"
 ISK_SENT_TEMPLATE = r"lp_buyback:isk:(?P<order_id>[0-9]+)"
 
+# Match help tickets: settle interaction traffic before archiving so Discord
+# does not unarchive the thread when a followup/edit lands after close.
+THREAD_ARCHIVE_DELAY_SECONDS = 5
+
+
+async def _clear_message_buttons(interaction: discord.Interaction) -> None:
+    if interaction.message is None:
+        return
+    try:
+        await interaction.message.edit(view=None)
+    except discord.HTTPException:
+        logger.warning(
+            "Could not clear LP buyback message buttons",
+            exc_info=True,
+        )
+
 
 async def _handle_ack(
     interaction: discord.Interaction,
@@ -24,6 +40,15 @@ async def _handle_ack(
     success_label: str,
 ) -> None:
     await interaction.response.defer(ephemeral=True)
+
+    # ISK sent completes the order and archives the thread. Confirm + clear
+    # buttons before the API close so nothing hits the thread afterward.
+    closes_thread = action == "isk_sent"
+    if closes_thread:
+        await _clear_message_buttons(interaction)
+        await interaction.followup.send(f"{success_label}.", ephemeral=True)
+        await asyncio.sleep(THREAD_ARCHIVE_DELAY_SECONDS)
+
     try:
         result = await asyncio.to_thread(
             discord_ack_order,
@@ -46,16 +71,10 @@ async def _handle_ack(
         )
         return
 
-    if interaction.message is not None:
-        try:
-            await interaction.message.edit(view=None)
-        except discord.HTTPException:
-            logger.warning(
-                "Acked order %s but could not clear message buttons",
-                order_id,
-                exc_info=True,
-            )
+    if closes_thread:
+        return
 
+    await _clear_message_buttons(interaction)
     await interaction.followup.send(
         f"{success_label} (status: {result.status}).",
         ephemeral=True,


### PR DESCRIPTION
## Summary
- Close completed/cancelled LP buyback forum threads without posting a status message (Discord unarchives on any post).
- On ISK-sent ack, clear buttons and send the ephemeral confirmation before archiving, with the same short delay used for help tickets.

## Test plan
- [x] `pipenv run python manage.py test industry.tests.test_loyalty_buyback.LpBuybackSideAwareMessagingTestCase industry.tests.test_loyalty_buyback.LpBuybackDiscordAckApiTestCase --settings=app.settings_test`
- [ ] Complete an LP order via ISK sent button and confirm the thread stays archived
- [ ] Cancel an LP order from the site and confirm the thread closes without a Cancelled post


Made with [Cursor](https://cursor.com)