### PR TITLE
Accept more buyback ores and price stacks under 100

### DIFF
--- a/backend/buyback/helpers/accepted_items.py
+++ b/backend/buyback/helpers/accepted_items.py
@@ -18,8 +18,11 @@ from buyback.helpers.classify import (
 )
 from buyback.models import BuybackAcceptedItem
 
-HIGHSEC_ORE_BASES = frozenset(
+# Compressed belt/moon ores accepted for buyback. Highsec bases plus selected
+# lowsec/nullsec ores (isogen-bearing and Equinox) requested for alliance take.
+BUYBACK_ORE_BASES = frozenset(
     {
+        # Highsec belt + HS moon
         "Veldspar",
         "Scordite",
         "Pyroxeres",
@@ -30,8 +33,20 @@ HIGHSEC_ORE_BASES = frozenset(
         "Sylvite",
         "Bitumens",
         "Coesite",
+        # Lowsec / nullsec belt (incl. isogen-rich)
+        "Hedbergite",
+        "Crokite",
+        "Dark Ochre",
+        # Equinox nullsec
+        "Ytirium",
+        "Eifyrium",
+        "Ducinium",
+        "Griemeer",
     }
 )
+
+# Back-compat alias for older imports / docs.
+HIGHSEC_ORE_BASES = BUYBACK_ORE_BASES
 
 _GRADE_SUFFIX_RE = re.compile(r"\s+(II|III|IV)-Grade$")
 _MOON_PREFIX_RE = re.compile(r"^(Brimful|Glistening)\s+")
@@ -46,21 +61,25 @@ PI_CATEGORIES = (
 )
 
 
-def compressed_highsec_base(name: str) -> str | None:
-    """Return the highsec ore base name if this is a matching Compressed type."""
+def compressed_buyback_ore_base(name: str) -> str | None:
+    """Return the ore base name if this is a matching Compressed buyback type."""
     if not name.startswith("Compressed "):
         return None
     rest = name[len("Compressed ") :]
     rest = _GRADE_SUFFIX_RE.sub("", rest)
     rest = _MOON_PREFIX_RE.sub("", rest)
-    if rest in HIGHSEC_ORE_BASES:
+    if rest in BUYBACK_ORE_BASES:
         return rest
     return None
 
 
+# Back-compat alias.
+compressed_highsec_base = compressed_buyback_ore_base
+
+
 def category_for_eve_type(eve_type: EveType) -> str | None:
     """Map an EveType to a BuybackAcceptedItem.Category value, or None."""
-    if compressed_highsec_base(eve_type.name):
+    if compressed_buyback_ore_base(eve_type.name):
         return BuybackAcceptedItem.Category.ORE
     group_id = getattr(eve_type, "eve_group_id", None)
     if group_id == GROUP_P1:
@@ -146,7 +165,7 @@ def iter_seed_ore_eve_types() -> Iterable[EveType]:
         .select_related("eve_group")
         .iterator()
     ):
-        if compressed_highsec_base(eve_type.name):
+        if compressed_buyback_ore_base(eve_type.name):
             yield eve_type
 
 
@@ -194,7 +213,7 @@ def seed_accepted_items(
     pi_lookback_days: int = DEFAULT_PI_LOOKBACK_DAYS,
 ) -> dict[str, int]:
     """
-    Upsert compressed highsec ores + PI used in recent industry orders.
+    Upsert compressed buyback ores + PI used in recent industry orders.
 
     PI rows outside the lookback BOM set are always deactivated. When
     deactivate_missing is True, active ore rows not in the seed set are also

--- a/backend/buyback/helpers/pricing.py
+++ b/backend/buyback/helpers/pricing.py
@@ -12,7 +12,6 @@ from eveuniverse.models import EveMarketPrice, EveType
 from industry.helpers.compressed_ore import (
     ORE_BATCH_SIZE,
     ore_materials_per_portion,
-    reprocess_output,
 )
 from market.helpers.pricing import JITA_REGION_ID
 from market.models import EveMarketItemHistory
@@ -127,6 +126,31 @@ class PricedLine:
     jita_buy: Optional[float] = None
 
 
+def _prorated_refine_outputs(
+    name: str,
+    quantity: int,
+    refine_rate: float,
+) -> dict[str, float] | None:
+    """
+    Mineral outputs for buyback pricing, prorating partial portions.
+
+    In-game refine floors to whole 100-unit batches, but buyback aggregates
+    stacks across contracts, so fractional amounts under (and remainders
+    above) ORE_BATCH_SIZE are priced in.
+    """
+    if quantity <= 0 or refine_rate <= 0:
+        return None
+    per_portion = ore_materials_per_portion(name)
+    if not per_portion:
+        return None
+    fraction = quantity / ORE_BATCH_SIZE
+    return {
+        mineral: fraction * base_qty * refine_rate
+        for mineral, base_qty in per_portion.items()
+        if base_qty > 0
+    }
+
+
 def price_ore_line(
     *,
     name: str,
@@ -136,19 +160,12 @@ def price_ore_line(
     ore_jita_buy: float,
     mineral_buy_by_name: dict[str, Decimal],
 ) -> PricedLine:
-    outputs = reprocess_output(name, quantity, refine_rate=refine_rate)
+    outputs = _prorated_refine_outputs(name, quantity, refine_rate)
     if not outputs:
-        if 0 < quantity < ORE_BATCH_SIZE:
-            reject_reason = (
-                f"Ore stacks under {ORE_BATCH_SIZE} units do not refine "
-                f"(in-game portion size)"
-            )
-        elif not ore_materials_per_portion(name):
-            reject_reason = "Could not refine ore (no material data)"
+        if quantity <= 0:
+            reject_reason = "Quantity must be positive"
         else:
-            reject_reason = (
-                f"Could not refine ore (need at least {ORE_BATCH_SIZE} units)"
-            )
+            reject_reason = "Could not refine ore (no material data)"
         return PricedLine(
             type_id=type_id,
             name=name,
@@ -173,7 +190,9 @@ def price_ore_line(
             line_total=None,
             accepted=False,
             reject_reason=f"Missing Jita buy for minerals: {', '.join(missing)}",
-            refine_outputs=outputs,
+            refine_outputs={
+                m: int(round(q)) for m, q in outputs.items() if round(q) > 0
+            },
         )
 
     mineral_isk = sum(
@@ -190,7 +209,9 @@ def price_ore_line(
         unit_price=round(unit_price, 2),
         line_total=round(line_total, 2),
         accepted=True,
-        refine_outputs=outputs,
+        refine_outputs={
+            m: int(round(q)) for m, q in outputs.items() if round(q) > 0
+        },
         jita_buy=None,
     )
 

--- a/backend/buyback/management/commands/seed_buyback_accepted_items.py
+++ b/backend/buyback/management/commands/seed_buyback_accepted_items.py
@@ -8,7 +8,7 @@ from buyback.helpers.accepted_items import (
 
 class Command(BaseCommand):
     help = (
-        "Seed buyback accepted items (compressed highsec ores + PI used in "
+        "Seed buyback accepted items (compressed buyback ores + PI used in "
         "recent industry orders)."
     )
 

--- a/backend/buyback/tests/test_appraisal.py
+++ b/backend/buyback/tests/test_appraisal.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from eveuniverse.models import EveCategory, EveGroup, EveType
 
 from buyback.helpers.accepted_items import (
-    compressed_highsec_base,
+    compressed_buyback_ore_base,
     seed_accepted_items,
 )
 from buyback.helpers.classify import BuybackCategory, classify_eve_type
@@ -205,14 +205,14 @@ class PriceBuybackTestCase(TestCase):
         self.assertEqual(line.unit_price, 90.0)
         self.assertEqual(line.line_total, 9000.0)
 
-    @patch("buyback.helpers.pricing.reprocess_output")
-    def test_price_ore_uses_mineral_buys(self, mock_reprocess):
-        mock_reprocess.return_value = {"Tritanium": 1000, "Pyerite": 100}
+    @patch("buyback.helpers.pricing.ore_materials_per_portion")
+    def test_price_ore_uses_mineral_buys(self, mock_per_portion):
+        mock_per_portion.return_value = {"Tritanium": 1000, "Pyerite": 100}
         line = price_ore_line(
             name="Compressed Veldspar",
             quantity=100,
             type_id=62516,
-            refine_rate=0.85,
+            refine_rate=1.0,
             ore_jita_buy=1.0,
             mineral_buy_by_name={
                 "Tritanium": Decimal("4"),
@@ -222,9 +222,22 @@ class PriceBuybackTestCase(TestCase):
         self.assertTrue(line.accepted)
         # 1000*4 + 100*20 = 6000
         self.assertEqual(line.line_total, 6000.0)
-        mock_reprocess.assert_called_once_with(
-            "Compressed Veldspar", 100, refine_rate=0.85
+        mock_per_portion.assert_called_once_with("Compressed Veldspar")
+
+    @patch("buyback.helpers.pricing.ore_materials_per_portion")
+    def test_price_ore_prorates_stacks_under_100(self, mock_per_portion):
+        mock_per_portion.return_value = {"Tritanium": 400}
+        line = price_ore_line(
+            name="Compressed Veldspar",
+            quantity=43,
+            type_id=62516,
+            refine_rate=1.0,
+            ore_jita_buy=1.0,
+            mineral_buy_by_name={"Tritanium": Decimal("5")},
         )
+        self.assertTrue(line.accepted)
+        # 43/100 * 400 Trit * 5 ISK = 860
+        self.assertEqual(line.line_total, 860.0)
 
 
 class BaselineBuyPriceHistoryTestCase(TestCase):
@@ -286,21 +299,32 @@ class BaselineBuyPriceHistoryTestCase(TestCase):
 
 
 class AcceptedItemsSeedTestCase(TestCase):
-    def test_compressed_highsec_base_matches_variants(self):
+    def test_compressed_buyback_ore_base_matches_variants(self):
         self.assertEqual(
-            compressed_highsec_base("Compressed Veldspar"), "Veldspar"
+            compressed_buyback_ore_base("Compressed Veldspar"), "Veldspar"
         )
         self.assertEqual(
-            compressed_highsec_base("Compressed Veldspar II-Grade"),
+            compressed_buyback_ore_base("Compressed Veldspar II-Grade"),
             "Veldspar",
         )
         self.assertEqual(
-            compressed_highsec_base("Compressed Brimful Zeolites"),
+            compressed_buyback_ore_base("Compressed Brimful Zeolites"),
             "Zeolites",
         )
-        self.assertIsNone(compressed_highsec_base("Veldspar"))
-        self.assertIsNone(compressed_highsec_base("Compressed Blue Ice"))
-        self.assertIsNone(compressed_highsec_base("Compressed Arkonor"))
+        self.assertEqual(
+            compressed_buyback_ore_base("Compressed Hedbergite III-Grade"),
+            "Hedbergite",
+        )
+        self.assertEqual(
+            compressed_buyback_ore_base("Compressed Ytirium"), "Ytirium"
+        )
+        self.assertEqual(
+            compressed_buyback_ore_base("Compressed Crokite IV-Grade"),
+            "Crokite",
+        )
+        self.assertIsNone(compressed_buyback_ore_base("Veldspar"))
+        self.assertIsNone(compressed_buyback_ore_base("Compressed Blue Ice"))
+        self.assertIsNone(compressed_buyback_ore_base("Compressed Arkonor"))
 
     @patch("eveonline.signals.update_character_public_data")
     def test_seed_upserts_allowlist(self, unused_mock_public):
@@ -516,10 +540,10 @@ class AppraiseEndpointTestCase(TestCase):
         self.assertFalse(by_name["Compressed Blue Ice"]["accepted"])
 
     @patch(
-        "buyback.helpers.pricing.reprocess_output",
-        return_value={"Tritanium": 100},
+        "buyback.helpers.pricing._prorated_refine_outputs",
+        return_value={"Tritanium": 100.0},
     )
-    def test_appraise_ore_uses_region_history(self, unused_mock_reprocess):
+    def test_appraise_ore_uses_region_history(self, unused_mock_refine):
         trit = _ensure_type(
             type_id=34,
             name="Tritanium",
@@ -550,15 +574,15 @@ class AppraiseEndpointTestCase(TestCase):
         self.assertTrue(by_name["Compressed Veldspar"]["accepted"])
 
     @patch(
-        "buyback.helpers.pricing.reprocess_output",
-        return_value={"Tritanium": 100},
+        "buyback.helpers.pricing._prorated_refine_outputs",
+        return_value={"Tritanium": 100.0},
     )
     @patch(
         "buyback.helpers.appraise.get_baseline_buy_prices_by_name",
         return_value={"Tritanium": Decimal("4")},
     )
     def test_appraise_rejects_items_not_on_allowlist(
-        self, unused_mock_minerals, unused_mock_reprocess
+        self, unused_mock_minerals, unused_mock_refine
     ):
         paste = (
             "Compressed Veldspar\t10\n"

--- a/frontend/app/src/components/blocks/BuybackInfo.astro
+++ b/frontend/app/src/components/blocks/BuybackInfo.astro
@@ -15,7 +15,7 @@ interface Props {
 
 const { settings } = Astro.props
 
-const HIGHSEC_ORE_BASES = [
+const BUYBACK_ORE_BASES = [
     'Veldspar',
     'Scordite',
     'Pyroxeres',
@@ -26,18 +26,25 @@ const HIGHSEC_ORE_BASES = [
     'Sylvite',
     'Bitumens',
     'Coesite',
+    'Hedbergite',
+    'Crokite',
+    'Dark Ochre',
+    'Ytirium',
+    'Eifyrium',
+    'Ducinium',
+    'Griemeer',
 ] as const
 
-const HIGHSEC_ORE_BASE_SET = new Set<string>(HIGHSEC_ORE_BASES)
+const BUYBACK_ORE_BASE_SET = new Set<string>(BUYBACK_ORE_BASES)
 const GRADE_SUFFIX_RE = /\s+(II|III|IV)-Grade$/
 const MOON_PREFIX_RE = /^(Brimful|Glistening)\s+/
 
-function compressed_highsec_base(name: string): string | null {
+function compressed_buyback_ore_base(name: string): string | null {
     if (!name.startsWith('Compressed ')) return null
     let rest = name.slice('Compressed '.length)
     rest = rest.replace(GRADE_SUFFIX_RE, '')
     rest = rest.replace(MOON_PREFIX_RE, '')
-    return HIGHSEC_ORE_BASE_SET.has(rest) ? rest : null
+    return BUYBACK_ORE_BASE_SET.has(rest) ? rest : null
 }
 
 interface DisplayItem {
@@ -70,7 +77,7 @@ function display_items_for_category(category: (typeof CATEGORY_ORDER)[number]): 
     const leftover: BuybackAcceptedItem[] = []
 
     for (const item of items) {
-        const base = compressed_highsec_base(item.name)
+        const base = compressed_buyback_ore_base(item.name)
         if (!base) {
             leftover.push(item)
             continue
@@ -80,7 +87,7 @@ function display_items_for_category(category: (typeof CATEGORY_ORDER)[number]): 
         by_base.set(base, group)
     }
 
-    const grouped: DisplayItem[] = HIGHSEC_ORE_BASES
+    const grouped: DisplayItem[] = BUYBACK_ORE_BASES
         .filter((base) => by_base.has(base))
         .map((base) => {
             const variants = (by_base.get(base) ?? [])

--- a/frontend/app/src/i18n/ui.ts
+++ b/frontend/app/src/i18n/ui.ts
@@ -460,7 +460,7 @@ export const ui = {
 
         'buyback.info.buying': 'Accepted items',
         'buyback.info.no_items': 'No accepted items are configured yet.',
-        'buyback.info.group.ore': 'Compressed highsec ore',
+        'buyback.info.group.ore': 'Compressed ore',
         'buyback.info.group.p1': 'P1',
         'buyback.info.group.p2': 'P2',
         'buyback.info.group.p3': 'P3',
@@ -476,7 +476,7 @@ export const ui = {
 
         'buyback.form.title': 'Get a buyback offer',
         'buyback.form.paste': 'Paste your items',
-        'buyback.form.paste_tip': 'Copy items from Inventory or Assets (Ctrl+A, Ctrl+C) and paste below. Ore is appraised in 100-unit portions.',
+        'buyback.form.paste_tip': 'Copy items from Inventory or Assets (Ctrl+A, Ctrl+C) and paste below. Ore is priced from refine yield (including stacks under 100).',
         'buyback.form.paste_placeholder': 'Compressed Veldspar\t1000\nWater\t5000',
         'buyback.form.submit': 'Appraise',
         'buyback.form.continue': 'Create contract walkthrough',


### PR DESCRIPTION
## Summary
- Expand compressed-ore buyback allowlist with Hedbergite, Crokite, Dark Ochre, and Equinox ores (Ytirium, Eifyrium, Ducinium, Griemeer) requested from Discord feedback.
- Price ore from prorated refine yield so stacks under 100 (and remainders) are paid; industry planner portion flooring is unchanged.
- Update buyback UI copy and add coverage for the new bases / fractional pricing.

## Test plan
- [ ] `pipenv run python manage.py test buyback.tests.test_appraisal --settings=app.settings_test`
- [ ] After deploy, run `pipenv run python manage.py seed_buyback_accepted_items` so new ore types are activated in the DB allowlist
- [ ] Paste the rejected ore list (Crokite/Dark Ochre/Ducinium/Eifyrium/Griemeer/Hedbergite/Ytirium + Kernite IV-Grade 43) and confirm they appraise instead of “not accepted” / under-100 reject
- [ ] Confirm Arkonor (and other non-allowlisted nullsec ores) still reject
- [ ] Spot-check that a 100-unit Veldspar offer is still in the same ballpark as before (full portion)


Made with [Cursor](https://cursor.com)