### PR TITLE
Defer unused global frontend scripts and hero video

### DIFF
--- a/frontend/app/src/components/blocks/CombatLogChart.astro
+++ b/frontend/app/src/components/blocks/CombatLogChart.astro
@@ -21,8 +21,10 @@ import FlexInline from '@components/compositions/FlexInline.astro'
 
 import Button from '@components/blocks/Button.astro'
 import MultiRangeInput from '@components/blocks/MultiRangeInput.astro';
+import ChartJsScript from '@components/partials/ChartJsScript.astro';
 ---
 
+<ChartJsScript />
 <Flexblock
     x-data={`{
         min: 0,

--- a/frontend/app/src/components/blocks/FittingCustom.astro
+++ b/frontend/app/src/components/blocks/FittingCustom.astro
@@ -280,6 +280,8 @@ import Markdown from '@components/blocks/Markdown.astro';
     </defs>
 </svg>
 
+<script is:inline type="module" src="https://ajax.googleapis.com/ajax/libs/model-viewer/4.0.0/model-viewer.min.js"></script>
+
 <style lang="scss">
     model-viewer::part(default-progress-bar) {
         top: 50%;

--- a/frontend/app/src/components/blocks/FlatPicker.astro
+++ b/frontend/app/src/components/blocks/FlatPicker.astro
@@ -14,6 +14,9 @@ const {
 } = Astro.props
 ---
 
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+<script is:inline src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+
 <div class="[ input-group ]">
     <slot name="icon" />
     <input

--- a/frontend/app/src/components/blocks/MultiRangeInput.astro
+++ b/frontend/app/src/components/blocks/MultiRangeInput.astro
@@ -8,6 +8,9 @@ const {
 } = Astro.props
 ---
 
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/nouislider@15.6.0/dist/nouislider.min.css">
+<script is:inline src="https://cdn.jsdelivr.net/npm/nouislider@15.6.0/dist/nouislider.min.js"></script>
+
 <div
     class="[ multi-range-input ]"
     x-data={`{

--- a/frontend/app/src/components/blocks/TuiEditor.astro
+++ b/frontend/app/src/components/blocks/TuiEditor.astro
@@ -25,6 +25,8 @@ const {
 </Wrapper>
 <div id="editor" style="display: none" set:html={content} />
 
+<script is:inline src="/js/toastui-editor-all.min.js"></script>
+
 <script is:inline>
     function initEditor() {
         // const { Editor } = await import('@toast-ui/editor')

--- a/frontend/app/src/components/blocks/campaigns/auga/AugaDailyShipsChartChartjs.astro
+++ b/frontend/app/src/components/blocks/campaigns/auga/AugaDailyShipsChartChartjs.astro
@@ -1,10 +1,12 @@
 ---
 import { DAYS, SHIPS_DESTROYED_DAILY } from '@/data/campaigns/auga'
+import ChartJsScript from '@components/partials/ChartJsScript.astro';
 
 const days = [...DAYS]
 const shipsData = [...SHIPS_DESTROYED_DAILY]
 ---
 
+<ChartJsScript />
 <div
     class="[ h-screen ]"
     x-data={`{

--- a/frontend/app/src/components/blocks/campaigns/etherium-reach/PlayerContentChartChartjs.astro
+++ b/frontend/app/src/components/blocks/campaigns/etherium-reach/PlayerContentChartChartjs.astro
@@ -6,6 +6,7 @@ import {
     MONTHS,
     toBillions,
 } from '@/data/campaigns/etherium-reach'
+import ChartJsScript from '@components/partials/ChartJsScript.astro';
 
 const iskData = ISK_DESTROYED_MONTHLY.map(toBillions)
 const fleetData = FLEETS_MONTHLY
@@ -48,6 +49,7 @@ const beatsConfig = CAMPAIGN_BEATS.map((beat) => ({
 }))
 ---
 
+<ChartJsScript />
 <div
     class="[ h-screen ]"
     x-data={`{

--- a/frontend/app/src/components/blocks/campaigns/etherium-reach/PlayerIncomeChartChartjs.astro
+++ b/frontend/app/src/components/blocks/campaigns/etherium-reach/PlayerIncomeChartChartjs.astro
@@ -7,6 +7,7 @@ import {
     RATTING_GROSS_ISK,
     toBillions,
 } from '@/data/campaigns/etherium-reach'
+import ChartJsScript from '@components/partials/ChartJsScript.astro';
 
 const miningData = MINING_GROSS_ISK.map(toBillions)
 const rattingData = RATTING_GROSS_ISK.map(toBillions)
@@ -14,6 +15,7 @@ const piData = PI_GROSS_ISK.map(toBillions)
 const explorationData = EXPLORATION_GROSS_ISK.map(toBillions)
 ---
 
+<ChartJsScript />
 <div
     class="[ h-screen ]"
     x-data={`{

--- a/frontend/app/src/components/blocks/campaigns/providence/ProvidenceContentChartChartjs.astro
+++ b/frontend/app/src/components/blocks/campaigns/providence/ProvidenceContentChartChartjs.astro
@@ -6,6 +6,7 @@ import {
     MONTHS,
     toBillions,
 } from '@/data/campaigns/providence'
+import ChartJsScript from '@components/partials/ChartJsScript.astro';
 
 const iskData = ISK_DESTROYED_MONTHLY.map(toBillions)
 const fleetData = FLEETS_MONTHLY
@@ -47,6 +48,7 @@ const beatsConfig = CAMPAIGN_BEATS.map((beat) => ({
 }))
 ---
 
+<ChartJsScript />
 <div
     class="[ h-screen ]"
     x-data={`{

--- a/frontend/app/src/components/blocks/campaigns/scalding-pass/PlayerContentChartChartjs.astro
+++ b/frontend/app/src/components/blocks/campaigns/scalding-pass/PlayerContentChartChartjs.astro
@@ -6,6 +6,7 @@ import {
     MONTHS,
     toBillions,
 } from '@/data/campaigns/scalding-pass'
+import ChartJsScript from '@components/partials/ChartJsScript.astro';
 
 const iskData = ISK_DESTROYED_MONTHLY.map(toBillions)
 const fleetData = [...FLEETS_MONTHLY]
@@ -45,6 +46,7 @@ const beatsConfig = CAMPAIGN_BEATS.map((beat) => ({
 }))
 ---
 
+<ChartJsScript />
 <div
     class="[ h-screen ]"
     x-data={`{

--- a/frontend/app/src/components/blocks/industry/guide-order-summary/GuideOrderProfitBarChart.astro
+++ b/frontend/app/src/components/blocks/industry/guide-order-summary/GuideOrderProfitBarChart.astro
@@ -1,4 +1,6 @@
 ---
+import ChartJsScript from '@components/partials/ChartJsScript.astro';
+
 interface Props {
     labels: readonly string[]
     valuesM: readonly number[]
@@ -8,6 +10,7 @@ const { labels, valuesM } = Astro.props
 const chartId = `guide-order-profit-bar-${Math.random().toString(36).slice(2, 9)}`
 ---
 
+<ChartJsScript />
 <div
     class="[ guide-order-profit-chart ]"
     x-data={`{

--- a/frontend/app/src/components/page/partials/PageCover.astro
+++ b/frontend/app/src/components/page/partials/PageCover.astro
@@ -63,11 +63,31 @@ const animate_cover = !oob_swap || (old_cover !== image)
             width="1920"
             height="1080"
             poster={video_thumb}
-            autoplay
+            muted
+            playsinline
             loop
-        >
-            <source src={video} type="video/webm" />
-        </video>
+            preload="none"
+            x-ref="coverVideo"
+            x-data={`{
+                src: ${JSON.stringify(video)},
+                started: false,
+                start() {
+                    if (this.started) return
+                    this.started = true
+                    const videoEl = this.$refs.coverVideo
+                    if (!videoEl || !this.src) return
+                    if (!videoEl.querySelector('source')) {
+                        const source = document.createElement('source')
+                        source.src = this.src
+                        source.type = 'video/webm'
+                        videoEl.appendChild(source)
+                    }
+                    videoEl.load()
+                    videoEl.play().catch(() => {})
+                }
+            }`}
+            x-intersect.once="start()"
+        ></video>
     }
 </div>
 

--- a/frontend/app/src/components/partials/ChartJsScript.astro
+++ b/frontend/app/src/components/partials/ChartJsScript.astro
@@ -1,0 +1,1 @@
+<script is:inline src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/frontend/app/src/components/partials/FooterScripts.astro
+++ b/frontend/app/src/components/partials/FooterScripts.astro
@@ -1,8 +1,5 @@
 ---
-import { is_disabled_ccpwgl } from '@helpers/env';
 import LearningAlpine from '@components/partials/LearningAlpine.astro';
-
-const DISABLED_CCPWGL = is_disabled_ccpwgl()
 ---
 
 <LearningAlpine />
@@ -14,7 +11,6 @@ const DISABLED_CCPWGL = is_disabled_ccpwgl()
 <script is:inline src="https://unpkg.com/@popperjs/core@2"></script>
 <script is:inline src="https://unpkg.com/tippy.js@6"></script>
 <script is:inline src="https://cdn.jsdelivr.net/npm/@tsparticles/confetti@3.0.3/tsparticles.confetti.bundle.min.js"></script>
-<script is:inline src="https://cdn.jsdelivr.net/npm/tsparticles/dist/tsparticles.min.js"></script>
 
 <script is:inline>
     const canvas = document.getElementById("confetti-canvas");
@@ -115,18 +111,4 @@ const DISABLED_CCPWGL = is_disabled_ccpwgl()
     }
 </script>
 
-{!DISABLED_CCPWGL &&
-    <script is:inline type="text/javascript" src="/js/ccpwgl/ccpwgl_int.min.js"></script>
-    <script is:inline type="text/javascript" src="/js/ccpwgl/ccpwgl.js"></script>
-    <script is:inline type="text/javascript" src="/js/ccpwgl/minmatar.js"></script>
-}
-
-<script is:inline src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
-
-<script is:inline src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-
 <script src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1/lite-youtube.min.js"></script>
-
-<script src="https://ajax.googleapis.com/ajax/libs/model-viewer/4.0.0/model-viewer.min.js"></script>
-
-<script is:inline src="/js/toastui-editor-all.min.js"></script>

--- a/frontend/app/src/components/partials/HeadScripts.astro
+++ b/frontend/app/src/components/partials/HeadScripts.astro
@@ -36,9 +36,4 @@
 
 <script defer src="https://unpkg.com/htmx.org@1.9.10"></script>
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/nouislider@15.6.0/dist/nouislider.min.css">
-<script is:inline src="https://cdn.jsdelivr.net/npm/nouislider@15.6.0/dist/nouislider.min.js"></script>
-
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
-
 <script src="https://cdn.jsdelivr.net/npm/medium-zoom/dist/medium-zoom.min.js"></script>

--- a/frontend/app/src/pages/celestials.astro
+++ b/frontend/app/src/pages/celestials.astro
@@ -23,10 +23,20 @@ import Flexblock from '@components/compositions/Flexblock.astro';
 import Input from '@components/blocks/Input.astro';
 import FlexInline from '@components/compositions/FlexInline.astro';
 
+import { is_disabled_ccpwgl } from '@helpers/env';
+
+const DISABLED_CCPWGL = is_disabled_ccpwgl()
 const page_title = 'Celestials';
 ---
 
 <Viewport title={page_title}>
+    {!DISABLED_CCPWGL &&
+        <>
+            <script is:inline type="text/javascript" src="/js/ccpwgl/ccpwgl_int.min.js"></script>
+            <script is:inline type="text/javascript" src="/js/ccpwgl/ccpwgl.js"></script>
+            <script is:inline type="text/javascript" src="/js/ccpwgl/minmatar.js"></script>
+        </>
+    }
     <PageLanding
         fullscreen={true}
         wide={true}


### PR DESCRIPTION
## Summary
- Move toastui, Chart.js, flatpickr, nouislider, model-viewer, and ccpwgl out of global Head/Footer scripts so they only load on pages that use them; drop unused `tsparticles.min.js` from the footer.
- Defer `PageCover` hero video with `preload="none"`, `muted`, `playsinline`, and in-view source attach/play so the poster can paint first.
- Expect ~0.9–1 MB less JS on cold homepage loads; SSR/TTFB unchanged.

## Test plan
- [ ] Cold-load homepage: confirm HTML has no toastui / chart.js / flatpickr / nouislider / model-viewer / tsparticles.min / ccpwgl script tags
- [ ] Homepage with video staging (e.g. Amamake): poster shows, then loop starts after intersect; no eager `<source>` in initial HTML
- [ ] Fleet add / timers add: FlatPicker still works
- [ ] Campaign page with charts (e.g. Auga): Chart.js renders
- [ ] Fitting render: model-viewer loads
- [ ] Propaganda/post editor: toastui editor initializes
- [ ] Combat log chart: MultiRangeInput + Chart.js still work


Made with [Cursor](https://cursor.com)