### PR TITLE
Fix LP ledger admin add/change crashes

### DIFF
--- a/backend/industry/admin.py
+++ b/backend/industry/admin.py
@@ -647,6 +647,12 @@ class IndustryLoyaltyPointLedgerEntryAdmin(admin.ModelAdmin):
 
         return RequestLedgerForm
 
+    def save_model(self, request, obj, form, change):
+        if not change:
+            # Already persisted by form.save() via post_ledger_entry.
+            return
+        super().save_model(request, obj, form, change)
+
     def has_delete_permission(self, request, obj=None):
         return False
 

--- a/backend/industry/forms.py
+++ b/backend/industry/forms.py
@@ -236,17 +236,27 @@ class IndustryLoyaltyPointLedgerEntryAdminForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.instance and self.instance.pk:
+            # On change, admin fieldsets/readonly drop these; the model
+            # isk_per_lp is shown via readonly_fields instead.
             for name in ("direction", "quantity", "isk_per_lp"):
-                self.fields[name].disabled = True
-                self.fields[name].required = False
+                self.fields.pop(name, None)
 
     def save(self, commit=True):
+        if self.instance.pk:
+            return self._save_existing(commit)
+        return self._save_new(commit)
+
+    def _save_existing(self, commit: bool):
         existing = self.instance
-        if existing.pk:
-            existing.notes = self.cleaned_data.get("notes") or ""
-            if commit:
-                existing.save(update_fields=["notes"])
-            return existing
+        existing.notes = self.cleaned_data.get("notes") or ""
+        if commit:
+            existing.save(update_fields=["notes"])
+        else:
+            # Admin always uses commit=False then form.save_m2m().
+            self.save_m2m = self._save_m2m_noop
+        return existing
+
+    def _save_new(self, commit: bool):
         direction = self.cleaned_data["direction"]
         quantity = int(self.cleaned_data["quantity"])
         amount = (
@@ -254,10 +264,18 @@ class IndustryLoyaltyPointLedgerEntryAdminForm(forms.ModelForm):
             if direction == IndustryLoyaltyPointAccountAdminForm.LEDGER_DEBIT
             else quantity
         )
-        return post_ledger_entry(
+        self.instance = post_ledger_entry(
             self.cleaned_data["account"],
             amount,
             int(self.cleaned_data["isk_per_lp"]),
             notes=self.cleaned_data.get("notes") or "",
             user=getattr(self, "_request_user", None),
         )
+        if not commit:
+            self.save_m2m = self._save_m2m_noop
+        return self.instance
+
+    @staticmethod
+    def _save_m2m_noop():
+        """No M2M fields; satisfy ModelAdmin.save_related after commit=False."""
+        return None

--- a/backend/industry/tests/test_lp_admin.py
+++ b/backend/industry/tests/test_lp_admin.py
@@ -177,6 +177,77 @@ class LpAdminViewsTestCase(TestCase):
         self.assertContains(response, "Direction")
         self.assertContains(response, "LP quantity")
 
+    def test_ledger_add_posts_credit(self):
+        url = reverse("admin:industry_industryloyaltypointledgerentry_add")
+        response = self.client.post(
+            url,
+            {
+                "account": self.account.pk,
+                "direction": "credit",
+                "quantity": "250000",
+                "isk_per_lp": "825",
+                "notes": "admin add",
+                "_continue": "Save and continue editing",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(account_balance(self.account), 250000)
+        entry = IndustryLoyaltyPointLedgerEntry.objects.get(
+            account=self.account
+        )
+        self.assertEqual(entry.amount, 250000)
+        self.assertEqual(entry.isk_per_lp, 825)
+        self.assertEqual(entry.notes, "admin add")
+        self.assertEqual(entry.created_by, self.user)
+        self.assertEqual(
+            IndustryLoyaltyPointLedgerEntry.objects.filter(
+                account=self.account
+            ).count(),
+            1,
+        )
+
+    def test_ledger_change_page_loads(self):
+        entry = post_ledger_entry(
+            self.account,
+            100_000,
+            850,
+            notes="seed",
+            user=self.user,
+        )
+        url = reverse(
+            "admin:industry_industryloyaltypointledgerentry_change",
+            args=[entry.pk],
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Alliance pot")
+        self.assertContains(response, "850")
+
+    def test_ledger_change_updates_notes(self):
+        entry = post_ledger_entry(
+            self.account,
+            100_000,
+            850,
+            notes="seed",
+            user=self.user,
+        )
+        url = reverse(
+            "admin:industry_industryloyaltypointledgerentry_change",
+            args=[entry.pk],
+        )
+        response = self.client.post(
+            url,
+            {
+                "notes": "updated note",
+                "_continue": "Save and continue editing",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        entry.refresh_from_db()
+        self.assertEqual(entry.notes, "updated note")
+        self.assertEqual(entry.amount, 100_000)
+        self.assertEqual(account_balance(self.account), 100_000)
+
     def test_market_order_change_page_loads(self):
         order = IndustryLoyaltyPointMarketOrder.objects.create(
             loyalty_point=self.currency,


### PR DESCRIPTION
## Summary
- Fix `AttributeError: RequestLedgerForm.save_m2m` when adding ledger entries from Django admin (`MINMATAR-REST-API-MT`)
- Fix `KeyError: isk_per_lp` when opening existing ledger entries (`MINMATAR-REST-API-MV`)
- Skip double-save on add since `post_ledger_entry` already persists the row
- Add admin regression tests for add POST, change GET, and notes update

## Test plan
- [x] `pipenv run python manage.py test industry.tests.test_lp_admin --settings=app.settings_test`
- [ ] In admin, add a ledger credit via Industry loyalty point ledger entries → confirm redirect and single row
- [ ] Open that entry's change page → confirm it loads
- [ ] Edit notes and save → confirm notes update without changing amount/balance


Made with [Cursor](https://cursor.com)