### PR TITLE
Document Jita guide vs location ItemPrice market sources

### DIFF
--- a/.cursor/rules/market-pricing.mdc
+++ b/.cursor/rules/market-pricing.mdc
@@ -1,0 +1,38 @@
+---
+description: Choose the correct EVE market price source — Jita/Forge guide vs live location ItemPrice. Read before using ItemPrice, EveMarketItemLocationPrice, Jita prices, or regional history.
+globs: backend/market/**/*.py,backend/buyback/**/*.py,backend/industry/**/*.py
+alwaysApply: false
+---
+
+# Market pricing sources
+
+There is **no** model named `ItemPrice`. Colloquial “ItemPrice” means **`EveMarketItemLocationPrice`** (live order book at one location). Do **not** use it as the Jita guide price.
+
+See also: `docs/market-pricing.md`.
+
+## Which source to use
+
+| Need | Use | Helper |
+|------|-----|--------|
+| **Jita / Forge guide** (“Jita buy/sell”, appraisal baseline, LP economics) | `EveMarketItemHistory` for `price_baseline` region (The Forge when Jita is baseline), then `EveMarketPrice` | `market.helpers.pricing.get_prices_by_type_id` or `buyback.helpers.pricing.get_baseline_buy_prices` |
+| **Live book at a hub/structure** (local sell/buy/split) | `EveMarketItemLocationPrice` | Synced via `market.helpers.location_price` for `prices_active` locations |
+| **Industry planner “Jita sell”** | Hybrid: baseline LocationPrice **sell**, else history | `industry.helpers.cost_breakdown.jita_sell_prices_by_type_id` |
+| **Coarse CCP average only** | `eveuniverse.EveMarketPrice` | Last resort / filters — prefer history helpers above |
+
+## Rules
+
+- For **Jita guide prices**, call `get_prices_by_type_id` / `get_baseline_buy_prices`. Never query `EveMarketItemLocationPrice` alone as “Jita”.
+- Jita NPC station buy orders are often **empty** in LocationPrice; that broke buyback when LocationPrice was used as the guide (#2548).
+- LP store / buyback / markup baselines use **regional history**, not live station rows.
+- `EveLocation.price_baseline` → which location’s **region** drives guide history (exactly one).
+- `EveLocation.prices_active` → sync LocationPrice from ESI (Jita can be prices_active without being a structure market).
+- `EveLocation.market_active` → alliance market sell-order / expectation flows — **not** the same as prices_active.
+
+```python
+# ❌ BAD — live station book as “Jita”
+EveMarketItemLocationPrice.objects.filter(location=baseline).values("buy_price")
+
+# ✅ GOOD — Forge/Jita regional guide
+from market.helpers.pricing import get_prices_by_type_id
+prices = get_prices_by_type_id(type_ids)
+```

--- a/backend/industry/helpers/cost_breakdown.py
+++ b/backend/industry/helpers/cost_breakdown.py
@@ -79,8 +79,11 @@ class PlanCostBreakdown:
 
 def jita_sell_prices_by_type_id(type_ids: Sequence[int]) -> Dict[int, int]:
     """
-    Lowest sell at the price_baseline location when available, else Jita-region
-    history / EveMarketPrice via ``get_prices_by_type_id``.
+    Industry “Jita sell”: lowest sell at price_baseline LocationPrice when
+    present, else regional guide via get_prices_by_type_id.
+
+    Prefer get_prices_by_type_id alone when you need the Forge history
+    guide (buyback, LP store), not this hybrid.
     """
     unique = list({int(tid) for tid in type_ids if tid})
     if not unique:

--- a/backend/industry/helpers/lp_store_economics.py
+++ b/backend/industry/helpers/lp_store_economics.py
@@ -1,4 +1,9 @@
-"""Economics helpers for admin LP store offer price tracking."""
+"""Economics helpers for admin LP store offer price tracking.
+
+Jita sell/buy columns use regional guide prices via
+market.helpers.pricing.get_prices_by_type_id (EveMarketItemHistory),
+not EveMarketItemLocationPrice live station orders.
+"""
 
 from __future__ import annotations
 

--- a/backend/market/helpers/location_price.py
+++ b/backend/market/helpers/location_price.py
@@ -1,9 +1,12 @@
 """Fetch market orders from ESI and update EveMarketItemLocationPrice.
 
-Supports both Upwell structures (structure markets API) and NPC stations
-(region orders API). Does not touch EveMarketItemOrder. Fetches orders in
-memory, computes lowest sell / highest buy (station-range only) / split
-per item, and writes only to EveMarketItemLocationPrice.
+Live per-location order-book aggregates (“ItemPrice”): lowest sell, highest
+station-range buy, and split. Supports Upwell structures and NPC stations.
+Does not touch EveMarketItemOrder.
+
+This is **not** the Jita/Forge guide price. For appraisals, LP economics,
+and “Jita buy/sell” baselines, use market.helpers.pricing.get_prices_by_type_id
+(regional EveMarketItemHistory). See docs/market-pricing.md.
 """
 
 import logging

--- a/backend/market/helpers/pricing.py
+++ b/backend/market/helpers/pricing.py
@@ -1,4 +1,14 @@
-"""Market price helpers for implant and item valuation."""
+"""
+Jita / price_baseline **regional guide** prices.
+
+Canonical source for “what is this worth in Jita?” is EveMarketItemHistory
+for the price_baseline location’s region (The Forge when Jita is baseline),
+with eveuniverse EveMarketPrice as fallback.
+
+Do **not** use EveMarketItemLocationPrice (live station/structure order book,
+aka “ItemPrice”) as the Jita guide — see docs/market-pricing.md and
+.cursor/rules/market-pricing.mdc.
+"""
 
 from datetime import timedelta
 
@@ -22,10 +32,13 @@ def _baseline_region_id() -> int:
 
 def get_prices_by_type_id(type_ids: list[int]) -> dict[int, int]:
     """
-    Return Jita-baseline ISK prices for type IDs.
+    Return Jita-baseline ISK guide prices for type IDs.
 
-    Uses the price_baseline location's region history when configured,
-    otherwise falls back to eveuniverse EveMarketPrice.average_price.
+    Prefers latest EveMarketItemHistory.average for the price_baseline
+    location's region (Forge when Jita is baseline). Missing types fall
+    back to EveMarketPrice.average_price.
+
+    This is regional history, not EveMarketItemLocationPrice live orders.
     """
     if not type_ids:
         return {}

--- a/backend/market/models/history.py
+++ b/backend/market/models/history.py
@@ -7,9 +7,11 @@ class EveMarketItemHistory(models.Model):
     """
     Daily region market history for an item in a region.
 
-    One row per (region_id, item, date) so we fetch each (region, type_id)
-    from ESI only once per date. Populated from GET markets/{region_id}/history/?type_id=.
-    Use location.region_id to query history for a location.
+    One row per (region_id, item, date). Populated from ESI
+    GET markets/{region_id}/history/?type_id=. Query via location.region_id
+    (price_baseline region = Jita/Forge guide). Used by
+    market.helpers.pricing.get_prices_by_type_id — preferred over
+    EveMarketItemLocationPrice for appraisals and “Jita” guide prices.
     """
 
     region_id = models.BigIntegerField(

--- a/backend/market/models/location_price.py
+++ b/backend/market/models/location_price.py
@@ -1,8 +1,12 @@
 """
-Store derived sell, buy, and split prices per (location, eve type).
+Live sell / buy / split prices per (location, eve type).
 
-Computed from EveMarketItemOrder: lowest sell price, highest buy price,
-and average of the two (split) for locations we fetch orders for.
+“ItemPrice” in conversation usually means this model
+(EveMarketItemLocationPrice): current order-book aggregates at one
+EveLocation (prices_active), not the Jita regional guide.
+
+For Jita/Forge guide prices use EveMarketItemHistory via
+market.helpers.pricing.get_prices_by_type_id — see docs/market-pricing.md.
 """
 
 from django.db import models
@@ -14,10 +18,11 @@ from eveonline.models import EveLocation
 
 class EveMarketItemLocationPrice(models.Model):
     """
-    One row per (location, item): lowest sell price, highest buy price,
-    and split (average of the two) from the structure orders endpoint.
+    One row per (location, item): lowest sell, highest station-range buy,
+    and split from the live ESI order book at that location.
 
-    Populated after fetching orders for market-active locations.
+    Synced for EveLocation.prices_active (not market_active). Not the
+    canonical Jita guide — use EveMarketItemHistory / get_prices_by_type_id.
     """
 
     location = models.ForeignKey(

--- a/docs/market-pricing.md
+++ b/docs/market-pricing.md
@@ -1,0 +1,96 @@
+# Market pricing
+
+How we store and choose EVE market prices. Agents and developers should use this when implementing appraisals, LP economics, industry costs, or market UI.
+
+## Naming cheat sheet
+
+| Colloquial name | Actual model / API |
+|-----------------|--------------------|
+| ItemPrice / LocationPrice | `EveMarketItemLocationPrice` |
+| Regional / Forge / Jita history / “Jita guide” | `EveMarketItemHistory` via `get_prices_by_type_id` |
+| CCP / ESI adjusted average | `eveuniverse.models.EveMarketPrice` |
+| Industry “Jita sell” | `jita_sell_prices_by_type_id` (LocationPrice sell → history fallback) |
+
+There is **no** Django model named `ItemPrice`.
+
+## Two different “Jita” concepts
+
+### 1. Jita / Forge **guide** price (preferred for “what is this worth in Jita?”)
+
+Regional daily averages from ESI `GET markets/{region_id}/history/`, stored as `EveMarketItemHistory`.
+
+- Region comes from the single `EveLocation` with `price_baseline=True` (normally Jita → The Forge, region `10000002`).
+- Latest day’s `average` is the guide price.
+- If history is missing, fall back to `EveMarketPrice.average_price`.
+
+**Helpers (use these):**
+
+- `market.helpers.pricing.get_prices_by_type_id` — shared ISK int map by type ID
+- `buyback.helpers.pricing.get_baseline_buy_prices` / `get_baseline_buy_prices_by_name` — Decimal guide for buyback
+
+**Used by:** buyback appraisals, LP store offer economics, ops/markup baselines, sell-order admin “jita_price”, inferred-sale baselines.
+
+**Sync:** Celery `fetch_market_item_history` / `fetch_market_item_history_for_type` → `market.helpers.history`.
+
+### 2. Live **location** order book (“ItemPrice”)
+
+Per-(location, type) aggregates from current ESI orders:
+
+- `sell_price` — lowest sell
+- `buy_price` — highest **station-range** buy (region-wide lowballs excluded)
+- `split_price` — midpoint when both exist
+
+Stored as `EveMarketItemLocationPrice`.
+
+**Use for:** structure/hub market UIs, comparing local book vs guide, industry sell when a synced baseline sell exists.
+
+**Do not** treat LocationPrice alone as the canonical Jita guide. At the Jita NPC station, buy rows are often empty; using them as “Jita buy” rejected all ore appraisals until buyback switched to history (PR #2548).
+
+**Sync:** `fetch_market_location_prices` for locations with `prices_active=True` (not `market_active`). Jita can sync LocationPrice without enabling alliance market flows.
+
+## Location flags (`EveLocation`)
+
+| Flag | Meaning |
+|------|---------|
+| `price_baseline` | Exactly one active location. Its **region** drives guide history. |
+| `prices_active` | Fetch/update `EveMarketItemLocationPrice` from ESI. |
+| `market_active` | Alliance market expectations / sell-order tooling. |
+
+## Decision guide
+
+```
+Need a Jita/Forge “guide” or appraisal baseline?
+  → get_prices_by_type_id / get_baseline_buy_prices
+  → EveMarketItemHistory (+ EveMarketPrice fallback)
+  → NOT EveMarketItemLocationPrice alone
+
+Need live sell/buy at Amamake (or another hub)?
+  → EveMarketItemLocationPrice for that EveLocation
+
+Need industry planner material “Jita sell”?
+  → jita_sell_prices_by_type_id
+    (baseline LocationPrice.sell_price, else get_prices_by_type_id)
+
+Only need a coarse average / “has any price”?
+  → EveMarketPrice is acceptable; prefer history helpers when building ISK values users see
+```
+
+## Correct examples in-repo
+
+- **LP store:** `industry.helpers.lp_store_economics` → `get_prices_by_type_id` (Forge history). Tests seed `EveMarketItemHistory`, not LocationPrice.
+- **Buyback:** `buyback.helpers.pricing.get_baseline_buy_prices` — history only; docstring states not live order-book rows.
+- **Market admin contrast:** local book from LocationPrice, separate `jita_price` from history/`get_prices_by_type_id`.
+
+## Incorrect pattern (do not repeat)
+
+```python
+# Wrong: live station ItemPrice as Jita guide
+baseline = EveLocation.objects.get(price_baseline=True)
+EveMarketItemLocationPrice.objects.filter(location=baseline).values("buy_price")
+```
+
+```python
+# Right
+from market.helpers.pricing import get_prices_by_type_id
+prices = get_prices_by_type_id(type_ids)
+```


### PR DESCRIPTION
## Summary
- Add agent rule and `docs/market-pricing.md` so Jita/Forge guide prices use regional history helpers (`get_prices_by_type_id`), not live `EveMarketItemLocationPrice` (“ItemPrice”).
- Clarify location flags (`price_baseline` / `prices_active` / `market_active`) and point key market/buyback/industry helpers at the same guidance.
- Documents the buyback (#2548) failure mode: empty Jita station buys when LocationPrice was used as the guide.

## Test plan
- [ ] Skim `docs/market-pricing.md` and `.cursor/rules/market-pricing.mdc` for accuracy against current helpers
- [ ] Confirm docstring-only changes in market/industry helpers need no test updates
- [ ] Optional: ask an agent “how do I get Jita prices?” and verify it cites history/`get_prices_by_type_id`


Made with [Cursor](https://cursor.com)