### PR TITLE
Fail-closed Discord auth.Group sync + live verification

### DIFF
--- a/backend/app/settings_celery.py
+++ b/backend/app/settings_celery.py
@@ -178,6 +178,13 @@ CELERYBEAT_GROUPS = [
         },
     ),
     (
+        "[Groups] Sync Community Groups",
+        {
+            "task": "groups.tasks.sync_community_groups",
+            "schedule": crontab(minute="20,50", hour="*"),
+        },
+    ),
+    (
         "[Groups] Sync Tribe Chief group",
         {
             "task": "groups.tasks.sync_tribe_chief_group",

--- a/backend/app/settings_test.py
+++ b/backend/app/settings_test.py
@@ -50,19 +50,18 @@ CORS_ALLOWED_ORIGINS = [
     "https://minmatar.org",
 ]
 
-# DISCORD
-DISCORD_BOT_TOKEN = os.environ.get("DISCORD_BOT_TOKEN", "")
-DISCORD_CLIENT_ID = os.environ.get("DISCORD_CLIENT_ID", "")
-DISCORD_CLIENT_SECRET = os.environ.get("DISCORD_CLIENT_SECRET", "")
-DISCORD_REDIRECT_URL = os.environ.get("DISCORD_REDIRECT_URL", "")
-DISCORD_ADMIN_REDIRECT_URL = os.environ.get("DISCORD_ADMIN_REDIRECT_URL", "")
-DISCORD_HOLY_RAT_WEBHOOK_MINMATAR_FLEET = os.environ.get(
-    "DISCORD_HOLY_RAT_WEBHOOK_MINMATAR_FLEET", ""
-)
-DISCORD_HOLY_RAT_WEBHOOK_RAT_CAVE = os.environ.get(
-    "DISCORD_HOLY_RAT_WEBHOOK_RAT_CAVE", ""
-)
-DISCORD_GUILD_ID = int(os.environ.get("DISCORD_GUILD_ID", 1041384161505722368))
+# DISCORD — never use real bot/OAuth secrets from the environment in unit tests.
+# Pipenv may load a .env with production tokens; those must not reach DiscordClient.
+DISCORD_BOT_TOKEN = ""
+DISCORD_CLIENT_ID = ""
+DISCORD_CLIENT_SECRET = ""
+DISCORD_REDIRECT_URL = ""
+DISCORD_ADMIN_REDIRECT_URL = ""
+DISCORD_HOLY_RAT_WEBHOOK_MINMATAR_FLEET = ""
+DISCORD_HOLY_RAT_WEBHOOK_RAT_CAVE = ""
+# Non-production placeholder; live verify must use app.settings + test guild.
+DISCORD_GUILD_ID = 1
+ALLOW_LIVE_DISCORD_IN_TESTS = False
 DISCORD_PEOPLE_TEAM_CHANNEL_ID = int(
     os.environ.get("DISCORD_PEOPLE_TEAM_CHANNEL_ID", 1098974756356771870)
 )

--- a/backend/discord/client.py
+++ b/backend/discord/client.py
@@ -49,6 +49,24 @@ class DiscordError(Exception):
         return e
 
 
+def _assert_discord_http_allowed() -> None:
+    """
+    Block live Discord HTTP during Django unit tests unless explicitly enabled.
+
+    settings_test sets TESTING=True and blank credentials. Live verification
+    uses app.settings (TESTING false) or ALLOW_LIVE_DISCORD_IN_TESTS=True.
+    """
+    if not getattr(settings, "TESTING", False):
+        return
+    if getattr(settings, "ALLOW_LIVE_DISCORD_IN_TESTS", False):
+        return
+    raise RuntimeError(
+        "Refusing live Discord HTTP during unit tests. Mock "
+        "discord.signals.discord / DiscordClient, or set "
+        "ALLOW_LIVE_DISCORD_IN_TESTS=True only for intentional live runs."
+    )
+
+
 def _raise_discord_rate_limit(response: requests.Response) -> None:
     """Raise RateLimitException with Discord Retry-After for backoff retries."""
     raw = response.headers.get("Retry-After", "1")
@@ -74,6 +92,7 @@ class DiscordBaseClient:
     @on_exception(expo, RateLimitException, max_tries=8)
     def post(self, *args, **kwargs):
         """Post a resource using REST API"""
+        _assert_discord_http_allowed()
         self.check_ratelimit()
         logger.info("POST %s", args)
         response = self.session.post(
@@ -92,6 +111,7 @@ class DiscordBaseClient:
     @on_exception(expo, RateLimitException, max_tries=8)
     def put(self, *args, **kwargs):
         """Put a resource using REST API"""
+        _assert_discord_http_allowed()
         self.check_ratelimit()
         logger.info("PUT %s", args)
         response = self.session.put(
@@ -108,6 +128,7 @@ class DiscordBaseClient:
     @on_exception(expo, RateLimitException, max_tries=8)
     def patch(self, *args, **kwargs):
         """Patch a resource using REST API"""
+        _assert_discord_http_allowed()
         self.check_ratelimit()
         logger.info("PATCH %s", args)
         response = self.session.patch(
@@ -124,6 +145,7 @@ class DiscordBaseClient:
     @on_exception(expo, RateLimitException, max_tries=8)
     def get(self, *args, **kwargs):
         """Get a resource using REST API"""
+        _assert_discord_http_allowed()
         self.check_ratelimit()
         logger.info("GET %s", args)
         response = self.session.get(
@@ -140,6 +162,7 @@ class DiscordBaseClient:
     @on_exception(expo, RateLimitException, max_tries=8)
     def delete(self, *args, **kwargs):
         """Delete a resource using REST API"""
+        _assert_discord_http_allowed()
         self.check_ratelimit()
         response = self.session.delete(
             *args,
@@ -161,6 +184,7 @@ class DiscordClient(DiscordBaseClient):
 
     def exchange_code(self, code: str, redirect_uri: str):
         """Exchange a Discord OAuth2 code for an access token"""
+        _assert_discord_http_allowed()
         data = {
             "client_id": settings.DISCORD_CLIENT_ID,
             "client_secret": settings.DISCORD_CLIENT_SECRET,

--- a/backend/discord/exceptions.py
+++ b/backend/discord/exceptions.py
@@ -1,0 +1,9 @@
+"""Exceptions for Discord role / auth group sync."""
+
+
+class DiscordRoleAssignmentError(Exception):
+    """
+    Raised when a Django auth.Group membership change cannot be mirrored
+    on Discord. Callers must treat this as aborting the M2M change (and
+    any source write that depends on it). See docs/auth/discord-groups.md.
+    """

--- a/backend/discord/live_verify.py
+++ b/backend/discord/live_verify.py
@@ -1,0 +1,978 @@
+"""
+Live Discord ↔ Django fail-closed verification (test guild only).
+
+Not run by default. Invoked via:
+
+  pipenv run python manage.py verify_discord_groups --username <user>
+
+or (opt-in TestCase, real settings DB — not settings_test):
+
+  RUN_DISCORD_LIVE_VERIFY=1 pipenv run python manage.py test \\
+    discord.test_live_discord_groups_verify --settings=app.settings
+
+See docs/auth/discord-groups-verification.md.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import traceback
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Callable
+
+from django.conf import settings
+from django.contrib.auth.models import Group, User
+from django.db import transaction
+from django.db.models import signals
+
+import discord.client as discord_client_mod
+import discord.helpers as discord_helpers
+import discord.signals as discord_signals
+import discord.tasks as discord_tasks
+from discord.client import DiscordClient
+from discord.exceptions import DiscordRoleAssignmentError
+from discord.models import DiscordRole, DiscordUser
+from discord.signals import discord_user_deleting
+from discord.sync_context import disable_discord_group_sync
+from discord.tasks import sync_discord_user
+from eveonline.helpers.characters import user_primary_character
+from eveonline.models import EveCorporation
+from groups.helpers import sync_user_community_groups
+from groups.models import (
+    AffiliationType,
+    EveCorporationGroup,
+    UserAffiliation,
+    UserCommunityStatus,
+)
+from groups.tasks import sync_community_groups, sync_eve_corporation_groups
+from tribes.helpers.tribe_auth_groups import (
+    remove_tribe_auth_groups_for_inactive_membership,
+)
+from tribes.models import Tribe, TribeGroup, TribeGroupMembership
+from users.helpers import offboard_user
+
+logger = logging.getLogger(__name__)
+
+# Hard refuse — never run live verify against production Minmatar Fleet.
+PRODUCTION_DISCORD_GUILD_IDS = frozenset(
+    {
+        1041384161505722368,
+    }
+)
+
+# Default allowlist for live OPSEC verification.
+ALLOWED_LIVE_VERIFY_GUILD_IDS = frozenset(
+    {
+        1459994254427291781,  # Minmatar Fleet Test Server
+    }
+)
+
+VERIFY_PREFIX = "VERIFY-"
+ENV_ENABLE = "RUN_DISCORD_LIVE_VERIFY"
+
+
+@dataclass
+class CaseResult:
+    case_id: str
+    passed: bool
+    notes: str = ""
+
+
+@dataclass
+class LiveVerifyReport:
+    guild_id: str
+    subject: str
+    results: list[CaseResult] = field(default_factory=list)
+
+    @property
+    def failed(self) -> list[CaseResult]:
+        return [r for r in self.results if not r.passed]
+
+    @property
+    def ok(self) -> bool:
+        return not self.failed
+
+
+class LiveVerifyError(RuntimeError):
+    """Safety gate or unrecoverable setup failure."""
+
+
+def assert_live_verify_allowed(
+    *,
+    require_env: bool = False,
+    allow_extra_guild_ids: frozenset[int] | None = None,
+    guild_id: int | None = None,
+) -> str:
+    """
+    Raise LiveVerifyError unless it is safe to hit live Discord.
+
+    Production guild IDs are always refused. Guild must be in the allowlist
+    (or an explicit extra allow set passed by the operator).
+    """
+    if require_env and os.environ.get(ENV_ENABLE) != "1":
+        raise LiveVerifyError(
+            f"Refusing live Discord verify: set {ENV_ENABLE}=1 to enable"
+        )
+
+    resolved = int(
+        guild_id if guild_id is not None else settings.DISCORD_GUILD_ID
+    )
+    if resolved in PRODUCTION_DISCORD_GUILD_IDS:
+        raise LiveVerifyError(
+            f"Refusing live Discord verify against production guild "
+            f"{resolved}. Point DISCORD_GUILD_ID at the test server "
+            f"or pass --guild-id <test-guild-id>."
+        )
+
+    allowed = set(ALLOWED_LIVE_VERIFY_GUILD_IDS)
+    if allow_extra_guild_ids:
+        allowed |= {int(x) for x in allow_extra_guild_ids}
+    if resolved not in allowed:
+        raise LiveVerifyError(
+            f"Refusing live Discord verify: guild {resolved} is not in the "
+            f"allowlist {sorted(allowed)}. Add it only for a known test guild."
+        )
+
+    if not settings.DISCORD_BOT_TOKEN:
+        raise LiveVerifyError("DISCORD_BOT_TOKEN is empty")
+
+    return str(resolved)
+
+
+def patch_discord_clients_to_guild(guild_id: str) -> None:
+    """Module-level DiscordClient instances capture GUILD_ID at import time."""
+    discord_client_mod.GUILD_ID = guild_id
+    for client in (
+        discord_signals.discord,
+        discord_helpers.discord,
+        discord_tasks.discord,
+    ):
+        client.guild_id = guild_id
+
+
+@contextmanager
+def broken_bot_token():
+    clients = [discord_signals.discord, discord_helpers.discord]
+    originals = [c.access_token for c in clients]
+    for client in clients:
+        client.access_token = "invalid-token-live-verify"
+    try:
+        yield
+    finally:
+        for client, token in zip(clients, originals):
+            client.access_token = token
+
+
+@dataclass
+class LiveVerifyRunner:
+    """Execute the A–H matrix against a linked Discord subject on the test guild."""
+
+    username: str
+    guild_id: str
+    burst_count: int = 20
+    results: list[CaseResult] = field(default_factory=list)
+    created_group_names: set[str] = field(default_factory=set)
+    scratch_user_ids: set[int] = field(default_factory=set)
+    corp_group_id: int | None = None
+    tribe_group_id: int | None = None
+    verify_aff_type_id: int | None = None
+    managed_role_id: str | None = None
+    original_affiliation_id: int | None = None
+    original_ucs: str | None = None
+    original_corp_id: int | None = None
+
+    def client(self) -> DiscordClient:
+        client = DiscordClient()
+        client.guild_id = self.guild_id
+        return client
+
+    def subject(self) -> User:
+        return User.objects.get(username=self.username)
+
+    def discord_id(self) -> int:
+        return DiscordUser.objects.get(user=self.subject()).id
+
+    def django_groups(self, user: User) -> set[str]:
+        return set(user.groups.values_list("name", flat=True))
+
+    def live_role_ids(self, discord_id: int) -> set[str]:
+        return set(self.client().get_user(discord_id)["roles"])
+
+    def role_id(self, group_name: str) -> str:
+        return str(DiscordRole.objects.get(group__name=group_name).role_id)
+
+    def members_linked(self, group_name: str, user: User) -> bool:
+        return (
+            DiscordRole.objects.get(group__name=group_name)
+            .members.filter(user=user)
+            .exists()
+        )
+
+    def ensure_group(self, name: str) -> Group:
+        if not name.startswith(VERIFY_PREFIX):
+            raise LiveVerifyError(
+                f"Scratch groups must use {VERIFY_PREFIX}: {name}"
+            )
+        group, _ = Group.objects.get_or_create(name=name)
+        self.created_group_names.add(name)
+        return group
+
+    def point_role_at_managed(self, group_name: str) -> str:
+        role = DiscordRole.objects.get(group__name=group_name)
+        previous = str(role.role_id)
+        role.role_id = int(self.managed_role_id)
+        role.save(update_fields=["role_id", "updated_at"])
+        return previous
+
+    def restore_role_id(self, group_name: str, role_id: str) -> None:
+        role = DiscordRole.objects.get(group__name=group_name)
+        role.role_id = int(role_id)
+        role.save(update_fields=["role_id", "updated_at"])
+
+    def record(self, case_id: str, passed: bool, notes: str = "") -> None:
+        self.results.append(CaseResult(case_id, passed, notes))
+        logger.info(
+            "LIVE_VERIFY %s %s %s",
+            case_id,
+            "PASS" if passed else "FAIL",
+            notes,
+        )
+
+    def run_case(self, case_id: str, fn: Callable[[], str | None]) -> None:
+        try:
+            notes = fn() or ""
+            self.record(case_id, True, notes)
+        except Exception as exc:  # noqa: BLE001 — collect per-case failures
+            self.record(
+                case_id,
+                False,
+                f"{exc}\n{traceback.format_exc()}",
+            )
+
+    def discover_managed_role_id(self) -> str:
+        for role in self.client().get_roles():
+            if role.get("managed") and str(role["id"]) != self.guild_id:
+                return str(role["id"])
+        raise LiveVerifyError(
+            "No managed Discord role found to induce 403 Missing Permissions"
+        )
+
+    def setup(self) -> None:
+        user = self.subject()
+        if not DiscordUser.objects.filter(user=user).exists():
+            raise LiveVerifyError(
+                f"Subject {self.username} has no DiscordUser (must be guild-linked)"
+            )
+
+        self.managed_role_id = self.discover_managed_role_id()
+
+        ua = UserAffiliation.objects.filter(user=user).first()
+        self.original_affiliation_id = ua.affiliation_id if ua else None
+        try:
+            self.original_ucs = user.community_status.status
+        except UserCommunityStatus.DoesNotExist:
+            self.original_ucs = UserCommunityStatus.STATUS_ACTIVE
+        primary = user_primary_character(user)
+        self.original_corp_id = primary.corporation_id if primary else None
+
+        no_discord, _ = User.objects.get_or_create(
+            username="verify-no-discord"
+        )
+        DiscordUser.objects.filter(user=no_discord).delete()
+        self.scratch_user_ids.add(no_discord.id)
+
+        for name in ("Alliance", "Guest", "On Leave", "Trial"):
+            group = Group.objects.get(name=name)
+            if not DiscordRole.objects.filter(group=group).exists():
+                DiscordRole.objects.create(name=name, group=group)
+
+        aff_group = self.ensure_group("VERIFY-Aff")
+        aff, _ = AffiliationType.objects.get_or_create(
+            name="VERIFY-Aff",
+            defaults={
+                "group": aff_group,
+                "priority": 2,
+                "requires_trial": False,
+            },
+        )
+        if aff.group_id != aff_group.id:
+            aff.group = aff_group
+            aff.save(update_fields=["group"])
+        self.verify_aff_type_id = aff.id
+
+        tribe = (
+            Tribe.objects.filter(name="Capitals").first()
+            or Tribe.objects.filter(is_active=True).first()
+        )
+        if tribe is None:
+            raise LiveVerifyError("No Tribe available for VERIFY tribe group")
+        tg_auth = self.ensure_group("VERIFY-TribeGroup")
+        tribe_group, _ = TribeGroup.objects.get_or_create(
+            code="verify.live",
+            defaults={
+                "tribe": tribe,
+                "name": "VERIFY Live",
+                "group": tg_auth,
+                "is_active": True,
+            },
+        )
+        if tribe_group.group_id != tg_auth.id:
+            tribe_group.group = tg_auth
+            tribe_group.save(update_fields=["group"])
+        self.tribe_group_id = tribe_group.id
+
+        if self.original_corp_id is None:
+            raise LiveVerifyError(
+                f"Subject {self.username} needs a primary character with corporation_id"
+            )
+        corp = EveCorporation.objects.get(corporation_id=self.original_corp_id)
+        corp_auth = self.ensure_group("VERIFY-Corp-Member")
+        ecg, _ = EveCorporationGroup.objects.get_or_create(
+            corporation=corp,
+            group_type=EveCorporationGroup.GROUP_TYPE_MEMBER,
+            defaults={"group": corp_auth},
+        )
+        if ecg.group_id != corp_auth.id:
+            ecg.group = corp_auth
+            ecg.save(update_fields=["group"])
+        self.corp_group_id = ecg.id
+
+    def restore_subject(self) -> None:
+        user = self.subject()
+        if self.original_affiliation_id:
+            affiliation = AffiliationType.objects.get(
+                pk=self.original_affiliation_id
+            )
+            ua = UserAffiliation.objects.filter(user=user).first()
+            if ua is None:
+                UserAffiliation.objects.create(
+                    user=user, affiliation=affiliation
+                )
+            elif ua.affiliation_id != affiliation.id:
+                ua.affiliation = affiliation
+                ua.save()
+        ucs, _ = UserCommunityStatus.objects.get_or_create(
+            user=user,
+            defaults={
+                "status": self.original_ucs
+                or UserCommunityStatus.STATUS_ACTIVE
+            },
+        )
+        desired = self.original_ucs or UserCommunityStatus.STATUS_ACTIVE
+        if ucs.status != desired:
+            ucs.status = desired
+            ucs.save()
+        primary = user_primary_character(user)
+        if (
+            primary is not None
+            and self.original_corp_id is not None
+            and primary.corporation_id != self.original_corp_id
+        ):
+            primary.corporation_id = self.original_corp_id
+            primary.save(update_fields=["corporation_id", "updated_at"])
+        sync_user_community_groups(user)
+        sync_discord_user(user.id)
+
+    def _cleanup_scratch_sources(self) -> None:
+        if self.corp_group_id:
+            EveCorporationGroup.objects.filter(id=self.corp_group_id).delete()
+        if self.tribe_group_id:
+            TribeGroupMembership.objects.filter(
+                tribe_group_id=self.tribe_group_id
+            ).delete()
+            TribeGroup.objects.filter(id=self.tribe_group_id).delete()
+        if self.verify_aff_type_id:
+            AffiliationType.objects.filter(id=self.verify_aff_type_id).delete()
+        AffiliationType.objects.filter(name="VERIFY-B4-Aff").delete()
+
+    def _cleanup_scratch_users(self) -> None:
+        signals.pre_delete.disconnect(
+            discord_user_deleting,
+            sender=DiscordUser,
+            dispatch_uid="discord_user_deleting",
+        )
+        try:
+            for user_id in list(self.scratch_user_ids):
+                User.objects.filter(id=user_id).delete()
+            for username in (
+                "verify-no-discord",
+                "verify-b",
+                "verify-g1-offboard",
+                "verify-d2-orphan",
+                "verify-f3-offboard",
+            ):
+                User.objects.filter(username=username).delete()
+        finally:
+            signals.pre_delete.connect(
+                discord_user_deleting,
+                sender=DiscordUser,
+                dispatch_uid="discord_user_deleting",
+            )
+
+    def _cleanup_verify_roles_and_groups(self) -> None:
+        client = self.client()
+        for name in list(self.created_group_names):
+            role = DiscordRole.objects.filter(group__name=name).first()
+            if role and role.role_id:
+                try:
+                    client.delete_role(role.role_id)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("cleanup discord role %s: %s", name, exc)
+            Group.objects.filter(name=name).delete()
+
+    def cleanup(self) -> None:
+        user = self.subject()
+        for name in list(self.created_group_names):
+            group = Group.objects.filter(name=name).first()
+            if group and user.groups.filter(pk=group.pk).exists():
+                try:
+                    user.groups.remove(group)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("cleanup remove %s: %s", name, exc)
+
+        self._cleanup_scratch_sources()
+        self._cleanup_scratch_users()
+        self._cleanup_verify_roles_and_groups()
+        self.restore_subject()
+
+    # ---- cases ----
+
+    def case_a1(self) -> str:
+        user = self.subject()
+        group = self.ensure_group("VERIFY-Role")
+        user.groups.add(group)
+        assert "VERIFY-Role" in self.django_groups(user)
+        assert self.role_id("VERIFY-Role") in self.live_role_ids(
+            self.discord_id()
+        )
+        assert self.members_linked("VERIFY-Role", user)
+        return "add aligned"
+
+    def case_a2(self) -> str:
+        user = self.subject()
+        group = Group.objects.get(name="VERIFY-Role")
+        user.groups.remove(group)
+        assert "VERIFY-Role" not in self.django_groups(user)
+        assert self.role_id("VERIFY-Role") not in self.live_role_ids(
+            self.discord_id()
+        )
+        return "remove aligned"
+
+    def case_a3(self) -> str:
+        group = self.ensure_group("VERIFY-New")
+        role = DiscordRole.objects.get(group=group)
+        assert role.role_id
+        names = {r["name"]: r["id"] for r in self.client().get_roles()}
+        assert names.get("VERIFY-New") == str(role.role_id)
+        return f"role_id={role.role_id}"
+
+    def case_a4(self) -> str:
+        user = self.subject()
+        sync_user_community_groups(user)
+        sync_discord_user(user.id)
+        live = self.live_role_ids(self.discord_id())
+        assert "Alliance" in self.django_groups(user)
+        assert self.role_id("Alliance") in live
+        assert "On Leave" not in self.django_groups(user)
+        assert self.role_id("On Leave") not in live
+        return "Alliance on Discord+Django; On Leave cleared"
+
+    def case_a5(self) -> str:
+        user = self.subject()
+        tribe_group = TribeGroup.objects.get(id=self.tribe_group_id)
+        membership, _ = TribeGroupMembership.objects.get_or_create(
+            user=user,
+            tribe_group=tribe_group,
+            defaults={"status": TribeGroupMembership.STATUS_PENDING},
+        )
+        membership.status = TribeGroupMembership.STATUS_ACTIVE
+        membership.save()
+        assert "VERIFY-TribeGroup" in self.django_groups(user)
+        assert self.role_id("VERIFY-TribeGroup") in self.live_role_ids(
+            self.discord_id()
+        )
+        return "tribe group active aligned"
+
+    def case_a6(self) -> str:
+        user = self.subject()
+        sync_eve_corporation_groups()
+        assert "VERIFY-Corp-Member" in self.django_groups(user)
+        assert self.role_id("VERIFY-Corp-Member") in self.live_role_ids(
+            self.discord_id()
+        )
+        return "corp member sync aligned"
+
+    def case_b1(self) -> str:
+        group = self.ensure_group("VERIFY-Role")
+        no_discord = User.objects.get(username="verify-no-discord")
+        try:
+            no_discord.groups.add(group)
+            raise AssertionError("expected DiscordRoleAssignmentError")
+        except DiscordRoleAssignmentError:
+            pass
+        assert "VERIFY-Role" not in self.django_groups(no_discord)
+        return "no DiscordUser blocked"
+
+    def case_b2(self) -> str:
+        user = self.subject()
+        group = self.ensure_group("VERIFY-B2")
+        previous = self.point_role_at_managed("VERIFY-B2")
+        try:
+            try:
+                with transaction.atomic():
+                    user.groups.add(group)
+                raise AssertionError("expected DiscordRoleAssignmentError")
+            except DiscordRoleAssignmentError:
+                pass
+            assert "VERIFY-B2" not in self.django_groups(user)
+            return "403 add blocked; not in Django"
+        finally:
+            self.restore_role_id("VERIFY-B2", previous)
+
+    def case_b3(self) -> str:
+        user = self.subject()
+        group = self.ensure_group("VERIFY-B3")
+        with broken_bot_token():
+            try:
+                with transaction.atomic():
+                    user.groups.add(group)
+                raise AssertionError("expected DiscordRoleAssignmentError")
+            except DiscordRoleAssignmentError:
+                pass
+        assert "VERIFY-B3" not in self.django_groups(user)
+        return "bad token blocked add"
+
+    def case_b4(self) -> str:
+        user = self.subject()
+        group = self.ensure_group("VERIFY-B4-Aff")
+        aff, _ = AffiliationType.objects.get_or_create(
+            name="VERIFY-B4-Aff",
+            defaults={"group": group, "priority": 3, "requires_trial": False},
+        )
+        self.created_group_names.add("VERIFY-B4-Aff")
+        previous = self.point_role_at_managed("VERIFY-B4-Aff")
+        alliance = AffiliationType.objects.get(name="Alliance")
+        ua = UserAffiliation.objects.get(user=user)
+        try:
+            try:
+                ua.affiliation = aff
+                ua.save()
+                raise AssertionError("expected affiliation rollback")
+            except DiscordRoleAssignmentError:
+                pass
+            ua.refresh_from_db()
+            assert ua.affiliation_id == alliance.id
+            assert "VERIFY-B4-Aff" not in self.django_groups(user)
+            return "affiliation rolled back on Discord fail"
+        finally:
+            self.restore_role_id("VERIFY-B4-Aff", previous)
+            AffiliationType.objects.filter(name="VERIFY-B4-Aff").delete()
+            ua.refresh_from_db()
+            if ua.affiliation_id != alliance.id:
+                ua.affiliation = alliance
+                ua.save()
+
+    def case_c1(self) -> str:
+        user = self.subject()
+        group = self.ensure_group("VERIFY-C1")
+        user.groups.add(group)
+        previous = self.point_role_at_managed("VERIFY-C1")
+        try:
+            try:
+                with transaction.atomic():
+                    user.groups.remove(group)
+                raise AssertionError("expected DiscordRoleAssignmentError")
+            except DiscordRoleAssignmentError:
+                pass
+            assert "VERIFY-C1" in self.django_groups(user)
+            assert previous in self.live_role_ids(self.discord_id())
+            return "403 remove kept Django+Discord"
+        finally:
+            self.restore_role_id("VERIFY-C1", previous)
+            if "VERIFY-C1" in self.django_groups(user):
+                user.groups.remove(group)
+
+    def case_c2(self) -> str:
+        user = self.subject()
+        group = self.ensure_group("VERIFY-C2")
+        user.groups.add(group)
+        with broken_bot_token():
+            try:
+                with transaction.atomic():
+                    user.groups.remove(group)
+                raise AssertionError("expected DiscordRoleAssignmentError")
+            except DiscordRoleAssignmentError:
+                pass
+        assert "VERIFY-C2" in self.django_groups(user)
+        assert self.role_id("VERIFY-C2") in self.live_role_ids(
+            self.discord_id()
+        )
+        user.groups.remove(group)
+        return "unreachable remove kept both"
+
+    def case_c3(self) -> str:
+        user = self.subject()
+        tribe_group = TribeGroup.objects.get(id=self.tribe_group_id)
+        membership = TribeGroupMembership.objects.get(
+            user=user, tribe_group=tribe_group
+        )
+        if membership.status != TribeGroupMembership.STATUS_ACTIVE:
+            membership.status = TribeGroupMembership.STATUS_ACTIVE
+            membership.save()
+        previous = self.point_role_at_managed("VERIFY-TribeGroup")
+        try:
+            try:
+                membership.status = TribeGroupMembership.STATUS_INACTIVE
+                membership.save()
+                raise AssertionError("expected inactive rollback")
+            except DiscordRoleAssignmentError:
+                pass
+            membership.refresh_from_db()
+            assert membership.status == TribeGroupMembership.STATUS_ACTIVE
+            assert "VERIFY-TribeGroup" in self.django_groups(user)
+            assert previous in self.live_role_ids(self.discord_id())
+            return "tribe inactive rolled back; roles kept"
+        finally:
+            self.restore_role_id("VERIFY-TribeGroup", previous)
+
+    def case_c4(self) -> str:
+        user = self.subject()
+        previous = self.point_role_at_managed("Alliance")
+        guest = AffiliationType.objects.get(name="Guest")
+        ua = UserAffiliation.objects.get(user=user)
+        try:
+            try:
+                ua.affiliation = guest
+                ua.save()
+                raise AssertionError("expected demotion failure/rollback")
+            except DiscordRoleAssignmentError:
+                pass
+            ua.refresh_from_db()
+            django_names = self.django_groups(user)
+            live = self.live_role_ids(self.discord_id())
+            if "Guest" in django_names and "Alliance" not in django_names:
+                if previous in live:
+                    raise AssertionError(
+                        "OPSEC: Guest in Django but Alliance still on Discord"
+                    )
+            assert (
+                ua.affiliation.name == "Alliance" or "Alliance" in django_names
+            )
+            return f"demotion blocked; aff={ua.affiliation.name}"
+        finally:
+            self.restore_role_id("Alliance", previous)
+            self.restore_subject()
+
+    def case_c5(self) -> str:
+        user = self.subject()
+        group = self.ensure_group("VERIFY-C5")
+        user.groups.add(group)
+        user.groups.remove(group)
+        assert "VERIFY-C5" not in self.django_groups(user)
+        assert self.role_id("VERIFY-C5") not in self.live_role_ids(
+            self.discord_id()
+        )
+        sync_user_community_groups(user)
+        return "converge after restore OK"
+
+    def case_d1(self) -> str:
+        g1, _ = User.objects.get_or_create(username="verify-g1-offboard")
+        self.scratch_user_ids.add(g1.id)
+        DiscordUser.objects.filter(user=g1).delete()
+        fake_id = 199999999999999999
+        DiscordUser.objects.filter(id=fake_id).delete()
+        DiscordUser.objects.create(
+            id=fake_id, user=g1, discord_tag="verify-g1#0"
+        )
+        group = self.ensure_group("VERIFY-D1")
+        with disable_discord_group_sync():
+            g1.groups.add(group)
+        try:
+            g1.groups.remove(group)
+        except User.DoesNotExist:
+            return "10007 remove allowed; user offboarded during handle"
+        if not User.objects.filter(username="verify-g1-offboard").exists():
+            return "10007 remove allowed; user offboarded"
+        assert "VERIFY-D1" not in self.django_groups(g1)
+        return "10007 remove allowed; user still present"
+
+    def case_d2(self) -> str:
+        tmp, _ = User.objects.get_or_create(username="verify-d2-orphan")
+        self.scratch_user_ids.add(tmp.id)
+        group = self.ensure_group("VERIFY-D2")
+        with disable_discord_group_sync():
+            tmp.groups.add(group)
+        DiscordUser.objects.filter(user=tmp).delete()
+        tmp.groups.remove(group)
+        assert "VERIFY-D2" not in self.django_groups(tmp)
+        return "no DiscordUser remove allowed"
+
+    def case_e1(self) -> str:
+        user = self.subject()
+        guest = AffiliationType.objects.get(name="Guest")
+        UserAffiliation.objects.filter(user=user).update(affiliation=guest)
+        alliance_group = Group.objects.get(name="Alliance")
+        if "Alliance" not in self.django_groups(user):
+            user.groups.add(alliance_group)
+        sync_user_community_groups(user)
+        live = self.live_role_ids(self.discord_id())
+        django_names = self.django_groups(user)
+        assert "Alliance" not in django_names
+        assert "Guest" in django_names
+        assert self.role_id("Alliance") not in live
+        assert self.role_id("Guest") in live
+        self.restore_subject()
+        return "stale Alliance stripped; Guest only"
+
+    def case_e2(self) -> str:
+        user = self.subject()
+        tribe_group = TribeGroup.objects.get(id=self.tribe_group_id)
+        membership = TribeGroupMembership.objects.get(
+            user=user, tribe_group=tribe_group
+        )
+        TribeGroupMembership.objects.filter(pk=membership.pk).update(
+            status=TribeGroupMembership.STATUS_INACTIVE
+        )
+        membership.refresh_from_db()
+        if "VERIFY-TribeGroup" not in self.django_groups(user):
+            user.groups.add(Group.objects.get(name="VERIFY-TribeGroup"))
+        remove_tribe_auth_groups_for_inactive_membership(membership)
+        assert "VERIFY-TribeGroup" not in self.django_groups(user)
+        assert self.role_id("VERIFY-TribeGroup") not in self.live_role_ids(
+            self.discord_id()
+        )
+        return "inactive tribe groups stripped"
+
+    def case_e3(self) -> str:
+        user = self.subject()
+        sync_eve_corporation_groups()
+        assert "VERIFY-Corp-Member" in self.django_groups(user)
+        primary = user_primary_character(user)
+        old = primary.corporation_id
+        primary.corporation_id = 98498664  # any other known corp
+        primary.save(update_fields=["corporation_id", "updated_at"])
+        try:
+            sync_eve_corporation_groups()
+            assert "VERIFY-Corp-Member" not in self.django_groups(user)
+            assert self.role_id(
+                "VERIFY-Corp-Member"
+            ) not in self.live_role_ids(self.discord_id())
+            return "corp role removed after primary change"
+        finally:
+            primary.corporation_id = old
+            primary.save(update_fields=["corporation_id", "updated_at"])
+
+    def case_f1(self) -> str:
+        user = self.subject()
+        groups = []
+        for index in range(self.burst_count):
+            group = self.ensure_group(f"VERIFY-Burst-{index}")
+            groups.append(group)
+            user.groups.add(group)
+        live = self.live_role_ids(self.discord_id())
+        django_names = self.django_groups(user)
+        for group in groups:
+            assert group.name in django_names
+            assert self.role_id(group.name) in live
+        return f"{self.burst_count} burst-adds aligned"
+
+    def case_f2(self) -> str:
+        user = self.subject()
+        groups = [
+            Group.objects.get(name=f"VERIFY-Burst-{index}")
+            for index in range(self.burst_count)
+        ]
+        for group in groups:
+            if group.name in self.django_groups(user):
+                user.groups.remove(group)
+        live = self.live_role_ids(self.discord_id())
+        for group in groups:
+            assert group.name not in self.django_groups(user)
+            assert self.role_id(group.name) not in live
+        return f"{self.burst_count} burst-removes aligned"
+
+    def case_f3(self) -> str:
+        user = self.subject()
+        tmp, _ = User.objects.get_or_create(username="verify-f3-offboard")
+        self.scratch_user_ids.add(tmp.id)
+        DiscordUser.objects.filter(user=tmp).delete()
+        DiscordUser.objects.create(
+            id=188888888888888888, user=tmp, discord_tag="verify-f3#0"
+        )
+        offboard_user(tmp.id)
+        group = self.ensure_group("VERIFY-F3")
+        user.groups.add(group)
+        assert self.role_id("VERIFY-F3") in self.live_role_ids(
+            self.discord_id()
+        )
+        user.groups.remove(group)
+        sync_community_groups()
+        return "post-offboard sync still works for subject"
+
+    def case_g1(self) -> str:
+        g1, _ = User.objects.get_or_create(username="verify-g1-offboard")
+        self.scratch_user_ids.add(g1.id)
+        DiscordUser.objects.filter(user=g1).delete()
+        DiscordUser.objects.filter(id=177777777777777777).delete()
+        DiscordUser.objects.create(
+            id=177777777777777777, user=g1, discord_tag="verify-g1#0"
+        )
+        group = self.ensure_group("VERIFY-G1")
+        with disable_discord_group_sync():
+            g1.groups.add(group)
+        user_id = g1.id
+        offboard_user(user_id)
+        assert not User.objects.filter(id=user_id).exists()
+        return "throwaway offboarded (never the subject)"
+
+    def case_g2(self) -> str:
+        """G2: sync still works after G1 — uses subject (not a second human)."""
+        user = self.subject()
+        group = self.ensure_group("VERIFY-G2")
+        user.groups.add(group)
+        assert self.role_id("VERIFY-G2") in self.live_role_ids(
+            self.discord_id()
+        )
+        user.groups.remove(group)
+        return "subject still syncs after throwaway offboard"
+
+    def case_h1(self) -> str:
+        user = self.subject()
+        self.restore_subject()
+        ucs = UserCommunityStatus.objects.get(user=user)
+        ucs.status = UserCommunityStatus.STATUS_ON_LEAVE
+        ucs.save()
+        django_names = self.django_groups(user)
+        live = self.live_role_ids(self.discord_id())
+        assert "On Leave" in django_names
+        assert "Alliance" not in django_names
+        assert self.role_id("On Leave") in live
+        assert self.role_id("Alliance") not in live
+        return "On Leave only"
+
+    def case_h2(self) -> str:
+        user = self.subject()
+        guest = AffiliationType.objects.get(name="Guest")
+        ua = UserAffiliation.objects.get(user=user)
+        ua.affiliation = guest
+        ua.save()
+        ucs = UserCommunityStatus.objects.get(user=user)
+        ucs.status = UserCommunityStatus.STATUS_ACTIVE
+        ucs.save()
+        django_names = self.django_groups(user)
+        live = self.live_role_ids(self.discord_id())
+        assert "Guest" in django_names
+        assert "On Leave" not in django_names
+        assert "Alliance" not in django_names
+        assert self.role_id("Guest") in live
+        assert self.role_id("On Leave") not in live
+        return "Guest only"
+
+    def case_h3(self) -> str:
+        user = self.subject()
+        self.restore_subject()
+        previous = self.point_role_at_managed("Alliance")
+        ucs = UserCommunityStatus.objects.get(user=user)
+        try:
+            try:
+                ucs.status = UserCommunityStatus.STATUS_ON_LEAVE
+                ucs.save()
+            except DiscordRoleAssignmentError:
+                pass
+            django_names = self.django_groups(user)
+            self.restore_role_id("Alliance", previous)
+            live = self.live_role_ids(self.discord_id())
+            if (
+                "On Leave" in django_names
+                and "Alliance" not in django_names
+                and previous in live
+            ):
+                raise AssertionError(
+                    "OPSEC: On Leave Django + Alliance still on Discord"
+                )
+            return (
+                "interrupted leave handled; "
+                f"community={sorted(n for n in django_names if n in ('Alliance', 'On Leave', 'Guest', 'Trial'))}"
+            )
+        finally:
+            try:
+                self.restore_role_id("Alliance", previous)
+            except Exception:  # noqa: BLE001
+                pass
+            self.restore_subject()
+
+    def run(self, case_ids: set[str] | None = None) -> LiveVerifyReport:
+        patch_discord_clients_to_guild(self.guild_id)
+        self.setup()
+
+        all_cases: list[tuple[str, Callable[[], str | None]]] = [
+            ("A1", self.case_a1),
+            ("A2", self.case_a2),
+            ("A3", self.case_a3),
+            ("A4", self.case_a4),
+            ("A5", self.case_a5),
+            ("A6", self.case_a6),
+            ("B1", self.case_b1),
+            ("B2", self.case_b2),
+            ("B3", self.case_b3),
+            ("B4", self.case_b4),
+            ("C1", self.case_c1),
+            ("C2", self.case_c2),
+            ("C3", self.case_c3),
+            ("C4", self.case_c4),
+            ("C5", self.case_c5),
+            ("D1", self.case_d1),
+            ("D2", self.case_d2),
+            ("E1", self.case_e1),
+            ("E2", self.case_e2),
+            ("E3", self.case_e3),
+            ("F1", self.case_f1),
+            ("F2", self.case_f2),
+            ("F3", self.case_f3),
+            ("G1", self.case_g1),
+            ("G2", self.case_g2),
+            ("H1", self.case_h1),
+            ("H2", self.case_h2),
+            ("H3", self.case_h3),
+        ]
+
+        try:
+            for case_id, fn in all_cases:
+                if case_ids is not None and case_id not in case_ids:
+                    continue
+                self.run_case(case_id, fn)
+        finally:
+            try:
+                self.cleanup()
+            except Exception:  # noqa: BLE001
+                logger.exception("LIVE_VERIFY cleanup failed")
+
+        return LiveVerifyReport(
+            guild_id=self.guild_id,
+            subject=self.username,
+            results=list(self.results),
+        )
+
+
+def run_live_discord_groups_verify(
+    *,
+    username: str,
+    require_env: bool = False,
+    allow_extra_guild_ids: frozenset[int] | None = None,
+    case_ids: set[str] | None = None,
+    burst_count: int = 20,
+    guild_id: int | None = None,
+) -> LiveVerifyReport:
+    resolved = assert_live_verify_allowed(
+        require_env=require_env,
+        allow_extra_guild_ids=allow_extra_guild_ids,
+        guild_id=guild_id,
+    )
+    runner = LiveVerifyRunner(
+        username=username,
+        guild_id=resolved,
+        burst_count=burst_count,
+    )
+    return runner.run(case_ids=case_ids)

--- a/backend/discord/management/commands/verify_discord_groups.py
+++ b/backend/discord/management/commands/verify_discord_groups.py
@@ -1,0 +1,121 @@
+"""Manually run live Discord ↔ Django fail-closed verification (test guild only)."""
+
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand, CommandError
+
+from discord.live_verify import (
+    ALLOWED_LIVE_VERIFY_GUILD_IDS,
+    LiveVerifyError,
+    run_live_discord_groups_verify,
+)
+
+
+class Command(BaseCommand):
+    help = (
+        "Live OPSEC verification of fail-closed auth.Group ↔ Discord role sync. "
+        "Refuses production guild IDs. Requires --i-understand-this-hits-live-discord. "
+        "See docs/auth/discord-groups-verification.md."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--username",
+            required=True,
+            help=(
+                "Django username of a guild-linked subject "
+                "(e.g. bearthatcares on the test server). Never offboarded."
+            ),
+        )
+        parser.add_argument(
+            "--i-understand-this-hits-live-discord",
+            action="store_true",
+            dest="confirm_live",
+            help="Required confirmation that this will call the live Discord API.",
+        )
+        parser.add_argument(
+            "--cases",
+            default="",
+            help="Comma-separated case IDs (e.g. A1,A2,B1). Default: full matrix.",
+        )
+        parser.add_argument(
+            "--burst-count",
+            type=int,
+            default=20,
+            help="Number of VERIFY-Burst-* roles for F1/F2 (default 20).",
+        )
+        parser.add_argument(
+            "--guild-id",
+            type=int,
+            default=None,
+            help=(
+                "Override settings.DISCORD_GUILD_ID for this run "
+                "(must be an allowlisted test guild; production always refused)."
+            ),
+        )
+        parser.add_argument(
+            "--allow-guild-id",
+            type=int,
+            action="append",
+            default=[],
+            dest="allow_guild_ids",
+            help=(
+                "Extra non-production guild ID to allow (repeatable). "
+                f"Default allowlist: {sorted(ALLOWED_LIVE_VERIFY_GUILD_IDS)}"
+            ),
+        )
+
+    def handle(self, *args, **options):
+        if not options["confirm_live"]:
+            raise CommandError(
+                "Refusing to run without "
+                "--i-understand-this-hits-live-discord"
+            )
+
+        case_ids = None
+        raw_cases = (options["cases"] or "").strip()
+        if raw_cases:
+            case_ids = {
+                part.strip().upper()
+                for part in raw_cases.split(",")
+                if part.strip()
+            }
+
+        extra = frozenset(options["allow_guild_ids"] or [])
+        try:
+            report = run_live_discord_groups_verify(
+                username=options["username"],
+                require_env=False,
+                allow_extra_guild_ids=extra or None,
+                case_ids=case_ids,
+                burst_count=options["burst_count"],
+                guild_id=options["guild_id"],
+            )
+        except LiveVerifyError as exc:
+            raise CommandError(str(exc)) from exc
+        except User.DoesNotExist as exc:
+            raise CommandError(
+                f"User {options['username']!r} not found"
+            ) from exc
+
+        self.stdout.write(
+            f"Live verify guild={report.guild_id} subject={report.subject}"
+        )
+        failed = 0
+        for result in report.results:
+            mark = "PASS" if result.passed else "FAIL"
+            note = result.notes.splitlines()[0] if result.notes else ""
+            line = f"  {result.case_id:4} {mark}  {note}"
+            if result.passed:
+                self.stdout.write(self.style.SUCCESS(line))
+            else:
+                failed += 1
+                self.stderr.write(self.style.ERROR(line))
+                if result.notes:
+                    self.stderr.write(result.notes)
+
+        total = len(report.results)
+        summary = f"{total - failed}/{total} passed"
+        if failed:
+            self.stderr.write(self.style.ERROR(summary))
+            raise CommandError(f"Live Discord verification failed ({summary})")
+        self.stdout.write(self.style.SUCCESS(summary))

--- a/backend/discord/signals.py
+++ b/backend/discord/signals.py
@@ -1,3 +1,11 @@
+"""
+Discord ↔ auth.Group sync signals.
+
+Contract: Discord roles MUST be accurate. Django group membership only
+changes when the corresponding Discord role mutate succeeds (fail-closed).
+See docs/auth/discord-groups.md.
+"""
+
 import logging
 
 from django.contrib.auth.models import Group, User
@@ -5,11 +13,14 @@ from django.db import IntegrityError
 from django.db.models import signals
 from django.dispatch import receiver
 
+from discord.client import DiscordClient
+from discord.exceptions import DiscordRoleAssignmentError
 from discord.helpers import (
     handle_discord_guild_member_error,
+    is_discord_unknown_guild_member_error,
     remove_all_roles_from_guild_member,
 )
-from discord.client import DiscordClient
+from discord.sync_context import is_discord_group_sync_disabled
 
 from .models import DiscordRole, DiscordUser
 
@@ -107,14 +118,30 @@ def group_post_save(
 def _discord_role_call(
     user, discord_user, role, *, add: bool, context: str
 ) -> bool:
-    """Apply or remove a Discord role. Returns False if member missing on Discord."""
+    """
+    Apply or remove a Discord role.
+
+    Returns True on success.
+    Returns False only when Discord reports unknown member (10007) — there is
+    no Discord access left to leave behind.
+    Raises DiscordRoleAssignmentError (or re-raises) for unreachable / 403 /
+    other failures so Django M2M does not commit.
+    """
     call = discord.add_user_role if add else discord.remove_user_role
     try:
         call(discord_user.id, role.role_id)
     except Exception as exc:
-        if handle_discord_guild_member_error(user, exc, context):
+        if is_discord_unknown_guild_member_error(exc):
+            handle_discord_guild_member_error(user, exc, context)
             return False
-        raise
+        # 403 and other handled errors must still abort membership changes.
+        handle_discord_guild_member_error(
+            user, exc, context, offboard_if_missing=False
+        )
+        raise DiscordRoleAssignmentError(
+            f"Discord role {'add' if add else 'remove'} failed for "
+            f"user={getattr(user, 'id', None)} role={role.name}: {exc}"
+        ) from exc
     return True
 
 
@@ -123,19 +150,25 @@ def _discord_user_for(user):
 
 
 def _add_user_to_group_discord_role(user, group):
+    """Fail-closed: raise unless Discord role is assigned (or already held)."""
     logger.info("User added to group, adding to discord role")
     discord_user = _discord_user_for(user)
     if discord_user is None:
-        logger.info("Group change without discord user")
-        return
-    logger.debug("Checking group %s", group.name)
-    if not DiscordRole.objects.filter(group=group).exists():
-        logger.warning("No discord role for group %s", group.name)
-        return
-    if discord_user in group.discord_group.members.all():
+        raise DiscordRoleAssignmentError(
+            f"Cannot add user {user.id} to group {group.name}: no DiscordUser"
+        )
+
+    try:
+        role = _ensure_discord_role_for_group(group)
+    except Exception as exc:
+        raise DiscordRoleAssignmentError(
+            f"Cannot ensure DiscordRole for group {group.name}: {exc}"
+        ) from exc
+
+    if discord_user in role.members.all():
         logger.debug("User already in role, skipping")
         return
-    role = DiscordRole.objects.get(group=group)
+
     logger.info(
         "Adding user %s to external discord role %s",
         discord_user,
@@ -144,23 +177,35 @@ def _add_user_to_group_discord_role(user, group):
     if not _discord_role_call(
         user, discord_user, role, add=True, context="add_user_role"
     ):
-        return
+        # Unknown member — offboard may have deleted the user; abort M2M.
+        raise DiscordRoleAssignmentError(
+            f"Cannot add user {user.id} to Discord role {role.name}: "
+            "member not on Discord server"
+        )
     role.members.add(discord_user)
 
 
 def _remove_user_from_group_discord_role(user, group):
+    """
+    Fail-closed on Discord unreachable/403 so Django cannot drop tracking
+    while Discord still has the role. Allows remove when there is nothing
+    left on Discord (no DiscordUser, no DiscordRole, or 10007).
+    """
     logger.info("User removed from group, removing from discord role")
     discord_user = _discord_user_for(user)
     if discord_user is None:
         logger.info("Group change without discord user")
         return
-    if not DiscordRole.objects.filter(group=group).exists():
+
+    role = DiscordRole.objects.filter(group=group).first()
+    if role is None:
         logger.warning("No discord role for group %s", group.name)
         return
-    role = DiscordRole.objects.get(group=group)
+
     if not _discord_role_call(
         user, discord_user, role, add=False, context="remove_user_role"
     ):
+        # 10007 — no Discord access left; allow Django remove.
         role.members.remove(discord_user)
         return
     role.members.remove(discord_user)
@@ -184,7 +229,9 @@ def _user_group_pre_clear(user):
     if discord_user is None:
         logger.info("Group change without discord user")
         return
-    for role in discord_user.groups.all():
+    # Snapshot roles before mutating membership tracking.
+    roles = list(discord_user.groups.all())
+    for role in roles:
         if not _discord_role_call(
             user,
             discord_user,
@@ -205,7 +252,16 @@ def _user_group_pre_clear(user):
 def user_group_changed(
     sender, instance, action, reverse, model, pk_set, **kwargs
 ):  # pylint: disable=unused-argument
-    """Adds user to discord role when added to group"""
+    """
+    Mirror auth.Group membership to Discord roles (fail-closed).
+
+    See docs/auth/discord-groups.md. Raises DiscordRoleAssignmentError from
+    pre_add/pre_remove/pre_clear when Discord cannot be updated, which aborts
+    the M2M change.
+    """
+    if is_discord_group_sync_disabled():
+        return
+
     if action == "pre_add":
         if reverse:
             group = instance
@@ -214,9 +270,6 @@ def user_group_changed(
                 _add_user_to_group_discord_role(user, group)
         else:
             user = instance
-            if _discord_user_for(user) is None:
-                logger.info("Group change without discord user")
-                return
             _user_group_pre_add(user, model, pk_set)
     elif action == "pre_remove":
         if reverse:
@@ -226,9 +279,6 @@ def user_group_changed(
                 _remove_user_from_group_discord_role(user, group)
         else:
             user = instance
-            if _discord_user_for(user) is None:
-                logger.info("Group change without discord user")
-                return
             _user_group_pre_remove(user, model, pk_set)
     elif action == "pre_clear":
         if reverse:
@@ -237,9 +287,6 @@ def user_group_changed(
                 _remove_user_from_group_discord_role(user, group)
         else:
             user = instance
-            if _discord_user_for(user) is None:
-                logger.info("Group change without discord user")
-                return
             _user_group_pre_clear(user)
 
 

--- a/backend/discord/sync_context.py
+++ b/backend/discord/sync_context.py
@@ -1,0 +1,29 @@
+"""Thread-local flag to skip Discord m2m sync during intentional offboard."""
+
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+
+_local = threading.local()
+
+
+def is_discord_group_sync_disabled() -> bool:
+    return bool(getattr(_local, "disabled", False))
+
+
+@contextmanager
+def disable_discord_group_sync():
+    """
+    Temporarily skip user↔group Discord role sync.
+
+    Use around offboard deletes so cascading M2M clears do not call Discord
+    (roles are cleaned via DiscordUser pre_delete / explicit role delete).
+    Always restores the previous flag so workers are never permanently muted.
+    """
+    previous = getattr(_local, "disabled", False)
+    _local.disabled = True
+    try:
+        yield
+    finally:
+        _local.disabled = previous

--- a/backend/discord/test_live_discord_groups_verify.py
+++ b/backend/discord/test_live_discord_groups_verify.py
@@ -1,0 +1,111 @@
+"""
+Opt-in live Discord fail-closed verification.
+
+Skipped unless RUN_DISCORD_LIVE_VERIFY=1. Uses SimpleTestCase so Django does
+not wrap the run in a transaction (that would roll back DB while leaving
+Discord roles behind).
+
+Run against the real local DB + test guild (never settings_test / never prod):
+
+  RUN_DISCORD_LIVE_VERIFY=1 \\
+  DISCORD_LIVE_VERIFY_USER=bearthatcares \\
+  DISCORD_LIVE_VERIFY_GUILD_ID=1459994254427291781 \\
+  pipenv run python manage.py test discord.test_live_discord_groups_verify \\
+    --settings=app.settings
+
+Prefer the management command for day-to-day use:
+
+  pipenv run python manage.py verify_discord_groups \\
+    --username bearthatcares \\
+    --guild-id 1459994254427291781 \\
+    --i-understand-this-hits-live-discord
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from django.conf import settings
+from django.test import SimpleTestCase, override_settings
+
+from discord.live_verify import (
+    ENV_ENABLE,
+    LiveVerifyError,
+    PRODUCTION_DISCORD_GUILD_IDS,
+    assert_live_verify_allowed,
+    run_live_discord_groups_verify,
+)
+
+
+class LiveDiscordGroupsVerifySafetyTestCase(SimpleTestCase):
+    """Always-on gates — must never hit live Discord."""
+
+    def test_production_guild_refused(self):
+        prod = next(iter(PRODUCTION_DISCORD_GUILD_IDS))
+        with override_settings(DISCORD_GUILD_ID=prod, DISCORD_BOT_TOKEN="x"):
+            with self.assertRaises(LiveVerifyError) as ctx:
+                assert_live_verify_allowed(require_env=False)
+            self.assertIn("production", str(ctx.exception).lower())
+
+    def test_unknown_guild_refused(self):
+        with override_settings(
+            DISCORD_GUILD_ID=999999999999999999, DISCORD_BOT_TOKEN="x"
+        ):
+            with self.assertRaises(LiveVerifyError) as ctx:
+                assert_live_verify_allowed(require_env=False)
+            self.assertIn("allowlist", str(ctx.exception).lower())
+
+    def test_env_gate_when_required(self):
+        with override_settings(
+            DISCORD_GUILD_ID=1459994254427291781, DISCORD_BOT_TOKEN="x"
+        ):
+            os.environ.pop(ENV_ENABLE, None)
+            with self.assertRaises(LiveVerifyError):
+                assert_live_verify_allowed(require_env=True)
+
+
+@unittest.skipUnless(
+    os.environ.get(ENV_ENABLE) == "1",
+    f"Set {ENV_ENABLE}=1 to run live Discord verification",
+)
+class LiveDiscordGroupsVerifyTestCase(SimpleTestCase):
+    """Full A–H matrix against live test Discord. Manual / opt-in only."""
+
+    # Allow ORM without TestCase transaction rollback (Discord is external).
+    databases = {"default"}
+
+    def test_fail_closed_matrix_against_live_test_guild(self):
+        username = os.environ.get("DISCORD_LIVE_VERIFY_USER", "").strip()
+        self.assertTrue(
+            username,
+            "Set DISCORD_LIVE_VERIFY_USER to a guild-linked Django username",
+        )
+        raw_guild = os.environ.get("DISCORD_LIVE_VERIFY_GUILD_ID", "").strip()
+        guild_override = int(raw_guild) if raw_guild else None
+        guild_id = int(
+            guild_override
+            if guild_override is not None
+            else settings.DISCORD_GUILD_ID
+        )
+        self.assertNotIn(
+            guild_id,
+            PRODUCTION_DISCORD_GUILD_IDS,
+            "Live verify must not use the production Discord guild",
+        )
+
+        report = run_live_discord_groups_verify(
+            username=username,
+            require_env=True,
+            guild_id=guild_override,
+        )
+        failed = [r for r in report.results if not r.passed]
+        if failed:
+            details = "\n".join(
+                f"{r.case_id}: {r.notes.splitlines()[0] if r.notes else 'FAIL'}"
+                for r in failed
+            )
+            self.fail(
+                f"{len(failed)}/{len(report.results)} live verify cases failed:\n"
+                f"{details}"
+            )

--- a/backend/discord/testing.py
+++ b/backend/discord/testing.py
@@ -1,0 +1,35 @@
+"""Shared helpers for Discord-related Django tests."""
+
+from django.contrib.auth.models import Group, User
+from django.db.models import signals
+
+from discord.models import DiscordRole
+from discord.signals import (
+    group_post_save,
+    resolve_existing_discord_role_from_server,
+    user_group_changed,
+)
+
+
+def reconnect_discord_group_signals() -> None:
+    """
+    Re-attach Discord group sync signals after tests that disconnect them.
+
+    Idempotent via dispatch_uid. Use in setUp/tearDown so fail-closed cases
+    still exercise m2m sync after other suites mute the signals.
+    """
+    signals.post_save.connect(
+        group_post_save,
+        sender=Group,
+        dispatch_uid="group_post_save",
+    )
+    signals.pre_save.connect(
+        resolve_existing_discord_role_from_server,
+        sender=DiscordRole,
+        dispatch_uid="resolve_existing_discord_role_from_server",
+    )
+    signals.m2m_changed.connect(
+        user_group_changed,
+        sender=User.groups.through,
+        dispatch_uid="user_group_changed",
+    )

--- a/backend/discord/tests.py
+++ b/backend/discord/tests.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch, Mock, MagicMock
 
 from django.contrib.auth.models import User, Group
+from django.db import transaction
 from django.test import SimpleTestCase, Client
 from django.db.models import signals
 from ratelimit import RateLimitException
@@ -18,6 +19,7 @@ from discord.client import DiscordError, _raise_discord_rate_limit
 from discord.core import DISCORD_NICKNAME_MAX_LENGTH, make_nickname
 from discord.forms import DiscordChannelAdminForm
 from discord.guilds import sync_discord_guilds
+from discord.exceptions import DiscordRoleAssignmentError
 from discord.helpers import (
     get_discord_user,
     handle_discord_guild_member_error,
@@ -37,7 +39,9 @@ from discord.signals import (
     resolve_existing_discord_role_from_server,
 )
 from discord.tasks import sync_discord_nickname, sync_discord_user
+from discord.testing import reconnect_discord_group_signals
 from discord.views import discord_login_redirect, fake_login
+from users.helpers import offboard_user
 
 
 class DiscordSimpleTests(SimpleTestCase):
@@ -182,6 +186,153 @@ class DiscordSignalTests(TestCase):
         discord_mock.create_role.assert_not_called()
 
 
+class FailClosedDiscordGroupSyncTests(TestCase):
+    """Django group membership must not diverge from Discord (fail-closed)."""
+
+    def setUp(self):
+        reconnect_discord_group_signals()
+        super().setUp()
+
+    def _http_error(self, status_code: int, code: int | None = None):
+        mock_response = MagicMock()
+        mock_response.status_code = status_code
+        if code is not None:
+            mock_response.json.return_value = {"code": code, "message": "x"}
+        else:
+            mock_response.json.return_value = {"message": "x"}
+        return HTTPError(response=mock_response)
+
+    @patch("discord.signals.discord")
+    def test_add_without_discord_user_raises_and_group_not_stuck(
+        self, discord_mock
+    ):
+        discord_mock.get_roles.return_value = []
+        discord_mock.create_role.return_value.json.return_value = {"id": 10}
+        group = Group.objects.create(name="fc-no-discord-user")
+        with self.assertRaises(DiscordRoleAssignmentError):
+            with transaction.atomic():
+                self.user.groups.add(group)
+        self.assertFalse(self.user.groups.filter(pk=group.pk).exists())
+
+    @patch("discord.signals.discord")
+    def test_add_discord_403_raises_and_group_not_stuck(self, discord_mock):
+        discord_mock.get_roles.return_value = []
+        discord_mock.create_role.return_value.json.return_value = {"id": 11}
+        DiscordUser.objects.create(id=11, discord_tag="t", user=self.user)
+        group = Group.objects.create(name="fc-add-403")
+        discord_mock.add_user_role.side_effect = self._http_error(403, 50013)
+        with self.assertRaises(DiscordRoleAssignmentError):
+            with transaction.atomic():
+                self.user.groups.add(group)
+        self.assertFalse(self.user.groups.filter(pk=group.pk).exists())
+
+    @patch("discord.signals.discord")
+    def test_add_success_assigns_discord_and_members(self, discord_mock):
+        discord_mock.get_roles.return_value = []
+        discord_mock.create_role.return_value.json.return_value = {"id": 12}
+        du = DiscordUser.objects.create(id=12, discord_tag="t", user=self.user)
+        group = Group.objects.create(name="fc-add-ok")
+        self.user.groups.add(group)
+        self.assertTrue(self.user.groups.filter(pk=group.pk).exists())
+        discord_mock.add_user_role.assert_called()
+        role = DiscordRole.objects.get(group=group)
+        self.assertTrue(role.members.filter(pk=du.pk).exists())
+
+    @patch("discord.signals.discord")
+    def test_reverse_add_same_rules(self, discord_mock):
+        discord_mock.get_roles.return_value = []
+        discord_mock.create_role.return_value.json.return_value = {"id": 13}
+        DiscordUser.objects.create(id=13, discord_tag="t", user=self.user)
+        group = Group.objects.create(name="fc-reverse-ok")
+        group.user_set.add(self.user)
+        self.assertTrue(self.user.groups.filter(pk=group.pk).exists())
+        discord_mock.add_user_role.assert_called()
+
+    @patch("discord.signals.discord")
+    def test_remove_unreachable_keeps_django_group(self, discord_mock):
+        discord_mock.get_roles.return_value = []
+        discord_mock.create_role.return_value.json.return_value = {"id": 14}
+        DiscordUser.objects.create(id=14, discord_tag="t", user=self.user)
+        group = Group.objects.create(name="fc-remove-fail")
+        self.user.groups.add(group)
+        discord_mock.remove_user_role.side_effect = self._http_error(503, 0)
+        # Non-10007 failure must abort remove
+        discord_mock.remove_user_role.side_effect = ConnectionError("down")
+        with self.assertRaises(DiscordRoleAssignmentError):
+            with transaction.atomic():
+                self.user.groups.remove(group)
+        self.assertTrue(self.user.groups.filter(pk=group.pk).exists())
+
+    @patch("discord.signals.discord")
+    def test_remove_403_keeps_django_group(self, discord_mock):
+        discord_mock.get_roles.return_value = []
+        discord_mock.create_role.return_value.json.return_value = {"id": 15}
+        DiscordUser.objects.create(id=15, discord_tag="t", user=self.user)
+        group = Group.objects.create(name="fc-remove-403")
+        self.user.groups.add(group)
+        discord_mock.remove_user_role.side_effect = self._http_error(
+            403, 50013
+        )
+        with self.assertRaises(DiscordRoleAssignmentError):
+            with transaction.atomic():
+                self.user.groups.remove(group)
+        self.assertTrue(self.user.groups.filter(pk=group.pk).exists())
+
+    @patch("discord.helpers.offboard_user")
+    @patch("discord.signals.discord")
+    def test_remove_10007_allows_django_remove(
+        self, discord_mock, mock_offboard
+    ):
+        discord_mock.get_roles.return_value = []
+        discord_mock.create_role.return_value.json.return_value = {"id": 16}
+        DiscordUser.objects.create(id=16, discord_tag="t", user=self.user)
+        group = Group.objects.create(name="fc-remove-10007")
+        self.user.groups.add(group)
+        discord_mock.remove_user_role.side_effect = self._http_error(
+            404, 10007
+        )
+        self.user.groups.remove(group)
+        self.assertFalse(self.user.groups.filter(pk=group.pk).exists())
+        mock_offboard.assert_called()
+
+    @patch("discord.signals.discord")
+    def test_remove_without_discord_user_allows_django_remove(
+        self, discord_mock
+    ):
+        discord_mock.get_roles.return_value = []
+        discord_mock.create_role.return_value.json.return_value = {"id": 17}
+        DiscordUser.objects.create(id=17, discord_tag="t", user=self.user)
+        group = Group.objects.create(name="fc-remove-no-du")
+        self.user.groups.add(group)
+        DiscordUser.objects.filter(user=self.user).delete()
+        self.user.groups.remove(group)
+        self.assertFalse(self.user.groups.filter(pk=group.pk).exists())
+
+    @patch("discord.signals.discord")
+    @patch("discord.helpers.discord")
+    def test_offboard_does_not_permanently_mute_sync(
+        self, helpers_discord, signals_discord
+    ):
+        signals_discord.get_roles.return_value = []
+        signals_discord.create_role.return_value.json.return_value = {"id": 18}
+        helpers_discord.get_user.side_effect = self._http_error(404, 10007)
+        helpers_discord.get_roles.return_value = []
+
+        DiscordUser.objects.create(id=18, discord_tag="t", user=self.user)
+        other = User.objects.create(username="other_fc")
+        DiscordUser.objects.create(id=19, discord_tag="o", user=other)
+        group = Group.objects.create(name="fc-offboard-mute")
+
+        # Offboard self.user (scoped skip); other user must still sync
+        with patch("users.helpers.DiscordClient") as client_cls:
+            client_cls.return_value.delete_role = MagicMock()
+            offboard_user(self.user.id)
+
+        other.groups.add(group)
+        self.assertTrue(other.groups.filter(pk=group.pk).exists())
+        signals_discord.add_user_role.assert_called()
+
+
 class DiscordTests(TestCase):
     """
     Django tests for Discord functionality.
@@ -318,54 +469,59 @@ class DiscordTests(TestCase):
 
     def test_discord_nickname_task(self):
         self.disconnect_signals()
-        DiscordUser.objects.create(id=1, user=self.user)
-        corp = EveCorporation.objects.create(
-            corporation_id=123,
-            introduction="",
-            biography="",
-            timezones="",
-            requirements="",
-            name="TestCorp",
-            ticker="CORP",
-        )
-        char = EveCharacter.objects.create(
-            character_id=123,
-            character_name="Test Char",
-            corporation_id=corp.corporation_id,
-        )
-        set_primary_character(self.user, char)
-        group, _ = Group.objects.get_or_create(name="Alliance")
-        self.user.groups.add(group)
+        try:
+            DiscordUser.objects.create(id=1, user=self.user)
+            corp = EveCorporation.objects.create(
+                corporation_id=123,
+                introduction="",
+                biography="",
+                timezones="",
+                requirements="",
+                name="TestCorp",
+                ticker="CORP",
+            )
+            char = EveCharacter.objects.create(
+                character_id=123,
+                character_name="Test Char",
+                corporation_id=corp.corporation_id,
+            )
+            set_primary_character(self.user, char)
+            group, _ = Group.objects.get_or_create(name="Alliance")
+            self.user.groups.add(group)
 
-        with patch("discord.tasks.discord") as discord_mock:
-            sync_discord_nickname(self.user, force_update=True)
+            with patch("discord.tasks.discord") as discord_mock:
+                sync_discord_nickname(self.user, force_update=True)
 
-            discord_mock.update_user.assert_called()
+                discord_mock.update_user.assert_called()
+        finally:
+            reconnect_discord_group_signals()
 
     @patch("discord.tasks.discord")
     @patch("discord.helpers.discord")
     def test_sync_discord_user(self, task_client, helper_client):
         self.disconnect_signals()
+        try:
+            helper_client.get_user.return_value = {
+                "roles": ["Alliance", "Another"]
+            }
 
-        helper_client.get_user.return_value = {
-            "roles": ["Alliance", "Another"]
-        }
+            user = User.objects.create(id=1234)
+            DiscordUser.objects.create(
+                user=user,
+                id=12345,
+                discord_tag="XYZ",
+            )
+            group, _ = Group.objects.get_or_create(name="Alliance")
+            DiscordRole.objects.create(
+                role_id=1,
+                name=group.name,
+                group=group,
+            )
+            user.groups.add(group)
 
-        user = User.objects.create(id=1234)
-        DiscordUser.objects.create(
-            user=user,
-            id=12345,
-            discord_tag="XYZ",
-        )
-        group, _ = Group.objects.get_or_create(name="Alliance")
-        DiscordRole.objects.create(
-            role_id=1,
-            name=group.name,
-            group=group,
-        )
-        user.groups.add(group)
-
-        sync_discord_user(user.id)
+            sync_discord_user(user.id)
+        finally:
+            reconnect_discord_group_signals()
 
     def test_fake_login(self):
         User.objects.create(id=1234)

--- a/backend/discord/tests.py
+++ b/backend/discord/tests.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch, Mock, MagicMock
 
 from django.contrib.auth.models import User, Group
+from django.conf import settings
 from django.db import transaction
 from django.test import SimpleTestCase, Client
 from django.db.models import signals
@@ -15,7 +16,11 @@ from eveonline.models import (
 from eveonline.helpers.characters import set_primary_character
 
 from app.test import TestCase
-from discord.client import DiscordError, _raise_discord_rate_limit
+from discord.client import (
+    DiscordClient,
+    DiscordError,
+    _raise_discord_rate_limit,
+)
 from discord.core import DISCORD_NICKNAME_MAX_LENGTH, make_nickname
 from discord.forms import DiscordChannelAdminForm
 from discord.guilds import sync_discord_guilds
@@ -48,6 +53,12 @@ class DiscordSimpleTests(SimpleTestCase):
     """
     Unit tests for Discord functionality.
     """
+
+    def test_unit_tests_block_live_discord_http(self):
+        client = DiscordClient()
+        with self.assertRaises(RuntimeError) as ctx:
+            client.get_roles()
+        self.assertIn("unit tests", str(ctx.exception).lower())
 
     def test_basic_nickname(self):
         character = Mock(character_name="Bob", corporation_id=999)
@@ -295,10 +306,12 @@ class FailClosedDiscordGroupSyncTests(TestCase):
         self.assertFalse(self.user.groups.filter(pk=group.pk).exists())
         mock_offboard.assert_called()
 
+    @patch("discord.signals.remove_all_roles_from_guild_member")
     @patch("discord.signals.discord")
     def test_remove_without_discord_user_allows_django_remove(
-        self, discord_mock
+        self, discord_mock, remove_roles_mock
     ):
+        del remove_roles_mock  # patched to block live Discord on DiscordUser delete
         discord_mock.get_roles.return_value = []
         discord_mock.create_role.return_value.json.return_value = {"id": 17}
         DiscordUser.objects.create(id=17, discord_tag="t", user=self.user)
@@ -736,8 +749,9 @@ class DiscordGuildSyncTestCase(TestCase):
 
     @patch("discord.guilds.discord.get_bot_guilds")
     def test_sync_discord_guilds_from_api(self, mock_get_bot_guilds):
+        primary_guild_id = int(settings.DISCORD_GUILD_ID)
         mock_get_bot_guilds.return_value = [
-            {"id": 1041384161505722368, "name": "Minmatar"},
+            {"id": primary_guild_id, "name": "Primary"},
             {"id": 999, "name": "Other Server"},
         ]
 
@@ -745,12 +759,12 @@ class DiscordGuildSyncTestCase(TestCase):
 
         self.assertEqual(2, synced)
         self.assertTrue(
-            DiscordGuild.objects.get(guild_id=1041384161505722368).is_primary
+            DiscordGuild.objects.get(guild_id=primary_guild_id).is_primary
         )
         self.assertTrue(DiscordGuild.objects.get(guild_id=999).is_active)
 
         mock_get_bot_guilds.return_value = [
-            {"id": 1041384161505722368, "name": "Minmatar"},
+            {"id": primary_guild_id, "name": "Primary"},
         ]
         sync_discord_guilds()
         self.assertFalse(DiscordGuild.objects.get(guild_id=999).is_active)

--- a/backend/groups/helpers/__init__.py
+++ b/backend/groups/helpers/__init__.py
@@ -149,6 +149,9 @@ def sync_user_community_groups(user: User) -> None:
     Active: affiliation group only.
     On Leave: On Leave group only (no affiliation group).
     Only adds/removes groups when membership actually changes to avoid Discord overhead.
+    Per-group add/remove so Discord fail-closed errors on one group do not skip
+    the rest of this user's diff (reconciler retries remaining). See
+    docs/auth/discord-groups.md.
     """
     trial_group, on_leave_group = _trial_and_on_leave_groups()
     affiliation = UserAffiliation.objects.filter(user=user).first()
@@ -189,10 +192,10 @@ def sync_user_community_groups(user: User) -> None:
     to_remove = current - desired_pks
     to_add = desired_pks - current
 
-    if to_remove:
-        user.groups.remove(*user.groups.filter(pk__in=to_remove))
-    if to_add:
-        user.groups.add(*user.groups.model.objects.filter(pk__in=to_add))
+    for group in AuthGroup.objects.filter(pk__in=to_remove):
+        user.groups.remove(group)
+    for group in AuthGroup.objects.filter(pk__in=to_add):
+        user.groups.add(group)
 
 
 def user_in_group_named(user: User, group_name: str) -> bool:
@@ -225,15 +228,38 @@ def sync_tribe_chief_group_membership() -> None:
     current_ids = set(chief_group.user_set.values_list("id", flat=True))
     to_add = desired_ids - current_ids
     to_remove = current_ids - desired_ids
+    added = 0
+    removed = 0
     if to_remove:
         for user in User.objects.filter(pk__in=to_remove):
-            user.groups.remove(chief_group)
+            try:
+                user.groups.remove(chief_group)
+                removed += 1
+            except Exception as exc:  # pylint: disable=broad-except
+                logger.error(
+                    "Failed removing user %s from %s: %s",
+                    user.id,
+                    TRIBE_CHIEF_GROUP_NAME,
+                    exc,
+                )
     if to_add:
         for user in User.objects.filter(pk__in=to_add):
-            user.groups.add(chief_group)
-    if to_add or to_remove:
+            try:
+                user.groups.add(chief_group)
+                added += 1
+            except Exception as exc:  # pylint: disable=broad-except
+                logger.error(
+                    "Failed adding user %s to %s: %s",
+                    user.id,
+                    TRIBE_CHIEF_GROUP_NAME,
+                    exc,
+                )
+    if added or removed or to_add or to_remove:
         logger.info(
-            "sync_tribe_chief_group_membership: added=%s removed=%s",
+            "sync_tribe_chief_group_membership: added=%s removed=%s "
+            "intended_add=%s intended_remove=%s",
+            added,
+            removed,
             len(to_add),
             len(to_remove),
         )

--- a/backend/groups/models.py
+++ b/backend/groups/models.py
@@ -1,4 +1,4 @@
-from django.db import models
+from django.db import models, transaction
 from eveuniverse.models import EveFaction
 
 from eveonline.models import EveAlliance, EveCharacter, EveCorporation
@@ -57,6 +57,12 @@ class UserCommunityStatus(models.Model):
     def __str__(self):
         return f"{self.user} — {self.get_status_display()}"
 
+    def save(self, *args, **kwargs):
+        # Atomic so post_save community group sync failures roll back status.
+        # See docs/auth/discord-groups.md.
+        with transaction.atomic():
+            super().save(*args, **kwargs)
+
 
 class UserCommunityStatusHistory(models.Model):
     """Append-only audit log for community status changes."""
@@ -114,6 +120,17 @@ class UserAffiliation(models.Model):
 
     def __str__(self):
         return f"{self.user} - {self.affiliation}"
+
+    def save(self, *args, **kwargs):
+        # Atomic so post_save community group sync failures roll back affiliation.
+        # See docs/auth/discord-groups.md.
+        with transaction.atomic():
+            super().save(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        # Atomic so post_delete community group sync failures roll back delete.
+        with transaction.atomic():
+            super().delete(*args, **kwargs)
 
 
 class EveCorporationGroup(models.Model):

--- a/backend/groups/signals.py
+++ b/backend/groups/signals.py
@@ -20,11 +20,12 @@ _previous_status_cache = {}
 
 
 @receiver(
-    signals.pre_delete,
+    signals.post_delete,
     sender=UserAffiliation,
-    dispatch_uid="user_affiliation_pre_delete",
+    dispatch_uid="user_affiliation_post_delete",
 )
-def user_affiliation_pre_delete(sender, instance, **kwargs):
+def user_affiliation_post_delete(sender, instance, **kwargs):
+    # Run after delete so sync_user_community_groups sees no affiliation row.
     logger.info("User affiliation deleted, syncing user community groups")
     sync_user_community_groups(instance.user)
     offboard_tribe_memberships_without_feature(instance.user)

--- a/backend/groups/tasks.py
+++ b/backend/groups/tasks.py
@@ -15,6 +15,7 @@ from eveonline.models import EvePlayer
 from .helpers import (
     process_bulk_community_status_row,
     sync_tribe_chief_group_membership,
+    sync_user_community_groups,
 )
 from .models import (
     AffiliationType,
@@ -79,7 +80,25 @@ def update_affiliations():
     for user in User.objects.all():
         try:
             _update_affiliation_for_user(user, affiliation_rules)
+            # Always reconcile community groups so Discord strips/adds retry
+            # even when the affiliation row did not change.
+            sync_user_community_groups(user)
         except Exception as e:
+            log_affiliation_update_error(user, e)
+
+
+@app.task
+def sync_community_groups():
+    """
+    Desired-state reconcile of Trial / On Leave / affiliation auth groups.
+
+    Retries Discord fail-closed add/remove until membership matches
+    UserCommunityStatus + UserAffiliation. See docs/auth/discord-groups.md.
+    """
+    for user in User.objects.all().iterator(chunk_size=500):
+        try:
+            sync_user_community_groups(user)
+        except Exception as e:  # pylint: disable=broad-except
             log_affiliation_update_error(user, e)
 
 
@@ -368,29 +387,38 @@ def sync_eve_corporation_groups():
         to_add = target_user_ids - in_group_user_ids
         to_remove = in_group_user_ids - target_user_ids
 
-        try:
-            if to_add:
-                for user in User.objects.filter(id__in=to_add):
+        if to_add:
+            for user in User.objects.filter(id__in=to_add):
+                try:
                     user.groups.add(group)
                     logger.info(
                         "User %s qualifies for corporation group %s, adding",
                         user.id,
                         group.name,
                     )
-            if to_remove:
-                for user in User.objects.filter(id__in=to_remove):
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.error(
+                        "Error adding user %s to corporation group %s: %s",
+                        user.id,
+                        corporation_group,
+                        e,
+                    )
+        if to_remove:
+            for user in User.objects.filter(id__in=to_remove):
+                try:
                     user.groups.remove(group)
                     logger.info(
                         "User %s no longer qualifies for corporation group %s, removing",
                         user.id,
                         group.name,
                     )
-        except Exception as e:
-            logger.error(
-                "Error syncing corporation group %s: %s",
-                corporation_group,
-                e,
-            )
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.error(
+                        "Error removing user %s from corporation group %s: %s",
+                        user.id,
+                        corporation_group,
+                        e,
+                    )
 
 
 @app.task

--- a/backend/groups/tests/test_discord_fail_closed.py
+++ b/backend/groups/tests/test_discord_fail_closed.py
@@ -1,0 +1,130 @@
+"""Tests for community group reconciler and fail-closed source behavior."""
+
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth.models import Group, User
+from django.db import transaction
+from django.db.models import signals
+
+from app.test import TestCase
+from discord.exceptions import DiscordRoleAssignmentError
+from discord.models import DiscordUser
+from discord.testing import reconnect_discord_group_signals
+from groups.helpers import sync_user_community_groups
+from groups.models import (
+    AffiliationType,
+    UserAffiliation,
+    UserCommunityStatus,
+)
+
+
+class SyncCommunityGroupsReconcilerTestCase(TestCase):
+    """Desired-state community group sync retries Discord strip/add."""
+
+    def setUp(self):
+        signals.post_save.disconnect(
+            sender=Group,
+            dispatch_uid="group_post_save",
+        )
+        signals.m2m_changed.disconnect(
+            sender=User.groups.through,
+            dispatch_uid="user_group_changed",
+        )
+        super().setUp()
+        self.affiliation_group, _ = Group.objects.get_or_create(
+            name="Alliance"
+        )
+        self.guest_group, _ = Group.objects.get_or_create(name="Guest")
+        Group.objects.get_or_create(name="Trial")
+        Group.objects.get_or_create(name="On Leave")
+        self.alliance_type = AffiliationType.objects.create(
+            name="Alliance",
+            description="",
+            image_url="",
+            group=self.affiliation_group,
+            priority=2,
+        )
+        self.guest_type = AffiliationType.objects.create(
+            name="Guest",
+            description="",
+            image_url="",
+            group=self.guest_group,
+            priority=1,
+            default=True,
+        )
+
+    def tearDown(self):
+        reconnect_discord_group_signals()
+        super().tearDown()
+
+    def test_reconciler_strips_stale_alliance_when_guest(self):
+        UserAffiliation.objects.create(
+            user=self.user, affiliation=self.guest_type
+        )
+        UserCommunityStatus.objects.create(
+            user=self.user, status=UserCommunityStatus.STATUS_ACTIVE
+        )
+        # Stale Alliance group left from a prior failed Discord remove
+        self.user.groups.add(self.affiliation_group)
+
+        sync_user_community_groups(self.user)
+
+        names = set(self.user.groups.values_list("name", flat=True))
+        self.assertNotIn("Alliance", names)
+        self.assertIn("Guest", names)
+
+    def test_sync_user_community_groups_per_group(self):
+        UserAffiliation.objects.create(
+            user=self.user, affiliation=self.alliance_type
+        )
+        UserCommunityStatus.objects.create(
+            user=self.user, status=UserCommunityStatus.STATUS_ACTIVE
+        )
+        sync_user_community_groups(self.user)
+        self.assertIn(self.affiliation_group, self.user.groups.all())
+
+
+class AffiliationAtomicRollbackTestCase(TestCase):
+    """Affiliation save rolls back when Discord group sync fails."""
+
+    def setUp(self):
+        reconnect_discord_group_signals()
+        super().setUp()
+
+    @patch("discord.signals.discord")
+    def test_affiliation_create_rolls_back_on_discord_add_failure(
+        self, discord_mock
+    ):
+        discord_mock.get_roles.return_value = []
+        role_ids = iter(range(100, 200))
+
+        def _create_role(role_name):
+            mock = MagicMock()
+            mock.json.return_value = {"id": next(role_ids)}
+            assert role_name
+            return mock
+
+        discord_mock.create_role.side_effect = _create_role
+        DiscordUser.objects.create(id=100, discord_tag="t", user=self.user)
+        alliance_group = Group.objects.create(name="Alliance FC")
+        affiliation_type = AffiliationType.objects.create(
+            name="Alliance FC",
+            description="",
+            image_url="",
+            group=alliance_group,
+            priority=10,
+        )
+        discord_mock.add_user_role.side_effect = ConnectionError("down")
+
+        with self.assertRaises(DiscordRoleAssignmentError):
+            with transaction.atomic():
+                UserAffiliation.objects.create(
+                    user=self.user, affiliation=affiliation_type
+                )
+
+        self.assertFalse(
+            UserAffiliation.objects.filter(user=self.user).exists()
+        )
+        self.assertFalse(
+            self.user.groups.filter(pk=alliance_group.pk).exists()
+        )

--- a/backend/groups/tests/test_discord_fail_closed.py
+++ b/backend/groups/tests/test_discord_fail_closed.py
@@ -53,10 +53,6 @@ class SyncCommunityGroupsReconcilerTestCase(TestCase):
             default=True,
         )
 
-    def tearDown(self):
-        reconnect_discord_group_signals()
-        super().tearDown()
-
     def test_reconciler_strips_stale_alliance_when_guest(self):
         UserAffiliation.objects.create(
             user=self.user, affiliation=self.guest_type

--- a/backend/tribes/models/tribe_group_membership.py
+++ b/backend/tribes/models/tribe_group_membership.py
@@ -1,4 +1,4 @@
-from django.db import models
+from django.db import models, transaction
 
 
 class TribeGroupMembership(models.Model):
@@ -88,7 +88,10 @@ class TribeGroupMembership(models.Model):
             and self.rank.tribe_group_id != self.tribe_group_id
         ):
             raise ValueError("Rank must belong to the membership tribe group.")
-        super().save(*args, **kwargs)
+        # Atomic so post_save Discord group sync failures roll back status/rank
+        # changes (Discord roles must stay accurate). See docs/auth/discord-groups.md.
+        with transaction.atomic():
+            super().save(*args, **kwargs)
 
     class Meta:
         ordering = ["-created_at"]

--- a/backend/tribes/tests/test_signals.py
+++ b/backend/tribes/tests/test_signals.py
@@ -1,10 +1,16 @@
 """Tests for tribes signals."""
 
+from unittest.mock import patch
+
 from django.contrib.auth.models import Group, User
 from django.db.models import signals as django_signals
 from django.test import TestCase
+from django.db import transaction
 from django.utils import timezone
 
+from discord.exceptions import DiscordRoleAssignmentError
+from discord.models import DiscordRole, DiscordUser
+from discord.signals import group_post_save, user_group_changed
 from tribes.helpers.tribe_auth_groups import (
     remove_tribe_auth_groups_for_inactive_membership,
 )
@@ -19,12 +25,6 @@ from tribes.models import (
 
 def setUpModule():
     """Disconnect Discord signals that hit the live API during tests."""
-    # pylint: disable-next=import-outside-toplevel
-    from discord.signals import (
-        group_post_save,
-        user_group_changed,
-    )  # noqa: PLC0415
-
     django_signals.post_save.disconnect(
         group_post_save,
         sender=Group,
@@ -202,3 +202,72 @@ class MembershipRankSignalTestCase(TestCase):
         self.membership.save()
 
         self.assertNotIn(self.strategic_group, self.user.groups.all())
+
+
+class TribeMembershipDiscordFailClosedTestCase(TestCase):
+    """Inactive membership must not stick when Discord role remove fails."""
+
+    def setUp(self):
+        # Reconnect Discord m2m sync only (module setup disconnects it).
+        # Leave group_post_save disconnected so Group.create does not hit Discord.
+        django_signals.m2m_changed.connect(
+            user_group_changed,
+            sender=User.groups.through,
+            dispatch_uid="user_group_changed",
+        )
+        self.tribe_auth_group = Group.objects.create(name="Tribe FC Auth")
+        self.group_auth_group = Group.objects.create(name="Group FC Auth")
+        self.tribe = Tribe.objects.create(
+            name="Capitals FC",
+            slug="capitals-fc",
+            group=self.tribe_auth_group,
+        )
+        self.tribe_group = TribeGroup.objects.create(
+            tribe=self.tribe,
+            name="Dreads FC",
+            group=self.group_auth_group,
+        )
+        self.user = User.objects.create(username="tribe_fc_user")
+
+    def tearDown(self):
+        django_signals.m2m_changed.disconnect(
+            user_group_changed,
+            sender=User.groups.through,
+            dispatch_uid="user_group_changed",
+        )
+
+    @patch("discord.signals.discord")
+    def test_inactive_rolls_back_when_discord_remove_fails(self, discord_mock):
+        discord_mock.get_roles.return_value = []
+        discord_mock.create_role.return_value.json.return_value = {"id": 200}
+        DiscordUser.objects.create(id=200, discord_tag="t", user=self.user)
+        for group, role_id in (
+            (self.group_auth_group, 201),
+            (self.tribe_auth_group, 202),
+        ):
+            if not DiscordRole.objects.filter(group=group).exists():
+                DiscordRole.objects.create(
+                    role_id=role_id, name=group.name, group=group
+                )
+
+        self.user.groups.add(self.group_auth_group)
+        self.user.groups.add(self.tribe_auth_group)
+
+        membership = TribeGroupMembership.objects.create(
+            user=self.user,
+            tribe_group=self.tribe_group,
+            status=TribeGroupMembership.STATUS_ACTIVE,
+        )
+
+        discord_mock.remove_user_role.side_effect = ConnectionError("down")
+        membership.status = TribeGroupMembership.STATUS_INACTIVE
+        membership.left_at = timezone.now()
+        membership.history_inactive_reason = "left"
+
+        with self.assertRaises(DiscordRoleAssignmentError):
+            with transaction.atomic():
+                membership.save()
+
+        membership.refresh_from_db()
+        self.assertEqual(membership.status, TribeGroupMembership.STATUS_ACTIVE)
+        self.assertIn(self.group_auth_group, self.user.groups.all())

--- a/backend/users/helpers.py
+++ b/backend/users/helpers.py
@@ -3,10 +3,10 @@ from typing import List, Optional
 
 import requests
 from django.contrib.auth.models import Group, User, Permission
-from django.db.models import signals
 
 from discord.client import DiscordClient
 from discord.models import DiscordRole, DiscordUser
+from discord.sync_context import disable_discord_group_sync
 from audit.models import AuditEntry
 from eveonline.helpers.characters import user_primary_character
 from eveonline.models import EveCorporation, EvePlayer
@@ -17,35 +17,43 @@ logger = logging.getLogger(__name__)
 
 
 def offboard_user(user_id: int):
-    signals.m2m_changed.disconnect(
-        sender=User.groups.through, dispatch_uid="user_group_changed"
-    )
-    user = User.objects.get(id=user_id)
-    user.delete()
+    """
+    Delete a user without firing Discord m2m role sync on cascading group clears.
+
+    Uses a scoped skip flag (not a permanent signal disconnect) so the worker
+    keeps syncing Discord for other users afterward.
+    """
+    with disable_discord_group_sync():
+        user = User.objects.get(id=user_id)
+        user.delete()
 
 
 def offboard_group(group_id: int):
-    signals.m2m_changed.disconnect(
-        sender=User.groups.through, dispatch_uid="user_group_changed"
-    )
-    group = Group.objects.get(id=group_id)
-    # Delete Discord role from server and remove DiscordRole row before deleting Group
-    try:
-        discord_role = group.discord_group
-        if discord_role.role_id:
-            try:
-                DiscordClient().delete_role(discord_role.role_id)
-            except requests.HTTPError as e:
-                logger.warning(
-                    "Could not delete Discord role %s (id=%s): %s",
-                    discord_role.name,
-                    discord_role.role_id,
-                    e,
-                )
-        discord_role.delete()
-    except DiscordRole.DoesNotExist:
-        pass
-    group.delete()
+    """
+    Delete an auth Group and its Discord role without m2m Discord sync noise.
+
+    Scoped skip only for this delete; Discord sync stays enabled afterward.
+    """
+    with disable_discord_group_sync():
+        group = Group.objects.get(id=group_id)
+        # Delete Discord role from server and remove DiscordRole row before
+        # deleting Group
+        try:
+            discord_role = group.discord_group
+            if discord_role.role_id:
+                try:
+                    DiscordClient().delete_role(discord_role.role_id)
+                except requests.HTTPError as e:
+                    logger.warning(
+                        "Could not delete Discord role %s (id=%s): %s",
+                        discord_role.name,
+                        discord_role.role_id,
+                        e,
+                    )
+            discord_role.delete()
+        except DiscordRole.DoesNotExist:
+            pass
+        group.delete()
 
 
 def get_user_permissions(user_id: int) -> list[str]:

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import User
 from esi.models import CallbackRedirect, Token
 
 from app.test import TestCase
+from discord.client import DiscordError
 from discord.models import DiscordUser
 from eveonline.models import EveCharacter, EveCorporation
 from eveonline.helpers.characters import (
@@ -162,23 +163,23 @@ class UserRouterTestCase(TestCase):
             self.assertTrue(discord_user.is_down_under)
             self.assertEqual("http://after.gif", discord_user.avatar)
 
-    @patch("discord.client.requests.post")
-    @patch("discord.client.requests.get")
-    def test_discord_login_redirect_error(self, profile_mock, exchange_mock):
-        exchange_mock.return_value.status_code = 400
-        profile_mock.return_value.status_code = 200
+    @patch("users.router.discord.exchange_code")
+    def test_discord_login_redirect_error(self, exchange_mock):
         request = MagicMock()
 
+        discord_response = MagicMock()
+        discord_response.status_code = 400
+        exchange_mock.side_effect = DiscordError.for_response(
+            "Error exchanging token", "EXCHG_CODE", discord_response
+        )
         response = callback(request, code="100001")
-
         self.assertEqual(response.status_code, 302)
         self.assertIn("error=EXCHG_CODE", response.url)
 
-        exchange_mock.return_value.status_code = 200
-        profile_mock.return_value.status_code = 400
-
+        exchange_mock.side_effect = DiscordError.for_response(
+            "Error fetching Discord profile", "GET_PROFILE", discord_response
+        )
         response = callback(request, code="100001")
-
         self.assertEqual(response.status_code, 302)
         self.assertIn("error=GET_PROFILE", response.url)
 

--- a/docs/auth/README.md
+++ b/docs/auth/README.md
@@ -6,6 +6,8 @@ How authentication and authorization work on minmatar.org.
 |-----|--------|
 | [authentication.md](authentication.md) | Discord OAuth login, JWT issuance, `AuthBearer` |
 | [authorization.md](authorization.md) | PilotFeature evaluation, scopes, `can_use_feature()`, gating endpoints |
+| [discord-groups.md](discord-groups.md) | Fail-closed `auth.Group` ↔ Discord roles; source/reconcile rules |
+| [discord-groups-verification.md](discord-groups-verification.md) | Live test-guild OPSEC verification playbook + how to run |
 | [feature-catalog.md](feature-catalog.md) | Every feature code, its scope, legacy permission, and default wiring |
 | [migration.md](migration.md) | Retiring Django auth-group permissions in favor of feature wiring |
 
@@ -17,6 +19,8 @@ Two questions, two systems:
 2. **What can you do?** — Authorization. A single evaluator, `can_use_feature(user, code, **context)`, decides access per capability.
 
 Identity (affiliation, community status, Discord roles) and product capabilities (view fleets, apply to tribes) are separate. Capabilities are **PilotFeatures**: stable codes defined in a code registry and wired in the admin to affiliations, tribe groups, or auth groups.
+
+**Discord roles MUST be accurate.** Mutating `user.groups` is fail-closed against Discord; see [discord-groups.md](discord-groups.md).
 
 ```mermaid
 flowchart TD

--- a/docs/auth/authorization.md
+++ b/docs/auth/authorization.md
@@ -113,7 +113,7 @@ flowchart LR
 
 - **`AffiliationType`** (Alliance, Militia, Associate, Guest) — identity bucket derived from the primary character's corp/alliance/faction by a scheduled Celery task. Features reference affiliations; affiliations do not grant product access by themselves.
 - **`TribeGroup.code`** — stable key (`industry.mining`, `capitals.dreads`, …) used in feature wiring and reports.
-- **`auth.Group`** — primarily Discord role mapping; also usable as a feature wiring target (e.g. Technology Team). Some groups may still hold Django permissions used as `legacy_permission` fallbacks (see [migration.md](migration.md)).
+- **`auth.Group`** — primarily Discord role mapping; also usable as a feature wiring target (e.g. Technology Team). Some groups may still hold Django permissions used as `legacy_permission` fallbacks (see [migration.md](migration.md)). **Mutating `user.groups` is subject to fail-closed Discord sync** — see [discord-groups.md](discord-groups.md).
 
 ### Tribe offboarding
 

--- a/docs/auth/discord-groups-verification.md
+++ b/docs/auth/discord-groups-verification.md
@@ -1,0 +1,168 @@
+# Live Discord verification (local + test guild)
+
+OPSEC playbook for fail-closed Discord ↔ Django ↔ affiliation ↔ tribe ↔ corp sync against the **real test Discord guild**, not mocks.
+
+Contract: [discord-groups.md](discord-groups.md).
+
+**Never run this against the production guild. Never commit bot tokens or OAuth secrets.**
+
+## Goal
+
+Confirm:
+
+1. Discord roles always match intended privileges.
+2. Django cannot gain or drop a group unless the Discord role mutate succeeded.
+3. Affiliation / community / tribe / corp sources cannot stick ahead of Discord without rollback or retry.
+4. Rate limits, 403 permission failures, and unknown-member (`10007`) cases behave correctly under live API conditions.
+
+**Pass rule (every case):** Discord member roles, Django `user.groups`, and `DiscordRole.members` agree with the intended source state. Any mismatch = **FAIL / OPSEC**.
+
+## How to run (preferred)
+
+From `backend/`, with local settings pointed at the **test** guild:
+
+```bash
+pipenv run python manage.py verify_discord_groups \
+  --username bearthatcares \
+  --guild-id 1459994254427291781 \
+  --i-understand-this-hits-live-discord
+```
+
+If `DISCORD_GUILD_ID` in `.env` still points at production, **`--guild-id` is required** (production is always refused). The bot token must belong to a bot that is a member of the test guild.
+
+Optional:
+
+| Flag | Purpose |
+|------|---------|
+| `--guild-id 1459994254427291781` | Override `.env` / settings guild for this run |
+| `--cases A1,A2,B1` | Run a subset of the matrix |
+| `--burst-count 10` | Fewer roles for F1/F2 |
+| `--allow-guild-id <id>` | Allow an extra non-production test guild |
+
+Safety gates in code (`discord/live_verify.py`):
+
+- Production guild ID `1041384161505722368` is **always refused**.
+- Default allowlist is the Minmatar Fleet Test Server (`1459994254427291781`).
+- The subject username is **never** offboarded (G1 uses `verify-*` throwaways only).
+- Scratch auth groups / Discord roles use the `VERIFY-` prefix and are deleted on cleanup.
+
+## Opt-in TestCase
+
+Skipped in normal CI / `settings_test` runs unless explicitly enabled. Uses `SimpleTestCase` (no DB transaction rollback that would diverge from Discord).
+
+```bash
+RUN_DISCORD_LIVE_VERIFY=1 \
+DISCORD_LIVE_VERIFY_USER=bearthatcares \
+DISCORD_LIVE_VERIFY_GUILD_ID=1459994254427291781 \
+pipenv run python manage.py test discord.test_live_discord_groups_verify \
+  --settings=app.settings
+```
+
+Do **not** use `--settings=app.settings_test` — that database has no linked Discord users. Set `DISCORD_LIVE_VERIFY_GUILD_ID` when `.env` still has the production guild.
+
+## Preconditions
+
+- Local backend with `DISCORD_BOT_TOKEN` for a bot that is **in the test guild** and can manage roles below its highest role.
+- Subject user is in the test guild and has a `DiscordUser` row (e.g. `bearthatcares`).
+- Affiliation types `Alliance` / `Guest` and community groups `On Leave` / `Trial` exist.
+- Subject has a primary EVE character with a `corporation_id` (for corp sync cases).
+
+### Inducing failures (what the runner does)
+
+| Failure | Mechanism |
+|---------|-----------|
+| 403 / Missing Permissions | Temporarily point a `VERIFY-*` (or Alliance) `DiscordRole.role_id` at a **managed** bot role, then add/remove |
+| Unreachable Discord | Temporarily set module bot token to an invalid value |
+| 10007 unknown member | Throwaway user whose `DiscordUser.id` is not a guild member |
+| Discord-only orphan roles | `sync_discord_user` after community sync (A4) — community sync alone only diffs Django community groups |
+
+## Verification matrix
+
+### A. Happy path
+
+| ID | Action | Expect |
+|----|--------|--------|
+| A1 | `groups.add(VERIFY-Role)` | Discord + Django + `DiscordRole.members` |
+| A2 | `groups.remove` | Role gone both sides |
+| A3 | Create `VERIFY-New` group | Discord role created; `role_id` set |
+| A4 | Community sync + `sync_discord_user` | Alliance present; On Leave cleared |
+| A5 | Activate VERIFY tribe membership | Tribe group role aligned |
+| A6 | `sync_eve_corporation_groups` | VERIFY corp member role aligned |
+
+### B. Fail-closed add
+
+| ID | Setup | Expect |
+|----|-------|--------|
+| B1 | User with no `DiscordUser` | `DiscordRoleAssignmentError`; not in Django group |
+| B2 | 403 on add | Error; not in Django |
+| B3 | Invalid bot token | Error; not in Django |
+| B4 | Affiliation change while Discord add fails | Affiliation **rolled back** |
+
+### C. Fail-closed remove (OPSEC critical)
+
+| ID | Setup | Expect |
+|----|-------|--------|
+| C1 | 403 on remove | Still in Django **and** Discord |
+| C2 | Unreachable on remove | Both still have role |
+| C3 | Tribe → inactive while remove blocked | Status stays **active**; roles kept |
+| C4 | Alliance → Guest while Alliance remove blocked | Never Guest-in-Django + Alliance-on-Discord |
+| C5 | Healthy remove after restore | Converges |
+
+### D. Allowed remove exceptions
+
+| ID | Setup | Expect |
+|----|-------|--------|
+| D1 | Unknown member (10007) | Django remove allowed (may offboard throwaway) |
+| D2 | No `DiscordUser` row | Django remove allowed |
+
+### E. Reconcilers
+
+| ID | Action | Expect |
+|----|--------|--------|
+| E1 | Stale Alliance while affiliation Guest → `sync_user_community_groups` | Alliance stripped; Guest only |
+| E2 | Inactive tribe with groups still attached → remove helper | Roles stripped |
+| E3 | Primary corp changed away → corp sync | Corp role removed |
+
+### F. Burst / rate limits
+
+| ID | Action | Expect |
+|----|--------|--------|
+| F1 | Burst-add N `VERIFY-Burst-*` roles | Final Discord == Django |
+| F2 | Burst-remove | Same |
+| F3 | Offboard throwaway then subject add | Sync still works (scoped skip, not permanent mute) |
+
+### G. Offboard integrity
+
+| ID | Action | Expect |
+|----|--------|--------|
+| G1 | `offboard_user` on **throwaway** only | User deleted |
+| G2 | Subject `groups.add` immediately after | Discord sync still works |
+
+### H. Community transitions
+
+| ID | Action | Expect |
+|----|--------|--------|
+| H1 | Active Alliance → On Leave | On Leave only on Discord + Django |
+| H2 | On Leave → Active Guest | Guest only |
+| H3 | Interrupt leave (403 on Alliance remove) | No On-Leave-in-Django with Alliance still on Discord |
+
+## Execution order
+
+1. Preconditions + **A**
+2. **B** then **C**
+3. **D** → **E** → **F** → **G** → **H**
+4. Cleanup (automatic in the runner): delete `VERIFY-*` roles/groups; restore subject affiliation / UCS / corp
+
+## Code map
+
+| Piece | Path |
+|-------|------|
+| Runner + safety gates | `backend/discord/live_verify.py` |
+| Management command | `backend/discord/management/commands/verify_discord_groups.py` |
+| Opt-in TestCase | `backend/discord/test_live_discord_groups_verify.py` |
+
+## Out of scope
+
+- Production guild testing
+- Healing historical prod drift (separate `sync_discord_user` pass)
+- Replacing unit tests in `discord/tests.py` / `groups/tests/test_discord_fail_closed.py`

--- a/docs/auth/discord-groups-verification.md
+++ b/docs/auth/discord-groups-verification.md
@@ -39,12 +39,13 @@ Optional:
 | `--burst-count 10` | Fewer roles for F1/F2 |
 | `--allow-guild-id <id>` | Allow an extra non-production test guild |
 
-Safety gates in code (`discord/live_verify.py`):
+Safety gates in code (`discord/live_verify.py` and `discord/client.py`):
 
 - Production guild ID `1041384161505722368` is **always refused**.
 - Default allowlist is the Minmatar Fleet Test Server (`1459994254427291781`).
 - The subject username is **never** offboarded (G1 uses `verify-*` throwaways only).
 - Scratch auth groups / Discord roles use the `VERIFY-` prefix and are deleted on cleanup.
+- Normal unit tests (`app.settings_test`) clear Discord credentials and **block live Discord HTTP** unless `ALLOW_LIVE_DISCORD_IN_TESTS=True` (do not set that for routine CI).
 
 ## Opt-in TestCase
 

--- a/docs/auth/discord-groups.md
+++ b/docs/auth/discord-groups.md
@@ -1,0 +1,69 @@
+# Discord roles and auth.Group membership
+
+**Operational invariant: Discord roles MUST be accurate.**
+
+Ping access, channel visibility, and opsec depend on Discord — not on Django `auth.Group` rows. Django is the **follower**: membership may only change when the corresponding Discord role mutate succeeds.
+
+## Rules for callers
+
+Anyone who adds or removes users from `auth.Group` (tribe approval, affiliation sync, corp groups, admin, Celery tasks) must follow these rules.
+
+### Fail-closed M2M
+
+`user.groups.add` / `.remove` / `.clear` (and reverse `group.user_set.*`) fire [`discord.signals.user_group_changed`](../../backend/discord/signals.py).
+
+| Operation | Discord outcome | Django membership |
+|-----------|-----------------|-------------------|
+| Add | Role assigned (or already held) | Allowed |
+| Add | No `DiscordUser`, missing/`ensure` failed, 403, unreachable, etc. | **Aborted** — raises `DiscordRoleAssignmentError` |
+| Remove | Role stripped | Allowed |
+| Remove | Unreachable / 403 | **Aborted** — raises `DiscordRoleAssignmentError` (keeps Django group so Discord is not a ghost privilege) |
+| Remove | Unknown member (`10007`), no `DiscordUser`, or no `DiscordRole` | Allowed (nothing left on Discord to leave behind) |
+
+Do **not** catch and ignore `DiscordRoleAssignmentError` unless you immediately retry or roll back the source write that required the group change.
+
+### Every membership group needs a DiscordRole
+
+There are no intentional Django-only user membership groups. Creating an `auth.Group` runs `group_post_save` → `_ensure_discord_role_for_group`. On add, missing `DiscordRole` rows are ensured again; failure aborts the add.
+
+### Sources must not stick ahead of Discord
+
+Writing a **source** (tribe membership inactive, affiliation change, community status) and then failing Discord leave users with Discord privileges Django no longer intends — and some paths will not retry.
+
+| Source | Retry / rollback |
+|--------|------------------|
+| Corp groups | Desired-state beat `sync_eve_corporation_groups` (~30m) |
+| Tribe - Chief | Desired-state beat `sync_tribe_chief_group` |
+| Tribe membership | `TribeGroupMembership.save` is `atomic()` so Discord failure rolls back status; inactive sweep also retries (~2h) |
+| Affiliation / community | `UserAffiliation` / `UserCommunityStatus` saves are `atomic()`; beats `update_affiliations` + `sync_community_groups` re-run `sync_user_community_groups` |
+
+**When adding a new group source**, pick one:
+
+1. **Desired-state reconciler** — a periodic task that diffs source → groups and retries until Discord succeeds, or  
+2. **`transaction.atomic()` around the source write** so `post_save` group sync raising `DiscordRoleAssignmentError` rolls back the source.
+
+### Offboard
+
+Use [`offboard_user`](../../backend/users/helpers.py) / `offboard_group`. They use a **scoped** skip flag (`disable_discord_group_sync`) so cascading M2M clears do not call Discord during delete. Never permanently `disconnect` `user_group_changed` in a long-lived worker.
+
+## Code map
+
+| Piece | Path |
+|-------|------|
+| Fail-closed signals | `backend/discord/signals.py` |
+| `DiscordRoleAssignmentError` | `backend/discord/exceptions.py` |
+| Offboard skip context | `backend/discord/sync_context.py` |
+| Community group sync | `backend/groups/helpers/__init__.py` → `sync_user_community_groups` |
+| Community reconciler | `backend/groups/tasks.py` → `sync_community_groups` |
+| Corp group sync | `backend/groups/tasks.py` → `sync_eve_corporation_groups` |
+| Tribe auth groups | `backend/tribes/helpers/tribe_auth_groups.py`, `backend/tribes/signals.py` |
+| Live verify runner | `backend/discord/live_verify.py` |
+| Live verify command | `manage.py verify_discord_groups` |
+
+## Temporary Discord-only drift
+
+If Discord succeeds for group A then fails for group B in the same multi-group `pre_add`, Django aborts the whole M2M op, but A may already have the Discord role. `sync_discord_user` / community-corp reconcilers remove excess tracked roles. Prefer that over Django-only membership or Discord ghosts.
+
+## Live verification (test guild)
+
+Manual OPSEC checklist and runner: [discord-groups-verification.md](discord-groups-verification.md).


### PR DESCRIPTION
## Summary
- Make Django `auth.Group` add/remove fail-closed against Discord role mutates so Discord stays the OPSEC source of truth (no Django-only privilege, no Discord ghosts on blocked remove).
- Roll back / reconcile affiliation, community, tribe, and corp sources when Discord sync fails; add community-group beat reconciler; fix offboard so m2m sync is only scoped-skipped.
- Document the contract and add an opt-in live test-guild verifier (`manage.py verify_discord_groups`) plus safety-gated TestCase (skipped unless `RUN_DISCORD_LIVE_VERIFY=1`).

## Test plan
- [x] `pipenv run python manage.py test discord.tests groups.tests.test_discord_fail_closed discord.test_live_discord_groups_verify tribes.tests.test_signals.TribeMembershipDiscordFailClosedTestCase --settings=app.settings_test`
- [ ] Smoke live verifier against test guild (manual):
  ```bash
  pipenv run python manage.py verify_discord_groups \
    --username bearthatcares \
    --guild-id 1459994254427291781 \
    --i-understand-this-hits-live-discord
  ```
- [ ] Confirm production guild is refused without `--guild-id` / allowlist override


Made with [Cursor](https://cursor.com)