### PR TITLE
Skill hygiene: leave restore grace + trial recency gate

### DIFF
--- a/.cursor/skills/on-leave/SKILL.md
+++ b/.cursor/skills/on-leave/SKILL.md
@@ -47,7 +47,7 @@ Override only from session context (quiet war window, user-named exempts).
 ```
 Task Progress:
 - [ ] Fetch (--max-fleets 6)
-- [ ] Drop auto-exempts (staff, directors) + rejoin grace + named exempts
+- [ ] Drop auto-exempts (staff, directors) + rejoin/restore grace + named exempts
 - [ ] Decide leave/keep; Story + Conf + reason
 - [ ] Emit report + CSV
 - [ ] Stop for executor review/upload
@@ -72,6 +72,13 @@ Task Progress:
 falls within the last **30 days**, and no fleets in the **30–180d** band before
 that (returning after a long gap). Example: one fleet yesterday after months
 dark → keep, do not flip.
+
+**Recent restore grace** (omit from recommend): any
+`UserCommunityStatusHistory` row in the last **30 days** with
+`from_status=on_leave` → `to_status=active` (or other non-leave). Someone a CEO
+just took off leave should not be flipped back on the next hygiene pass. Fetch
+exposes `restored_from_leave_at` (ISO date or `null`); treat non-null as omit.
+
 ## Signals
 
 | Signal | Model | Roll-up |
@@ -79,6 +86,7 @@ dark → keep, do not flip.
 | Fleets | `EveFleetInstanceMember` | Distinct instances across linked EVE IDs |
 | Kills | `EveCharacterKillmailAttacker` | Attackers; exclude self-victim |
 | Voice | `DiscordChannelActivityRecord` | `voice_minute` by Django `username` → hours |
+| Restore | `UserCommunityStatusHistory` | Latest `on_leave`→non-leave in last 30d → `restored_from_leave_at` |
 
 Fleets are primary. Kills/voice set Away vs OPSEC and break ties. Login,
 mining, PI, industry do not clear the fleet bar unless this run expands
@@ -87,7 +95,7 @@ when they matter.
 
 ## Decision rules (90d)
 
-1. Exempt / director / recent-rejoin grace → keep (omit).
+1. Exempt / director / recent-rejoin grace / recent-restore grace → keep (omit).
 2. Fleets ≥ 6 → keep (even low kills).
 3. Fleets 0–2, weak support (under ~5 kills and under ~5h voice) → **recommend**.
    Away if kills≈0 and voice≈0; else OPSEC. Conf **high**.

--- a/.cursor/skills/on-leave/examples.md
+++ b/.cursor/skills/on-leave/examples.md
@@ -40,3 +40,7 @@ group or `EveCorporation.directors`); named CEOs/LTI this session.
 
 **Rejoin grace:** first 90d fleet within last 30d and no fleets in 30–180d prior
 (e.g. `_obiwand` — one fleet after a long gap) → keep.
+
+**Restore grace:** `on_leave` → `active` (or other non-leave) within last 30d in
+`UserCommunityStatusHistory` (fetch `restored_from_leave_at` set) → keep. Do not
+re-impose leave on someone a CEO just restored.

--- a/.cursor/skills/on-leave/scripts/fetch_alliance_activity.py
+++ b/.cursor/skills/on-leave/scripts/fetch_alliance_activity.py
@@ -33,9 +33,14 @@ from django.utils import timezone
 from discord.models import DiscordChannelActivityRecord
 from eveonline.models import EveCharacter, EveCharacterKillmailAttacker, EvePlayer
 from fleets.models import EveFleetInstanceMember
-from groups.models import UserAffiliation, UserCommunityStatus
+from groups.models import (
+    UserAffiliation,
+    UserCommunityStatus,
+    UserCommunityStatusHistory,
+)
 
 PRODUCTION_DB = "production_readonly"
+RESTORE_GRACE_DAYS = 30
 
 
 def fetch_activity(
@@ -46,6 +51,7 @@ def fetch_activity(
 ) -> dict:
     now = timezone.now()
     since = now - timedelta(days=days)
+    restore_since = now - timedelta(days=RESTORE_GRACE_DAYS)
 
     affiliations = list(
         UserAffiliation.objects.using(PRODUCTION_DB)
@@ -139,6 +145,23 @@ def fetch_activity(
             )
         }
 
+    # Latest on_leave → non-leave within restore grace window.
+    restored_at_by_user: dict[int, object] = {}
+    if active_user_ids:
+        for user_id, changed_at in (
+            UserCommunityStatusHistory.objects.using(PRODUCTION_DB)
+            .filter(
+                user_id__in=active_user_ids,
+                changed_at__gte=restore_since,
+                from_status=UserCommunityStatus.STATUS_ON_LEAVE,
+            )
+            .exclude(to_status=UserCommunityStatus.STATUS_ON_LEAVE)
+            .order_by("user_id", "-changed_at")
+            .values_list("user_id", "changed_at")
+        ):
+            if user_id not in restored_at_by_user:
+                restored_at_by_user[user_id] = changed_at
+
     members = []
     for user_id in active_user_ids:
         username = username_by_id.get(user_id)
@@ -149,6 +172,7 @@ def fetch_activity(
         if max_fleets is not None and fleets >= max_fleets:
             continue
         voice_min = voice_by_username.get(username, 0)
+        restored_at = restored_at_by_user.get(user_id)
         members.append(
             {
                 "username": username,
@@ -161,6 +185,9 @@ def fetch_activity(
                 "kills": sum(kills_by_char.get(cid, 0) for cid in char_ids),
                 "voice_minutes": voice_min,
                 "voice_hours": round(voice_min / 60, 1),
+                "restored_from_leave_at": (
+                    restored_at.strftime("%Y-%m-%d") if restored_at else None
+                ),
             }
         )
 

--- a/.cursor/skills/trial-approval/SKILL.md
+++ b/.cursor/skills/trial-approval/SKILL.md
@@ -26,6 +26,10 @@ or a clear mix.
 We do **not** care just about fleets. We care about them doing things like solo
 / small gang kills, being in voice, etc. Participating in the alliance.
 
+Participation must span the window — **do not approve on a strong first month
+then silence**. Full-window totals alone are not enough; recent activity is
+required.
+
 `active` → affiliation group only (Trial Discord role stripped) via
 `sync_user_community_groups`.
 
@@ -44,7 +48,8 @@ cd backend
 pipenv run python ../.cursor/skills/trial-approval/scripts/fetch_trial_activity.py --json
 ```
 
-Defaults: **90d** window; affiliation **Alliance**; status **trial**.
+Defaults: **90d** window + **30d** recent slice; affiliation **Alliance**;
+status **trial**.
 
 ## Workflow
 
@@ -52,6 +57,7 @@ Defaults: **90d** window; affiliation **Alliance**; status **trial**.
 Task Progress:
 - [ ] Fetch trial Alliance activity (--json)
 - [ ] Split wrong-affiliation (fix command) vs real trial
+- [ ] Apply recency gate (30d / days_since_activity)
 - [ ] Decide approve / hold; Path + Conf + reason
 - [ ] Emit report + CSV (approve rows only)
 - [ ] Stop for executor review/upload
@@ -76,12 +82,21 @@ Task Progress:
 **Gang buckets** (attacker count on the killmail): small ≤10, medium 11–24,
 large 25–39, blob 40+. Solo / small-gang = **small** bucket.
 
+Fetch also emits a **30d recent slice** and ages:
+
+| Field | Meaning |
+|-------|---------|
+| `fleets_30d` / `kills_30d` / `kills_small_30d` / `voice_hours_30d` | Same metrics, last 30d only |
+| `days_since_fleet` / `days_since_kill` / `days_since_voice` | Age of latest event in window (`null` if none) |
+| `days_since_activity` | Min of the three ages (`null` if fully dark in window) |
+
 Login, mining, PI, industry alone do not clear the bar. Note ESI gaps / zero
 linked chars / untracked ops in reasons when they matter.
 
 ## Decision rules (90d)
 
-Paths are co-equal. Approve when **one strong path** or **two medium paths**.
+Paths are co-equal. Approve when **one strong path** or **two medium paths**,
+**and** the recency gate passes.
 
 **Strong path (approve, Conf high):**
 
@@ -98,41 +113,67 @@ Paths are co-equal. Approve when **one strong path** or **two medium paths**.
 | Total kills (any gang) | ≥ 10 with some small-gang (≥ 3) |
 | Voice | ≥ 5h with any fleet or kill touch |
 
+### Recency gate (required for approve)
+
+Full-window strength is necessary but not sufficient.
+
+**Recent enough to approve** when any of:
+
+1. `days_since_activity` ≤ 30 (fleet, kill, or voice in the last 30d)
+2. Or explicit 30d touch: `fleets_30d` ≥ 1 **or** `kills_30d` ≥ 1 **or** `voice_hours_30d` ≥ 1
+
+**Front-loaded / stale — hold** even if 90d path clears:
+
+- 90d totals would approve, but no recent touch (`days_since_activity` > 30 or
+  null with only early-window activity) — they started strong then disappeared
+- Typical shape: high `fleets` / `kills_small` over 90d, but `fleets_30d` = 0,
+  `kills_30d` = 0, `voice_hours_30d` ≈ 0
+
+Reason tag: `Front-loaded — … last activity Nd ago` (or `no activity in 30d`).
+Conf: do not approve; hold for CEO contact / re-eval when they return.
+
+Do **not** overweight month-one PAP: if almost all kills/fleets sit in the older
+part of the window and the last 30d is quiet, hold.
+
 **Hold trial:**
 
 - Dark: fleets ≤ 1, kills ≈ 0, voice ≈ 0
+- Front-loaded / stale (above)
 - Voice-only social ghost: high voice, no fleets, no kills
 - Blob-only killboard with no fleets / no small-gang / no voice (unclear alliance play)
 - No linked characters (caveat; Conf medium if somehow recommending — prefer hold)
 
 Tag approve **Path**: `Fleet`, `Small-gang`, `Voice`, or `Mixed`.
 
-Reason line: Path + 1–2 metrics. See [examples.md](examples.md).
+Reason line: Path + 1–2 metrics; add last-activity age when non-obvious. See
+[examples.md](examples.md).
 
 ## Deliverables
 
 Always both. Sort approves by Conf (`high` then `medium`).
 
-**Summary:** `N approve (H/M); H held; W wrong-affiliation. Window: 90d.`
+**Summary:** `N approve (H/M); H held (F front-loaded); W wrong-affiliation. Window: 90d / recent 30d.`
 
 ### Report
 
-| Username | Primary | Previous | New | Fleets | Kills | Small | Voice | Path | Conf | Reason |
-|----------|---------|----------|-----|-------:|------:|------:|------:|------|------|--------|
+| Username | Primary | Previous | New | Fleets | Kills | Small | Voice | 30d | Last | Path | Conf | Reason |
+|----------|---------|----------|-----|-------:|------:|------:|------:|-----|------|------|------|--------|
 
 - Previous = `trial`; New = `active`
 - Voice as hours (`12.5h`)
 - Small = small-gang kill count
-- Held / wrong-affiliation: counts only unless asked
+- **30d** = short recent slice (`2F/5K/1.2h` or `quiet`)
+- **Last** = `days_since_activity` (`12d` / `—`)
+- Held / wrong-affiliation: counts only unless asked; call out front-loaded holds when relevant
 
 ### CSV (admin upload)
 
-Approve rows only:
+Approve rows only (recency gate already applied):
 
 ```csv
 username,community_status,reason
-someuser,active,Mixed — 5 fleets, 9 small-gang, 6h voice (90d)
-otheruser,active,Small-gang — 0 fleets, 14 small-gang kills (90d)
+someuser,active,Mixed — 5 fleets, 9 small-gang, 6h voice (90d; last 8d)
+otheruser,active,Small-gang — 0 fleets, 14 small-gang kills (90d; last 3d)
 ```
 
 `community_status` = `active`. `reason` ≤255. Username = Django username.
@@ -144,7 +185,7 @@ otheruser,active,Small-gang — 0 fleets, 14 small-gang kills (90d)
 
 ## Executor: apply CSV
 
-1. Review report (metrics, Path/Conf/Reason).
+1. Review report (metrics, 30d/Last, Path/Conf/Reason). Treat front-loaded holds as Contact candidates, not silent Passes.
 2. Delete rows you want to keep on trial; save `trial_approve_YYYY-MM-DD.csv` (UTF-8).
 3. Admin: `/admin/groups/usercommunitystatus/bulk-upload/`
 4. Upload; prefer per-row reasons.

--- a/.cursor/skills/trial-approval/examples.md
+++ b/.cursor/skills/trial-approval/examples.md
@@ -1,31 +1,46 @@
 # Trial Approval — decision examples
 
-90d window. Paths co-equal: fleets, solo/small-gang, voice. Report always pairs
-with CSV.
+90d window + 30d recent slice. Paths co-equal: fleets, solo/small-gang, voice.
+Approve needs path strength **and** recent activity. Report always pairs with CSV.
 
 ## Report + CSV pair
 
-| Username | Primary | Previous | New | Fleets | Kills | Small | Voice | Path | Conf | Reason |
-|----------|---------|----------|-----|-------:|------:|------:|------:|------|------|--------|
-| bob | Bob Main | trial | active | 5 | 12 | 9 | 6h | Mixed | high | Mixed — 5 fleets, 9 small-gang, 6h voice (90d). |
+| Username | Primary | Previous | New | Fleets | Kills | Small | Voice | 30d | Last | Path | Conf | Reason |
+|----------|---------|----------|-----|-------:|------:|------:|------:|-----|------|------|------|--------|
+| bob | Bob Main | trial | active | 5 | 12 | 9 | 6h | 2F/4K/2h | 8d | Mixed | high | Mixed — 5 fleets, 9 small-gang, 6h voice (90d; last 8d). |
 
 ```csv
-bob,active,Mixed — 5 fleets, 9 small-gang, 6h voice (90d)
+bob,active,Mixed — 5 fleets, 9 small-gang, 6h voice (90d; last 8d)
 ```
 
 ## Approve
 
-| Fleets | Kills | Small | Voice | Path | Conf | Reason |
-|-------:|------:|------:|------:|------|------|--------|
-| 6 | 2 | 1 | 1h | Fleet | high | Fleet — 6 alliance fleets in 90d. |
-| 4 | 0 | 0 | 0h | Fleet | high | Fleet — 4 fleets; clear ops participation. |
-| 0 | 18 | 14 | 2h | Small-gang | high | Small-gang — 14 small-gang kills, almost no PAP. |
-| 1 | 10 | 8 | 0h | Small-gang | high | Small-gang — 8 small-gang kills with one fleet touch. |
-| 2 | 4 | 3 | 12h | Voice | high | Voice — 12h voice with fleet + kill touch. |
-| 3 | 6 | 5 | 5h | Mixed | medium | Mixed — medium fleets, small-gang, and voice. |
-| 2 | 12 | 4 | 6h | Mixed | medium | Mixed — 2 fleets, some small-gang, 6h voice. |
+| Fleets | Small | Voice | 30d | Last | Path | Conf | Reason |
+|-------:|------:|------:|-----|------|------|------|--------|
+| 6 | 1 | 1h | 2F | 10d | Fleet | high | Fleet — 6 alliance fleets in 90d; last 10d. |
+| 4 | 0 | 0h | 1F | 20d | Fleet | high | Fleet — 4 fleets; recent fleet touch. |
+| 0 | 14 | 2h | 3K | 5d | Small-gang | high | Small-gang — 14 small-gang kills; active in 30d. |
+| 1 | 8 | 0h | 2K | 12d | Small-gang | high | Small-gang — 8 small-gang kills with one fleet touch. |
+| 2 | 3 | 12h | 1F/4h | 3d | Voice | high | Voice — 12h voice with fleet + kill touch. |
+| 3 | 5 | 5h | 1F/2K | 15d | Mixed | medium | Mixed — medium fleets, small-gang, and voice. |
 
-## Hold
+## Hold — front-loaded / stale
+
+90d path would clear, but quiet in the last 30d → **hold**, do not approve.
+
+| Fleets | Small | Voice | 30d | Last | Note |
+|-------:|------:|------:|-----|------|------|
+| 8 | 57 | 0.4h | quiet | 43d | Front-loaded — strong June PAP, gone since; hold. |
+| 2 | 5 | 0h | quiet | 71d | Front-loaded — medium 90d path, cold >30d; hold. |
+| 5 | 11 | 2.9h | quiet | 40d | Borderline stale — Contact / hold, not auto-Pass. |
+| 4 | 0 | 0h | quiet | 72d | Fleet path on paper; last fleet >30d — hold. |
+
+Reason examples:
+
+- `Front-loaded — 8 fleets, 57 small-gang (90d) but quiet 30d; last activity 43d ago.`
+- `Stale — clears 90d bar; no fleet/kill/voice in 30d.`
+
+## Hold — other
 
 | Fleets | Kills | Small | Voice | Note |
 |-------:|------:|------:|------:|------|

--- a/.cursor/skills/trial-approval/scripts/fetch_trial_activity.py
+++ b/.cursor/skills/trial-approval/scripts/fetch_trial_activity.py
@@ -4,6 +4,9 @@ Fetch Alliance-affiliated trial users with fleet / kill / voice metrics.
 
 Does NOT decide who to approve — the agent applies SKILL.md reasoning.
 
+Emits full-window totals plus a recent (30d) slice and last-activity ages so
+front-loaded then-gone pilots are visible.
+
 Usage (from repo root):
   cd backend && pipenv run python ../.cursor/skills/trial-approval/scripts/fetch_trial_activity.py --json
 """
@@ -15,8 +18,9 @@ import json
 import os
 import sys
 from collections import defaultdict
-from datetime import timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Optional
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 BACKEND_DIR = REPO_ROOT / "backend"
@@ -29,7 +33,7 @@ import django
 
 django.setup()
 
-from django.db.models import Count, F, Sum
+from django.db.models import Count, F, Max, Sum
 from django.utils import timezone
 
 from discord.models import DiscordChannelActivityRecord
@@ -38,6 +42,7 @@ from fleets.models import EveFleetInstanceMember
 from groups.models import UserAffiliation, UserCommunityStatus
 
 PRODUCTION_DB = "production_readonly"
+RECENT_DAYS = 30
 
 
 def gang_bucket(size: int) -> str:
@@ -50,6 +55,16 @@ def gang_bucket(size: int) -> str:
     return "blob"
 
 
+def days_since(now: datetime, when: Optional[datetime]) -> Optional[int]:
+    if when is None:
+        return None
+    return (now - when).days
+
+
+def empty_gangs() -> dict[str, int]:
+    return {"small": 0, "medium": 0, "large": 0, "blob": 0}
+
+
 def fetch_activity(
     *,
     days: int,
@@ -57,6 +72,7 @@ def fetch_activity(
 ) -> dict:
     now = timezone.now()
     since = now - timedelta(days=days)
+    recent_since = now - timedelta(days=RECENT_DAYS)
 
     affiliations = list(
         UserAffiliation.objects.using(PRODUCTION_DB)
@@ -111,21 +127,30 @@ def fetch_activity(
     all_eve_ids = list(user_by_eve)
 
     fleets_by_user: dict[int, set[int]] = defaultdict(set)
+    fleets_30d_by_user: dict[int, set[int]] = defaultdict(set)
+    last_fleet_by_user: dict[int, datetime] = {}
     if all_eve_ids:
-        for character_id, instance_id in (
+        for character_id, instance_id, join_time in (
             EveFleetInstanceMember.objects.using(PRODUCTION_DB)
             .filter(character_id__in=all_eve_ids, join_time__gte=since)
-            .values_list("character_id", "eve_fleet_instance_id")
+            .values_list("character_id", "eve_fleet_instance_id", "join_time")
             .iterator(chunk_size=5000)
         ):
             uid = user_by_eve.get(character_id)
-            if uid is not None:
-                fleets_by_user[uid].add(instance_id)
+            if uid is None:
+                continue
+            fleets_by_user[uid].add(instance_id)
+            if join_time >= recent_since:
+                fleets_30d_by_user[uid].add(instance_id)
+            prev = last_fleet_by_user.get(uid)
+            if prev is None or join_time > prev:
+                last_fleet_by_user[uid] = join_time
 
-    gang_by_user: dict[int, dict[str, int]] = defaultdict(
-        lambda: {"small": 0, "medium": 0, "large": 0, "blob": 0}
-    )
+    gang_by_user: dict[int, dict[str, int]] = defaultdict(empty_gangs)
+    gang_30d_by_user: dict[int, dict[str, int]] = defaultdict(empty_gangs)
     kills_by_user: dict[int, int] = defaultdict(int)
+    kills_30d_by_user: dict[int, int] = defaultdict(int)
+    last_kill_by_user: dict[int, datetime] = {}
     if all_eve_ids:
         kill_rows = (
             EveCharacterKillmailAttacker.objects.using(PRODUCTION_DB)
@@ -139,18 +164,27 @@ def fetch_activity(
                     "killmail__evecharacterkillmailattacker", distinct=True
                 )
             )
-            .values_list("character_id", "gang_size")
+            .values_list("character_id", "gang_size", "killmail__killmail_time")
             .iterator(chunk_size=5000)
         )
-        for character_id, gang_size in kill_rows:
+        for character_id, gang_size, kill_time in kill_rows:
             uid = user_by_eve.get(character_id)
             if uid is None:
                 continue
             kills_by_user[uid] += 1
-            gang_by_user[uid][gang_bucket(gang_size)] += 1
+            bucket = gang_bucket(gang_size)
+            gang_by_user[uid][bucket] += 1
+            if kill_time >= recent_since:
+                kills_30d_by_user[uid] += 1
+                gang_30d_by_user[uid][bucket] += 1
+            prev = last_kill_by_user.get(uid)
+            if prev is None or kill_time > prev:
+                last_kill_by_user[uid] = kill_time
 
     usernames = list(username_by_id.values())
-    voice_by_username = {}
+    voice_by_username: dict[str, int] = {}
+    voice_30d_by_username: dict[str, int] = {}
+    last_voice_by_username: dict[str, datetime] = {}
     if usernames:
         voice_by_username = {
             row["username"]: int(row["total"] or 0)
@@ -165,6 +199,33 @@ def fetch_activity(
                 .annotate(total=Sum("quantity"))
             )
         }
+        voice_30d_by_username = {
+            row["username"]: int(row["total"] or 0)
+            for row in (
+                DiscordChannelActivityRecord.objects.using(PRODUCTION_DB)
+                .filter(
+                    username__in=usernames,
+                    activity_type="voice_minute",
+                    created_on__gte=recent_since,
+                )
+                .values("username")
+                .annotate(total=Sum("quantity"))
+            )
+        }
+        last_voice_by_username = {
+            row["username"]: row["latest"]
+            for row in (
+                DiscordChannelActivityRecord.objects.using(PRODUCTION_DB)
+                .filter(
+                    username__in=usernames,
+                    activity_type="voice_minute",
+                    created_on__gte=since,
+                )
+                .values("username")
+                .annotate(latest=Max("created_on"))
+            )
+            if row["latest"] is not None
+        }
 
     members = []
     for user_id in trial_user_ids:
@@ -173,13 +234,21 @@ def fetch_activity(
             continue
         char_ids = eve_ids_by_user.get(user_id, [])
         fleets = len(fleets_by_user.get(user_id, ()))
+        fleets_30d = len(fleets_30d_by_user.get(user_id, ()))
         voice_min = voice_by_username.get(username, 0)
-        gangs = gang_by_user.get(
-            user_id, {"small": 0, "medium": 0, "large": 0, "blob": 0}
-        )
+        voice_min_30d = voice_30d_by_username.get(username, 0)
+        gangs = gang_by_user.get(user_id, empty_gangs())
+        gangs_30d = gang_30d_by_user.get(user_id, empty_gangs())
         meta = affiliation_meta.get(
             user_id, {"affiliation": affiliation_name, "requires_trial": True}
         )
+
+        last_fleet = last_fleet_by_user.get(user_id)
+        last_kill = last_kill_by_user.get(user_id)
+        last_voice = last_voice_by_username.get(username)
+        activity_times = [t for t in (last_fleet, last_kill, last_voice) if t]
+        last_activity = max(activity_times) if activity_times else None
+
         members.append(
             {
                 "username": username,
@@ -196,6 +265,15 @@ def fetch_activity(
                 "kills_blob": gangs["blob"],
                 "voice_minutes": voice_min,
                 "voice_hours": round(voice_min / 60, 1),
+                "fleets_30d": fleets_30d,
+                "kills_30d": kills_30d_by_user.get(user_id, 0),
+                "kills_small_30d": gangs_30d["small"],
+                "voice_minutes_30d": voice_min_30d,
+                "voice_hours_30d": round(voice_min_30d / 60, 1),
+                "days_since_fleet": days_since(now, last_fleet),
+                "days_since_kill": days_since(now, last_kill),
+                "days_since_voice": days_since(now, last_voice),
+                "days_since_activity": days_since(now, last_activity),
             }
         )
 
@@ -209,6 +287,7 @@ def fetch_activity(
     return {
         "as_of": now.strftime("%Y-%m-%d"),
         "window_days": days,
+        "recent_days": RECENT_DAYS,
         "affiliation": affiliation_name,
         "community_status": "trial",
         "member_count": len(members),


### PR DESCRIPTION
## Summary
- Add a 30-day **restore grace** to the on-leave skill: omit anyone with `on_leave` → non-leave in `UserCommunityStatusHistory` within 30 days
- Fetch script exposes `restored_from_leave_at` so hygiene passes can skip recent CEO restores
- Trial approval: require a **30d recency gate** so strong first-month then-gone pilots are held, not auto-passed on 90d totals alone
- Trial fetch emits `*_30d` metrics plus `days_since_*` / `days_since_activity`

## Test plan
- [ ] Run `pipenv run python ../.cursor/skills/on-leave/scripts/fetch_alliance_activity.py --json --max-fleets 6` from `backend/`
- [ ] Confirm members restored from leave in the last 30d have a non-null `restored_from_leave_at`
- [ ] Confirm those members are omitted from recommend / CSV when following the skill
- [ ] Run `pipenv run python ../.cursor/skills/trial-approval/scripts/fetch_trial_activity.py --json` from `backend/`
- [ ] Confirm members include `fleets_30d`, `kills_30d`, `days_since_activity`
- [ ] Spot-check a front-loaded pilot (quiet 30d, strong 90d) is held, not approved