### PR TITLE
Fix FlatPicker on ClientRouter soft navigation

### DIFF
--- a/frontend/app/src/components/blocks/CombatLogChart.astro
+++ b/frontend/app/src/components/blocks/CombatLogChart.astro
@@ -36,7 +36,8 @@ import ChartJsScript from '@components/partials/ChartJsScript.astro';
         damage_in: ${JSON.stringify(damage_in.map(damage => damage/10))},
         damage_out: ${JSON.stringify(damage_out.map(damage => damage/10))},
         reps_out: ${JSON.stringify(reps_out.map(rep => rep/10))},
-        init() {
+        async init() {
+            await window.__ensureChartJs()
             const ctx = document.getElementById("damage-log-chart").getContext("2d")
 
             Chart.defaults.borderColor = 'rgb(255, 255, 255, 0.05)'

--- a/frontend/app/src/components/blocks/FlatPicker.astro
+++ b/frontend/app/src/components/blocks/FlatPicker.astro
@@ -14,8 +14,7 @@ const {
 } = Astro.props
 ---
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
-<script is:inline src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" data-lib="flatpickr-css">
 
 <div class="[ input-group ]">
     <slot name="icon" />
@@ -24,7 +23,42 @@ const {
         {...attributes}
         x-data={`{
             fp: null,
-            init() {
+            async init() {
+                // ClientRouter inits Alpine before page-local scripts run, so load
+                // flatpickr on demand (same race as LearningAlpine / FooterScripts).
+                if (typeof flatpickr === 'undefined') {
+                    if (!window.__flatpickrReady) {
+                        window.__flatpickrReady = new Promise((resolve, reject) => {
+                            if (!document.querySelector('link[data-lib="flatpickr-css"]')) {
+                                const link = document.createElement('link')
+                                link.rel = 'stylesheet'
+                                link.href = 'https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css'
+                                link.dataset.lib = 'flatpickr-css'
+                                document.head.appendChild(link)
+                            }
+                            const existing = document.querySelector('script[data-lib="flatpickr"]')
+                            if (existing) {
+                                existing.addEventListener('load', resolve, { once: true })
+                                existing.addEventListener('error', reject, { once: true })
+                                // Cached/already-executed scripts may not fire load again.
+                                queueMicrotask(() => {
+                                    if (typeof flatpickr !== 'undefined') resolve()
+                                })
+                                return
+                            }
+                            const script = document.createElement('script')
+                            script.src = 'https://cdn.jsdelivr.net/npm/flatpickr'
+                            script.dataset.lib = 'flatpickr'
+                            script.addEventListener('load', resolve, { once: true })
+                            script.addEventListener('error', reject, { once: true })
+                            document.head.appendChild(script)
+                        }).catch((err) => {
+                            window.__flatpickrReady = null
+                            throw err
+                        })
+                    }
+                    await window.__flatpickrReady
+                }
                 this.fp = flatpickr($el, ${JSON.stringify(options)});
             }
         }`}

--- a/frontend/app/src/components/blocks/FlatPicker.astro
+++ b/frontend/app/src/components/blocks/FlatPicker.astro
@@ -14,8 +14,6 @@ const {
 } = Astro.props
 ---
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" data-lib="flatpickr-css">
-
 <div class="[ input-group ]">
     <slot name="icon" />
     <input
@@ -24,41 +22,8 @@ const {
         x-data={`{
             fp: null,
             async init() {
-                // ClientRouter inits Alpine before page-local scripts run, so load
-                // flatpickr on demand (same race as LearningAlpine / FooterScripts).
-                if (typeof flatpickr === 'undefined') {
-                    if (!window.__flatpickrReady) {
-                        window.__flatpickrReady = new Promise((resolve, reject) => {
-                            if (!document.querySelector('link[data-lib="flatpickr-css"]')) {
-                                const link = document.createElement('link')
-                                link.rel = 'stylesheet'
-                                link.href = 'https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css'
-                                link.dataset.lib = 'flatpickr-css'
-                                document.head.appendChild(link)
-                            }
-                            const existing = document.querySelector('script[data-lib="flatpickr"]')
-                            if (existing) {
-                                existing.addEventListener('load', resolve, { once: true })
-                                existing.addEventListener('error', reject, { once: true })
-                                // Cached/already-executed scripts may not fire load again.
-                                queueMicrotask(() => {
-                                    if (typeof flatpickr !== 'undefined') resolve()
-                                })
-                                return
-                            }
-                            const script = document.createElement('script')
-                            script.src = 'https://cdn.jsdelivr.net/npm/flatpickr'
-                            script.dataset.lib = 'flatpickr'
-                            script.addEventListener('load', resolve, { once: true })
-                            script.addEventListener('error', reject, { once: true })
-                            document.head.appendChild(script)
-                        }).catch((err) => {
-                            window.__flatpickrReady = null
-                            throw err
-                        })
-                    }
-                    await window.__flatpickrReady
-                }
+                // ClientRouter inits Alpine before page-local scripts; CSS must land in <head>.
+                await window.__ensureFlatpickr()
                 this.fp = flatpickr($el, ${JSON.stringify(options)});
             }
         }`}

--- a/frontend/app/src/components/blocks/MultiRangeInput.astro
+++ b/frontend/app/src/components/blocks/MultiRangeInput.astro
@@ -8,14 +8,12 @@ const {
 } = Astro.props
 ---
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/nouislider@15.6.0/dist/nouislider.min.css">
-<script is:inline src="https://cdn.jsdelivr.net/npm/nouislider@15.6.0/dist/nouislider.min.js"></script>
-
 <div
     class="[ multi-range-input ]"
     x-data={`{
         values: ${JSON.stringify(values)},
-        init() {
+        async init() {
+            await window.__ensureNoUiSlider()
             noUiSlider.create($el, {
                 start: [this.values[0], this.values[this.values.length - 1]],
                 connect: true,

--- a/frontend/app/src/components/blocks/campaigns/auga/AugaDailyShipsChartChartjs.astro
+++ b/frontend/app/src/components/blocks/campaigns/auga/AugaDailyShipsChartChartjs.astro
@@ -12,7 +12,8 @@ const shipsData = [...SHIPS_DESTROYED_DAILY]
     x-data={`{
         DAYS: ${JSON.stringify(days)},
         shipsData: ${JSON.stringify(shipsData)},
-        init() {
+        async init() {
+            await window.__ensureChartJs()
             var ctx = document.getElementById('auga-daily-ships-chart').getContext('2d')
 
             Chart.defaults.borderColor = 'rgb(255, 255, 255, 0.05)'

--- a/frontend/app/src/components/blocks/campaigns/etherium-reach/PlayerContentChartChartjs.astro
+++ b/frontend/app/src/components/blocks/campaigns/etherium-reach/PlayerContentChartChartjs.astro
@@ -57,7 +57,8 @@ const beatsConfig = CAMPAIGN_BEATS.map((beat) => ({
         iskData: ${JSON.stringify(iskData)},
         fleetData: ${JSON.stringify(fleetData)},
         beatsConfig: ${JSON.stringify(beatsConfig)},
-        init() {
+        async init() {
+            await window.__ensureChartJs()
             var ctx = document.getElementById('player-content-chart').getContext('2d')
 
             Chart.defaults.borderColor = 'rgb(255, 255, 255, 0.05)'

--- a/frontend/app/src/components/blocks/campaigns/etherium-reach/PlayerIncomeChartChartjs.astro
+++ b/frontend/app/src/components/blocks/campaigns/etherium-reach/PlayerIncomeChartChartjs.astro
@@ -24,7 +24,8 @@ const explorationData = EXPLORATION_GROSS_ISK.map(toBillions)
         rattingData: ${JSON.stringify(rattingData)},
         piData: ${JSON.stringify(piData)},
         explorationData: ${JSON.stringify(explorationData)},
-        init() {
+        async init() {
+            await window.__ensureChartJs()
             const ctx = document.getElementById('player-income-chart').getContext('2d')
 
             Chart.defaults.borderColor = 'rgb(255, 255, 255, 0.05)'

--- a/frontend/app/src/components/blocks/campaigns/providence/ProvidenceContentChartChartjs.astro
+++ b/frontend/app/src/components/blocks/campaigns/providence/ProvidenceContentChartChartjs.astro
@@ -56,7 +56,8 @@ const beatsConfig = CAMPAIGN_BEATS.map((beat) => ({
         iskData: ${JSON.stringify(iskData)},
         fleetData: ${JSON.stringify(fleetData)},
         beatsConfig: ${JSON.stringify(beatsConfig)},
-        init() {
+        async init() {
+            await window.__ensureChartJs()
             var ctx = document.getElementById('providence-content-chart').getContext('2d')
 
             Chart.defaults.borderColor = 'rgb(255, 255, 255, 0.05)'

--- a/frontend/app/src/components/blocks/campaigns/scalding-pass/PlayerContentChartChartjs.astro
+++ b/frontend/app/src/components/blocks/campaigns/scalding-pass/PlayerContentChartChartjs.astro
@@ -54,7 +54,8 @@ const beatsConfig = CAMPAIGN_BEATS.map((beat) => ({
         iskData: ${JSON.stringify(iskData)},
         fleetData: ${JSON.stringify(fleetData)},
         beatsConfig: ${JSON.stringify(beatsConfig)},
-        init() {
+        async init() {
+            await window.__ensureChartJs()
             var ctx = document.getElementById('scalding-pass-content-chart').getContext('2d')
 
             Chart.defaults.borderColor = 'rgb(255, 255, 255, 0.05)'

--- a/frontend/app/src/components/blocks/industry/guide-order-summary/GuideOrderProfitBarChart.astro
+++ b/frontend/app/src/components/blocks/industry/guide-order-summary/GuideOrderProfitBarChart.astro
@@ -79,13 +79,9 @@ const chartId = `guide-order-profit-bar-${Math.random().toString(36).slice(2, 9)
             })
             return true
         },
-        init() {
-            if (this.buildChart()) return
-            let tries = 0
-            const timer = setInterval(() => {
-                tries += 1
-                if (this.buildChart() || tries > 40) clearInterval(timer)
-            }, 100)
+        async init() {
+            await window.__ensureChartJs()
+            this.buildChart()
         },
     }`}
 >

--- a/frontend/app/src/components/partials/ChartJsScript.astro
+++ b/frontend/app/src/components/partials/ChartJsScript.astro
@@ -1,1 +1,6 @@
-<script is:inline src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+---
+/**
+ * Chart.js is loaded on demand via window.__ensureChartJs() (FooterScripts).
+ * Kept as a no-op import so existing chart components stay unchanged.
+ */
+---

--- a/frontend/app/src/components/partials/EnsureExternalScripts.astro
+++ b/frontend/app/src/components/partials/EnsureExternalScripts.astro
@@ -82,11 +82,12 @@
     }
 
     window.__ensureFlatpickr = window.__ensureFlatpickr || function () {
+        // CSS is bundled in styles/components/_flatpickr.scss (before theme overrides).
+        // Do not inject the CDN stylesheet — it appends after app CSS and forces a white calendar.
         return window.__ensureExternalScript(
             'flatpickr',
             'https://cdn.jsdelivr.net/npm/flatpickr',
             {
-                css: 'https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css',
                 ready: function () { return typeof flatpickr !== 'undefined' },
             }
         )

--- a/frontend/app/src/components/partials/EnsureExternalScripts.astro
+++ b/frontend/app/src/components/partials/EnsureExternalScripts.astro
@@ -1,0 +1,151 @@
+---
+/**
+ * On-demand CDN/lib loaders for ClientRouter soft navigation.
+ *
+ * Alpine's MutationObserver inits new x-data after body swap *before*
+ * page-local is:inline scripts run. Components that call flatpickr /
+ * Chart / noUiSlider / ccpwgl in Alpine init() must await these helpers
+ * (defined once in FooterScripts, same pattern as LearningAlpine).
+ *
+ * Stylesheets are always injected into document.head — body <link> tags
+ * from swapped page content often do not apply under ClientRouter.
+ */
+---
+
+<script is:inline>
+    window.__externalScripts = window.__externalScripts || {}
+
+    window.__ensureStylesheet = window.__ensureStylesheet || function (key, href) {
+        const headLink = document.head.querySelector('link[data-lib="' + key + '-css"]')
+        if (headLink) {
+            if (headLink.sheet || headLink.dataset.loaded === '1') return Promise.resolve()
+            return new Promise(function (resolve) {
+                headLink.addEventListener('load', function () {
+                    headLink.dataset.loaded = '1'
+                    resolve()
+                }, { once: true })
+                headLink.addEventListener('error', resolve, { once: true })
+            })
+        }
+
+        return new Promise(function (resolve) {
+            const link = document.createElement('link')
+            link.rel = 'stylesheet'
+            link.href = href
+            link.dataset.lib = key + '-css'
+            link.addEventListener('load', function () {
+                link.dataset.loaded = '1'
+                resolve()
+            }, { once: true })
+            link.addEventListener('error', resolve, { once: true })
+            document.head.appendChild(link)
+        })
+    }
+
+    window.__ensureExternalScript = window.__ensureExternalScript || function (key, src, options) {
+        options = options || {}
+        const ready = options.ready || function () { return false }
+        const cssPromise = options.css
+            ? window.__ensureStylesheet(key, options.css)
+            : Promise.resolve()
+
+        if (ready()) return cssPromise
+
+        if (window.__externalScripts[key]) {
+            return Promise.all([cssPromise, window.__externalScripts[key]])
+        }
+
+        window.__externalScripts[key] = new Promise(function (resolve, reject) {
+            const existing = document.querySelector('script[data-lib="' + key + '"]')
+            if (existing) {
+                existing.addEventListener('load', resolve, { once: true })
+                existing.addEventListener('error', reject, { once: true })
+                queueMicrotask(function () {
+                    if (ready()) resolve()
+                })
+                return
+            }
+
+            const script = document.createElement('script')
+            script.src = src
+            script.dataset.lib = key
+            if (options.type) script.type = options.type
+            script.addEventListener('load', resolve, { once: true })
+            script.addEventListener('error', reject, { once: true })
+            document.head.appendChild(script)
+        }).catch(function (err) {
+            window.__externalScripts[key] = null
+            throw err
+        })
+
+        return Promise.all([cssPromise, window.__externalScripts[key]])
+    }
+
+    window.__ensureFlatpickr = window.__ensureFlatpickr || function () {
+        return window.__ensureExternalScript(
+            'flatpickr',
+            'https://cdn.jsdelivr.net/npm/flatpickr',
+            {
+                css: 'https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css',
+                ready: function () { return typeof flatpickr !== 'undefined' },
+            }
+        )
+    }
+
+    window.__ensureNoUiSlider = window.__ensureNoUiSlider || function () {
+        return window.__ensureExternalScript(
+            'nouislider',
+            'https://cdn.jsdelivr.net/npm/nouislider@15.6.0/dist/nouislider.min.js',
+            {
+                css: 'https://cdn.jsdelivr.net/npm/nouislider@15.6.0/dist/nouislider.min.css',
+                ready: function () { return typeof noUiSlider !== 'undefined' },
+            }
+        )
+    }
+
+    window.__ensureChartJs = window.__ensureChartJs || function () {
+        return window.__ensureExternalScript(
+            'chartjs',
+            'https://cdn.jsdelivr.net/npm/chart.js',
+            {
+                ready: function () { return typeof Chart !== 'undefined' },
+            }
+        )
+    }
+
+    window.__ensureCcpwgl = window.__ensureCcpwgl || function () {
+        if (typeof ccpwgl !== 'undefined' && typeof ccpwgl_int !== 'undefined' && typeof fitting !== 'undefined') {
+            return Promise.resolve()
+        }
+        if (window.__externalScripts.ccpwgl_bundle) return window.__externalScripts.ccpwgl_bundle
+
+        window.__externalScripts.ccpwgl_bundle = Promise.resolve()
+            .then(function () {
+                return window.__ensureExternalScript(
+                    'ccpwgl_int',
+                    '/js/ccpwgl/ccpwgl_int.min.js',
+                    { ready: function () { return typeof ccpwgl_int !== 'undefined' } }
+                )
+            })
+            .then(function () {
+                return window.__ensureExternalScript(
+                    'ccpwgl',
+                    '/js/ccpwgl/ccpwgl.js',
+                    { ready: function () { return typeof ccpwgl !== 'undefined' } }
+                )
+            })
+            .then(function () {
+                return window.__ensureExternalScript(
+                    'ccpwgl_minmatar',
+                    '/js/ccpwgl/minmatar.js',
+                    { ready: function () { return typeof fitting !== 'undefined' } }
+                )
+            })
+            .catch(function (err) {
+                window.__externalScripts.ccpwgl_bundle = null
+                throw err
+            })
+
+        return window.__externalScripts.ccpwgl_bundle
+    }
+</script>

--- a/frontend/app/src/components/partials/FooterScripts.astro
+++ b/frontend/app/src/components/partials/FooterScripts.astro
@@ -1,8 +1,10 @@
 ---
 import LearningAlpine from '@components/partials/LearningAlpine.astro';
+import EnsureExternalScripts from '@components/partials/EnsureExternalScripts.astro';
 ---
 
 <LearningAlpine />
+<EnsureExternalScripts />
 
 <script is:inline src="/js/clipboard.js"></script>
 <script is:inline src="/js/numbers.js"></script>

--- a/frontend/app/src/pages/celestials.astro
+++ b/frontend/app/src/pages/celestials.astro
@@ -30,13 +30,6 @@ const page_title = 'Celestials';
 ---
 
 <Viewport title={page_title}>
-    {!DISABLED_CCPWGL &&
-        <>
-            <script is:inline type="text/javascript" src="/js/ccpwgl/ccpwgl_int.min.js"></script>
-            <script is:inline type="text/javascript" src="/js/ccpwgl/ccpwgl.js"></script>
-            <script is:inline type="text/javascript" src="/js/ccpwgl/minmatar.js"></script>
-        </>
-    }
     <PageLanding
         fullscreen={true}
         wide={true}
@@ -84,7 +77,10 @@ const page_title = 'Celestials';
             width="500"
             height="500"
             x-data={`{
-                init_ccpwgl() {
+                async init_ccpwgl() {
+                    if (${DISABLED_CCPWGL}) return
+                    await window.__ensureCcpwgl()
+
                     let canvas
                     let scene
                     const mat4 = ccpwgl_int.math.mat4

--- a/frontend/app/src/styles/components/_flatpickr.scss
+++ b/frontend/app/src/styles/components/_flatpickr.scss
@@ -1,8 +1,13 @@
+/* Bundle base layout CSS before theme so CDN injection cannot win the cascade
+   (ClientRouter on-demand <link> appends after app CSS → white calendar + invisible days). */
+@import 'flatpickr/dist/flatpickr.min.css';
+
 .flatpickr-calendar {
     accent-color: var(--highlight);
 
     border-radius: 0;
-    background-color: var(--light-transparency-background);
+    /* Shorthand beats flatpickr's `background:#fff` if base CSS is ever loaded again. */
+    background: var(--light-transparency-background);
     backdrop-filter: blur(var(--transparency-backdrop-blur));
     box-shadow: none;
     border: solid 1px var(--border-color);


### PR DESCRIPTION
## Summary
- Fleet create (`/fleets/add`) date/time pickers broke after #2558 moved flatpickr out of global footer/head scripts
- With `ClientRouter`, Alpine initializes `x-data` before page-local scripts run, so `flatpickr` was undefined on soft nav
- Body `<link>` tags from swapped pages also failed to apply flatpickr CSS (white broken calendar grid + low-contrast theme tokens)
- Shared `EnsureExternalScripts` helpers in FooterScripts load JS/CSS into `<head>` on demand for FlatPicker, MultiRangeInput/noUiSlider, Chart.js charts, and celestials/ccpwgl

## Test plan
- [ ] Soft-navigate Upcoming Fleets → Schedule fleet (no hard refresh)
- [ ] Open date picker: dark themed calendar, aligned day grid, readable month/weekday labels
- [ ] Open time picker and set a value
- [ ] Hard-refresh `/fleets/add/` and confirm pickers still look/work correctly
- [ ] Soft-navigate to `/intel/timers/add` and confirm FlatPicker still works
- [ ] Soft-navigate to a combat log with MultiRangeInput / Chart.js and confirm slider + chart render
- [ ] Soft-navigate to a campaign chart page and confirm Chart.js renders
- [ ] Soft-navigate to `/celestials` (superadmin) and confirm WebGL scene starts