### PR TITLE
Default LP buyback form to Tribal Liberation Force

### DIFF
--- a/frontend/app/src/components/blocks/LoyaltyOrderBook.astro
+++ b/frontend/app/src/components/blocks/LoyaltyOrderBook.astro
@@ -46,6 +46,21 @@ const {
     default_claim_corporation = '',
 } = Astro.props
 
+const FACTION_ORDER: readonly number[] = [
+    1000182, // TLIB
+    1000179, // 24th
+    1000180, // State
+    1000181, // FDU
+]
+const sorted_currencies = [...currencies].sort((a, b) => {
+    const ai = FACTION_ORDER.indexOf(a.corporation_id)
+    const bi = FACTION_ORDER.indexOf(b.corporation_id)
+    const ao = ai === -1 ? FACTION_ORDER.length : ai
+    const bo = bi === -1 ? FACTION_ORDER.length : bi
+    if (ao !== bo) return ao - bo
+    return a.name.localeCompare(b.name)
+})
+
 const default_lp_destination = default_claim_corporation
     || claim_corporations[0]
     || ''
@@ -641,7 +656,7 @@ const order_purchasers = (order: LoyaltyMarketOrder): PurchaserIcon[] => {
                                 x-model="form_loyalty_point_id"
                                 x-on:change="on_currency_change()"
                             >
-                                {currencies.map((c) => (
+                                {sorted_currencies.map((c) => (
                                     <option value={c.id}>{c.name}</option>
                                 ))}
                             </Select>

--- a/frontend/app/src/pages/industry/loyalty.astro
+++ b/frontend/app/src/pages/industry/loyalty.astro
@@ -76,8 +76,12 @@ if (is_logged_in && auth_token) {
 }
 
 const highlight_order_id = Astro.url.searchParams.get('order')
-const default_currency_id = currencies[0]?.id ?? null
-const default_isk_per_lp = currencies[0]?.default_isk_per_lp ?? 800
+const TLIB_CORP_ID = 1000182
+const default_currency = currencies.find((c) => c.corporation_id === TLIB_CORP_ID)
+    ?? currencies[0]
+    ?? null
+const default_currency_id = default_currency?.id ?? null
+const default_isk_per_lp = default_currency?.default_isk_per_lp ?? 800
 
 import Viewport from '@layouts/Viewport.astro'
 import PageWide from '@components/page/PageWide.astro'


### PR DESCRIPTION
## Summary
- Default the LP buyback sell/buy form currency and ISK/LP rate to Tribal Liberation Force (corp `1000182`) instead of the first alphabetically listed militia currency.
- Sort the currency dropdown TLIB-first to match rate cards and stockpiles.

## Test plan
- [ ] Open `/industry/loyalty/` logged in
- [ ] Click Sell / Buy — currency should default to Tribal Liberation Force with its default ISK/LP
- [ ] Confirm the currency select lists TLIB first
- [ ] Changing currency still updates ISK/LP from that currency's default


Made with [Cursor](https://cursor.com)