### PR TITLE
Fix missing admin order profit breakdown snapshots

### DIFF
--- a/backend/industry/admin.py
+++ b/backend/industry/admin.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.contrib import admin
 from django.contrib import messages
 from django import forms
@@ -43,7 +45,10 @@ from industry.helpers.lp_store_economics import (
     offer_economics_for_queryset,
     tracked_corporation_ids,
 )
-from industry.tasks import sync_loyalty_store_offers_task
+from industry.tasks import (
+    compute_order_profit_breakdown_task,
+    sync_loyalty_store_offers_task,
+)
 from industry.models import (
     IndustryContractAssociation,
     IndustryLoyaltyPoint,
@@ -62,6 +67,8 @@ from industry.models import (
     MiningUpgradeCompletion,
 )
 from tribes.models import TribeGroup
+
+logger = logging.getLogger(__name__)
 
 
 class IndustryLoyaltyPointAccountInline(admin.TabularInline):
@@ -1025,6 +1032,19 @@ class IndustryOrderAdmin(admin.ModelAdmin):
                 is_active=True
             ).order_by("tribe__name", "name")
         return super().formfield_for_manytomany(db_field, request, **kwargs)
+
+    def save_related(self, request, form, formsets, change):
+        """Enqueue profit snapshot after order items exist on the order."""
+        super().save_related(request, form, formsets, change)
+        order = form.instance
+        if not order.pk:
+            return
+        try:
+            compute_order_profit_breakdown_task.delay(order.pk)
+        except Exception:  # noqa: BLE001 — never fail admin save on planner
+            logger.exception(
+                "Failed to enqueue profit breakdown for order %s", order.pk
+            )
 
     def changeform_view(
         self, request, object_id=None, form_url="", extra_context=None

--- a/backend/industry/endpoints/orders/post_order.py
+++ b/backend/industry/endpoints/orders/post_order.py
@@ -13,14 +13,14 @@ from industry.endpoints.orders.schemas import (
     CreateOrderRequest,
     CreateOrderResponse,
 )
-from industry.helpers.order_profit_breakdown import (
-    ensure_order_profit_breakdown,
-)
 from industry.helpers.public_short_code import (
     pick_unique_public_short_code_among_actives,
 )
 from industry.models import IndustryOrder, IndustryOrderItem
-from industry.tasks import emit_order_created_notification
+from industry.tasks import (
+    compute_order_profit_breakdown_task,
+    emit_order_created_notification,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -162,10 +162,10 @@ def post_order(request, payload: CreateOrderRequest):
             self_assign_maximum=item.self_assign_maximum,
         )
     try:
-        ensure_order_profit_breakdown(order)
+        compute_order_profit_breakdown_task.delay(order.pk)
     except Exception:  # noqa: BLE001 — never fail order create on planner
         logger.exception(
-            "Failed to store profit breakdown for order %s", order.pk
+            "Failed to enqueue profit breakdown for order %s", order.pk
         )
     try:
         emit_order_created_notification.delay(order.pk, request.user.id)

--- a/backend/industry/tasks.py
+++ b/backend/industry/tasks.py
@@ -19,9 +19,40 @@ from industry.helpers.notifications import (
     emit_order_created,
     emit_order_jobs_for_created_job_ids,
 )
+from industry.helpers.order_profit_breakdown import (
+    can_refresh_order_profit_breakdown,
+    refresh_order_profit_breakdown,
+)
 from industry.models import IndustryOrder, IndustryOrderItemAssignment
 
 logger = logging.getLogger(__name__)
+
+
+@app.task()
+def compute_order_profit_breakdown_task(order_id: int) -> bool:
+    """
+    Compute and store the order profit/price snapshot off the request thread.
+
+    Refresh is allowed while the order is open, or once when no snapshot
+    exists yet (including fulfilled orders that never got one).
+    """
+    try:
+        order = IndustryOrder.objects.get(pk=order_id)
+    except IndustryOrder.DoesNotExist:
+        logger.warning(
+            "Order %s not found for profit breakdown compute", order_id
+        )
+        return False
+    if not can_refresh_order_profit_breakdown(order):
+        return False
+    try:
+        refresh_order_profit_breakdown(order)
+        return True
+    except Exception:
+        logger.exception(
+            "Failed to store profit breakdown for order %s", order_id
+        )
+        return False
 
 
 @app.task()

--- a/backend/industry/tests/test_admin.py
+++ b/backend/industry/tests/test_admin.py
@@ -1,7 +1,7 @@
 """Tests for industry admin customizations."""
 
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
@@ -15,12 +15,16 @@ from app.test import TestCase
 from eveonline.models import EveCharacter
 from eveuniverse.models import EveCategory, EveGroup, EveType
 
-from industry.admin import _apply_industry_app_list
+from industry.admin import IndustryOrderAdmin, _apply_industry_app_list
 from industry.admin_views import (
     industry_order_hub_view,
     industry_orders_home_view,
 )
-from industry.models import IndustryOrderItem, IndustryOrderItemAssignment
+from industry.models import (
+    IndustryOrder,
+    IndustryOrderItem,
+    IndustryOrderItemAssignment,
+)
 from industry.test_utils import create_industry_order
 
 
@@ -134,6 +138,25 @@ class IndustryAdminCustomizationsTestCase(TestCase):
         self.assertEqual(response.status_code, 302)
         mock_refresh.assert_called_once()
         self.assertEqual(mock_refresh.call_args.args[0].pk, self.order.pk)
+
+    @patch("industry.admin.compute_order_profit_breakdown_task")
+    def test_save_related_enqueues_profit_breakdown(self, mock_task):
+        # pylint: disable=import-outside-toplevel
+        from django.contrib.admin.sites import AdminSite
+
+        admin_obj = IndustryOrderAdmin(IndustryOrder, AdminSite())
+        form = MagicMock()
+        form.instance = self.order
+        request = self.factory.post("/")
+        request.user = self.staff
+
+        with patch(
+            "django.contrib.admin.options.ModelAdmin.save_related",
+            return_value=None,
+        ):
+            admin_obj.save_related(request, form, [], change=True)
+
+        mock_task.delay.assert_called_once_with(self.order.pk)
 
     def test_apply_industry_app_list_hides_nested_models(self):
         self.staff.user_permissions.add(self.view_perm)

--- a/backend/industry/tests/test_order_profit_breakdown.py
+++ b/backend/industry/tests/test_order_profit_breakdown.py
@@ -26,6 +26,7 @@ from industry.helpers.order_profit_breakdown import (
 )
 from industry.helpers.product_unit_cost import ProductUnitCost
 from industry.models import IndustryOrder, IndustryOrderItem
+from industry.tasks import compute_order_profit_breakdown_task
 from industry.test_utils import create_industry_order
 from tribes.models import Tribe, TribeGroup
 
@@ -260,6 +261,47 @@ class OrderProfitBreakdownTestCase(AppTestCase):
         order = IndustryOrder.objects.get(pk=order_id)
         self.assertIsNotNone(order.profit_breakdown)
         self.assertIsNotNone(order.profit_breakdown_computed_at)
+
+    @patch("industry.helpers.orders_profit_summary.plan_product_unit_cost")
+    @patch(
+        "industry.helpers.orders_profit_summary.jita_sell_prices_by_type_id"
+    )
+    def test_compute_task_stores_breakdown(self, mock_prices, mock_plan):
+        mock_prices.return_value = {self.eve_type.id: 1_500_000}
+        mock_plan.side_effect = lambda tid, **kw: self._unit_cost(
+            tid, self.eve_type.name
+        )
+        order = create_industry_order(
+            needed_by=(timezone.now() + timedelta(days=7)).date(),
+            character=self.character,
+            location=self.location,
+        )
+        IndustryOrderItem.objects.create(
+            order=order, eve_type=self.eve_type, quantity=2
+        )
+        self.assertIsNone(order.profit_breakdown)
+        self.assertTrue(compute_order_profit_breakdown_task(order.pk))
+        order.refresh_from_db()
+        self.assertIsNotNone(order.profit_breakdown)
+        self.assertIsNotNone(order.profit_breakdown_computed_at)
+
+    def test_compute_task_skips_fulfilled_with_snapshot(self):
+        order = create_industry_order(
+            needed_by=(timezone.now() + timedelta(days=7)).date(),
+            character=self.character,
+            location=self.location,
+        )
+        order.profit_breakdown = {"rows": [], "totals": {}}
+        order.profit_breakdown_computed_at = timezone.now()
+        order.fulfilled_at = timezone.now()
+        order.save(
+            update_fields=[
+                "profit_breakdown",
+                "profit_breakdown_computed_at",
+                "fulfilled_at",
+            ]
+        )
+        self.assertFalse(compute_order_profit_breakdown_task(order.pk))
 
     @patch("industry.helpers.orders_profit_summary.plan_product_unit_cost")
     @patch(


### PR DESCRIPTION
## Summary
- Admin order create/edit never stored `profit_breakdown`, so Order summary skipped open orders (prod 42/43 were missing).
- Enqueue `compute_order_profit_breakdown_task` from `IndustryOrderAdmin.save_related` and from API `post_order` so snapshots are computed off-request.
- Add coverage for admin enqueue and the Celery task store/skip paths.

## Test plan
- [x] `pipenv run python manage.py test industry.tests.test_admin.IndustryAdminCustomizationsTestCase.test_save_related_enqueues_profit_breakdown industry.tests.test_order_profit_breakdown.OrderProfitBreakdownTestCase --settings=app.settings_test`
- [ ] Create/edit an open industry order in Django admin → confirm `profit_breakdown_computed_at` populates (after Celery worker runs)
- [ ] On prod, click **Refresh order breakdown** for open orders 42 and 43 (or wait for a re-save) and confirm Order summary includes them


Made with [Cursor](https://cursor.com)