### PR TITLE
Pin frontend Docker image to Node 22

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:lts AS base
+# Pin Node 22: node:lts floated to 24 and better-sqlite3 aborts on Statement
+# teardown (Assertion failed: (env) != nullptr in RemoveEnvironmentCleanupHook).
+FROM node:22-bookworm AS base
 WORKDIR /app
 
 # By copying only the package.json and package-lock.json here, we ensure that the following `-deps` steps are independent of the source code.


### PR DESCRIPTION
## Summary
- Production frontend is crash-looping with `better-sqlite3` native abort: `Assertion failed: (env) != nullptr` in `Statement::~Statement` / `RemoveEnvironmentCleanupHook`.
- Root cause: `frontend/Dockerfile` used floating `node:lts`, which is now Node **24.19**; SDE access via `better-sqlite3` dies under that runtime.
- Pin the image to `node:22-bookworm` (currently 22.23.2), which matches our known-good Node 22 line.

## Test plan
- [ ] On HAMMY: `docker compose -f docker-compose-prod.yml build frontend && docker compose -f docker-compose-prod.yml up -d frontend`
- [ ] Confirm container stays up under normal traffic (no `RemoveEnvironmentCleanupHook` / `Assertion failed` in `docker compose ... logs frontend`)
- [ ] Smoke: home, fittings, industry orders pages load
- [ ] Optional: `docker compose ... exec frontend node -v` shows `v22.x`


Made with [Cursor](https://cursor.com)