### PR TITLE
Show LP buyback ISK due after claim

### DIFF
--- a/backend/industry/helpers/lp_buyback_discord.py
+++ b/backend/industry/helpers/lp_buyback_discord.py
@@ -14,6 +14,7 @@ from industry.helpers.lp_buyback_discord_buttons import (
     lp_sent_components,
 )
 from industry.helpers.lp_market_orders import (
+    claimed_quantity,
     currency_short_name,
     format_lp_quantity,
     remaining_quantity,
@@ -218,18 +219,52 @@ def _send_lp_line(
     return f"\n{prefix}Send LP to: **{dest}**"
 
 
+def _lp_quantity_for_isk(
+    order: IndustryLoyaltyPointMarketOrder,
+    *,
+    claim=None,
+) -> int:
+    """LP quantity used to compute ISK due for payment prompts."""
+    if claim is not None:
+        return int(claim.amount)
+    claimed = claimed_quantity(order)
+    if claimed > 0:
+        return claimed
+    return int(order.quantity)
+
+
+def _isk_due(
+    order: IndustryLoyaltyPointMarketOrder,
+    *,
+    claim=None,
+) -> int:
+    return _lp_quantity_for_isk(order, claim=claim) * int(order.isk_per_lp)
+
+
 def _pay_isk_line(
     order: IndustryLoyaltyPointMarketOrder,
     *,
     claim=None,
 ) -> str:
-    """ISK payout line for buy-order claims (claimer destination)."""
+    """ISK payout line (amount + destination)."""
     dest = _destination_label(order, claim=claim)
     if dest == "(unset)":
         return ""
     mention = _user_mention(isk_payer(order))
     prefix = f"{mention} " if mention else ""
-    return f"\n{prefix}Pay ISK to: **{dest}**"
+    isk = _isk_due(order, claim=claim)
+    return f"\n{prefix}Pay **{isk:,} ISK** to **{dest}**"
+
+
+def _isk_due_line(
+    order: IndustryLoyaltyPointMarketOrder,
+    *,
+    claim=None,
+) -> str:
+    """ISK total for sell claims where destination is set later."""
+    lp = _lp_quantity_for_isk(order, claim=claim)
+    isk = _isk_due(order, claim=claim)
+    return f"\nISK due: **{isk:,} ISK** ({lp:,} LP @ {order.isk_per_lp})"
 
 
 def _isk_payout_label(order: IndustryLoyaltyPointMarketOrder) -> str:
@@ -266,6 +301,7 @@ def notify_order_claimed(
             msg += _pay_isk_line(order, claim=claim)
         else:
             msg += _send_lp_line(order, sender, claim=claim)
+            msg += _isk_due_line(order, claim=claim)
         if remaining > 0:
             msg += f"\nRemaining: **{remaining:,}** LP (still open)"
         else:
@@ -276,6 +312,7 @@ def notify_order_claimed(
             msg += _pay_isk_line(order)
         else:
             msg += _send_lp_line(order, sender)
+            msg += _isk_due_line(order)
     msg += f"\n{order_site_url(order)}"
     post_order_status_update(order, message=msg)
 
@@ -296,12 +333,15 @@ def _awaiting_lp_message(order: IndustryLoyaltyPointMarketOrder) -> str:
 
 
 def _awaiting_isk_message(order: IndustryLoyaltyPointMarketOrder) -> str:
+    lp = _lp_quantity_for_isk(order)
+    isk = _isk_due(order)
     return "\n".join(
         [
             _user_mention(isk_payer(order)),
             "",
             ":moneybag: LP received — awaiting ISK payment",
-            f"Pay ISK to: **{_isk_payout_label(order)}**",
+            f"Pay **{isk:,} ISK** to **{_isk_payout_label(order)}**",
+            f"{lp:,} LP @ {order.isk_per_lp} ISK/LP",
             order_site_url(order),
         ]
     )

--- a/backend/industry/tests/test_loyalty_buyback.py
+++ b/backend/industry/tests/test_loyalty_buyback.py
@@ -861,7 +861,8 @@ class LpBuybackSideAwareMessagingTestCase(AppTestCase):
         )
         msg = _awaiting_isk_message(order)
         self.assertIn("<@1001>", msg)
-        self.assertIn("Pay ISK to: **Seller ISK Corp**", msg)
+        self.assertIn("Pay **800,000 ISK** to **Seller ISK Corp**", msg)
+        self.assertIn("1,000 LP @ 800 ISK/LP", msg)
 
     def test_wtb_awaiting_isk_falls_back_to_claimer_name(self):
         order = IndustryLoyaltyPointMarketOrder.objects.create(
@@ -875,7 +876,29 @@ class LpBuybackSideAwareMessagingTestCase(AppTestCase):
         )
         msg = _awaiting_isk_message(order)
         self.assertIn("<@1001>", msg)
-        self.assertIn("Pay ISK to: **BearThatCares**", msg)
+        self.assertIn("Pay **800,000 ISK** to **BearThatCares**", msg)
+        self.assertIn("1,000 LP @ 800 ISK/LP", msg)
+
+    def test_wts_awaiting_isk_includes_isk_amount(self):
+        order = IndustryLoyaltyPointMarketOrder.objects.create(
+            loyalty_point=self.currency,
+            side=IndustryLoyaltyPointMarketOrder.Side.SELL,
+            quantity=267_000,
+            isk_per_lp=800,
+            status=IndustryLoyaltyPointMarketOrder.Status.AWAITING_ISK,
+            created_by=self.seller,
+            claimed_by=self.claimer,
+        )
+        IndustryLoyaltyPointMarketOrderClaim.objects.create(
+            order=order,
+            amount=267_000,
+            destination_corporation_name="Rattini Tribe",
+            claimed_by=self.claimer,
+        )
+        msg = _awaiting_isk_message(order)
+        self.assertIn("<@1002>", msg)
+        self.assertIn("Pay **213,600,000 ISK** to **WTS Pilot**", msg)
+        self.assertIn("267,000 LP @ 800 ISK/LP", msg)
 
     @patch("industry.helpers.lp_buyback_discord.discord")
     def test_awaiting_lp_posts_lp_sent_button(self, discord_mock):

--- a/frontend/app/src/components/blocks/LoyaltyOrderBook.astro
+++ b/frontend/app/src/components/blocks/LoyaltyOrderBook.astro
@@ -492,6 +492,7 @@ const order_purchasers = (order: LoyaltyMarketOrder): PurchaserIcon[] => {
                                 <th>{t('industry.loyalty.orders.col.currency')}</th>
                                 <th class="[ tabular ]">{t('industry.loyalty.orders.col.quantity')}</th>
                                 <th class="[ tabular ]">{t('industry.loyalty.orders.col.rate')}</th>
+                                <th class="[ tabular ]">{t('industry.loyalty.orders.col.total')}</th>
                                 <th>{t('industry.loyalty.orders.col.status')}</th>
                                 <th>{t('industry.loyalty.orders.col.purchasers')}</th>
                                 <th class="[ loyalty-orders__actions-col ]">{t('industry.loyalty.orders.col.actions')}</th>
@@ -505,6 +506,10 @@ const order_purchasers = (order: LoyaltyMarketOrder): PurchaserIcon[] => {
                                 const quantity_remaining = order.quantity_remaining ?? order.quantity
                                 const quantity_claimed = order.quantity_claimed ?? 0
                                 const can_claim = order.status === 'open' && quantity_remaining > 0
+                                const lp_for_total = quantity_claimed > 0
+                                    ? quantity_claimed
+                                    : order.quantity
+                                const isk_total = lp_for_total * order.isk_per_lp
                                 const status_color = STATUS_COLORS[order.status] ?? 'alliance-blue'
                                 const status_text_color = STATUS_TEXT_COLORS[order.status]
                                 const status_label = status_labels[order.status] ?? order.status
@@ -538,6 +543,13 @@ const order_purchasers = (order: LoyaltyMarketOrder): PurchaserIcon[] => {
                                             )}
                                         </td>
                                         <td class="[ tabular ]">{number_thousand_separator(order.isk_per_lp)}</td>
+                                        <td class:list={[
+                                            'tabular',
+                                            'loyalty-orders__total',
+                                            { 'loyalty-orders__total--due': order.status === 'awaiting_isk' },
+                                        ]}>
+                                            {number_thousand_separator(isk_total)}
+                                        </td>
                                         <td>
                                             <Tag
                                                 text={status_label}
@@ -1050,6 +1062,11 @@ const order_purchasers = (order: LoyaltyMarketOrder): PurchaserIcon[] => {
         font-size: var(--step--2);
         opacity: 0.8;
         white-space: nowrap;
+    }
+
+    .loyalty-orders__total--due {
+        color: var(--green);
+        font-weight: 600;
     }
 
     .loyalty-orders__purchasers {

--- a/frontend/app/src/components/blocks/LoyaltyOrderHistory.astro
+++ b/frontend/app/src/components/blocks/LoyaltyOrderHistory.astro
@@ -96,6 +96,7 @@ const rows = [...orders].sort((a, b) => {
                                 <th>{t('industry.loyalty.orders.col.currency')}</th>
                                 <th class="[ tabular ]">{t('industry.loyalty.orders.col.quantity')}</th>
                                 <th class="[ tabular ]">{t('industry.loyalty.orders.col.rate')}</th>
+                                <th class="[ tabular ]">{t('industry.loyalty.orders.col.total')}</th>
                                 <th>{t('industry.loyalty.orders.col.status')}</th>
                                 <th>{t('industry.loyalty.orders.col.purchasers')}</th>
                             </tr>
@@ -105,6 +106,11 @@ const rows = [...orders].sort((a, b) => {
                                 const status_color = STATUS_COLORS[order.status] ?? 'alliance-blue'
                                 const status_label = status_labels[order.status] ?? order.status
                                 const purchasers = order_purchasers(order)
+                                const quantity_claimed = order.quantity_claimed ?? 0
+                                const lp_for_total = quantity_claimed > 0
+                                    ? quantity_claimed
+                                    : order.quantity
+                                const isk_total = lp_for_total * order.isk_per_lp
                                 return (
                                     <tr id={`order-${order.id}`}>
                                         <td class="[ loyalty-history__date ]">
@@ -124,6 +130,9 @@ const rows = [...orders].sort((a, b) => {
                                         </td>
                                         <td class="[ tabular ]">
                                             {number_thousand_separator(order.isk_per_lp)}
+                                        </td>
+                                        <td class="[ tabular ]">
+                                            {number_thousand_separator(isk_total)}
                                         </td>
                                         <td>
                                             <Tag

--- a/frontend/app/src/i18n/ui.ts
+++ b/frontend/app/src/i18n/ui.ts
@@ -648,6 +648,7 @@ export const ui = {
         'industry.loyalty.orders.col.currency': 'Currency',
         'industry.loyalty.orders.col.quantity': 'Quantity',
         'industry.loyalty.orders.col.rate': 'ISK/LP',
+        'industry.loyalty.orders.col.total': 'Total ISK',
         'industry.loyalty.orders.col.status': 'Status',
         'industry.loyalty.orders.col.purchasers': 'Purchasers',
         'industry.loyalty.orders.col.actions': 'Actions',


### PR DESCRIPTION
## Summary
- Discord `awaiting_isk` (and claim) messages now include the ISK amount to pay, LP qty, and rate — not just the payee
- Open and history LP order tables gain a **Total ISK** column (highlighted when status is awaiting ISK)

Fixes the gap reported in pulse-technology feedback where the claim dialog was the only place showing how much ISK to send.

## Test plan
- [ ] `pipenv run python manage.py test industry.tests.test_loyalty_buyback --settings=app.settings_test`
- [ ] Claim a WTS order → Discord thread shows `ISK due: …` on claim, then `Pay **N ISK** to …` with qty @ rate on LP received
- [ ] Confirm open order book and history show Total ISK; awaiting-ISK rows highlight the total in green
- [ ] WTB path still shows claim destination as ISK payee with amount


Made with [Cursor](https://cursor.com)