### PR TITLE
Load transfer corp finder from live alliance EveCorporations

### DIFF
--- a/frontend/app/src/components/blocks/CorporationFinder.astro
+++ b/frontend/app/src/components/blocks/CorporationFinder.astro
@@ -8,12 +8,30 @@ import Flexblock from '@components/compositions/Flexblock.astro';
 import FixedFluid from '@components/compositions/FixedFluid.astro';
 import VerticalCenter from './VerticalCenter.astro';
 
-import corporations from '@json/hosted/corporations.json';
-
+import { get_all_corporations } from '@helpers/api.minmatar.org/corporations';
 import { get_corporation_logo } from '@helpers/eve_image_server';
+
+interface CorporationFinderItem {
+    corporation_id: number;
+    name: string;
+}
 
 interface Props {
     [propName: string]: any;
+}
+
+let corporations: CorporationFinderItem[] = []
+
+try {
+    const api_corporations = await get_all_corporations('alliance')
+    corporations = api_corporations
+        .map((corporation) => ({
+            corporation_id: corporation.corporation_id,
+            name: corporation.corporation_name,
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name))
+} catch (error) {
+    console.log(`Error fetching corporations for finder: ${error.message}`)
 }
 ---
 
@@ -58,7 +76,6 @@ interface Props {
                             <VerticalCenter>
                                 <Flexblock gap='0' class="[ items-start ]">
                                     <span class="[ truncate ]">{corporation.name}</span>
-                                    <small>{`${corporation.members_count} ${t('members_count').toLowerCase()}`}</small>
                                 </Flexblock>
                             </VerticalCenter>
                         </FixedFluid>

--- a/frontend/app/testing/components/blocks/CorporationFinder.test.ts
+++ b/frontend/app/testing/components/blocks/CorporationFinder.test.ts
@@ -2,9 +2,51 @@ import { experimental_AstroContainer as AstroContainer } from "astro/container";
 import { expect, test, vi } from "vitest";
 import CorporationFinder from "@components/blocks/CorporationFinder.astro";
 
+import { get_all_corporations } from "@helpers/api.minmatar.org/corporations";
+vi.mock("@helpers/api.minmatar.org/corporations");
+
 test("CorporationFinder defaults", async () => {
+  vi.mocked(get_all_corporations).mockResolvedValue([
+    {
+      corporation_id: 98794203,
+      corporation_name: "Banshee Squadron",
+      alliance_id: 99011978,
+      alliance_name: "Minmatar Fleet Alliance",
+      faction_id: 500002,
+      faction_name: "Minmatar Republic",
+      type: "alliance",
+      introduction: "",
+      biography: "",
+      executor_notes: "",
+      timezones: [],
+      requirements: [],
+      members: [],
+      active: true,
+      trial: false,
+    },
+    {
+      corporation_id: 98726134,
+      corporation_name: "Rattini Tribe",
+      alliance_id: 99011978,
+      alliance_name: "Minmatar Fleet Alliance",
+      faction_id: 500002,
+      faction_name: "Minmatar Republic",
+      type: "alliance",
+      introduction: "",
+      biography: "",
+      executor_notes: "",
+      timezones: [],
+      requirements: [],
+      members: [],
+      active: true,
+      trial: false,
+    },
+  ]);
+
   const container = await AstroContainer.create();
   const result = await container.renderToString(CorporationFinder, {});
 
-  // expect(result).toMatchSnapshot();
+  expect(result).toContain("Banshee Squadron");
+  expect(result).toContain("Rattini Tribe");
+  expect(get_all_corporations).toHaveBeenCalledWith("alliance");
 });


### PR DESCRIPTION
## Summary
- Application **Transfer to corporation** finder now SSR-fetches alliance corps via `get_all_corporations('alliance')` instead of stale `corporations.json`.
- Corps such as Banshee Squadron appear automatically as they exist in `EveCorporation`.
- Finder test mocks the API and asserts alliance corps render.

## Test plan
- [ ] Open a pending corporation application → Transfer to corporation
- [ ] Search for Banshee Squadron and confirm it appears
- [ ] Transfer succeeds to another alliance corp
- [ ] `npm run check` / CorporationFinder vitest (already run locally)

Made with [Cursor](https://cursor.com)