### PR TITLE
Gate LP purchase CTA and humanize feature_denied

### DIFF
--- a/backend/industry/endpoints/loyalty/__init__.py
+++ b/backend/industry/endpoints/loyalty/__init__.py
@@ -2,6 +2,12 @@
 
 from ninja import Router
 
+from industry.endpoints.loyalty.get_capabilities import (
+    PATH as get_capabilities_path,
+    ROUTE_SPEC as get_capabilities_spec,
+    get_capabilities,
+    METHOD as get_capabilities_method,
+)
 from industry.endpoints.loyalty.get_currencies import (
     PATH as get_currencies_path,
     ROUTE_SPEC as get_currencies_spec,
@@ -67,6 +73,12 @@ _ROUTES = (
         get_stockpiles,
     ),
     (get_ledger_method, get_ledger_path, get_ledger_spec, get_ledger),
+    (
+        get_capabilities_method,
+        get_capabilities_path,
+        get_capabilities_spec,
+        get_capabilities,
+    ),
     (get_orders_method, get_orders_path, get_orders_spec, get_orders),
     (post_orders_method, post_orders_path, post_orders_spec, post_orders),
     (

--- a/backend/industry/endpoints/loyalty/get_capabilities.py
+++ b/backend/industry/endpoints/loyalty/get_capabilities.py
@@ -1,0 +1,22 @@
+"""GET /capabilities - current user's LP buyback capabilities."""
+
+from authentication import AuthBearer
+from groups.helpers.feature_access import can_use_feature
+from industry.endpoints.loyalty.auth_helpers import can_manage_buyback
+from industry.endpoints.loyalty.schemas import LoyaltyCapabilitiesResponse
+
+PATH = "/capabilities"
+METHOD = "get"
+ROUTE_SPEC = {
+    "summary": "Loyalty buyback capabilities for the current user",
+    "auth": AuthBearer(),
+    "response": {200: LoyaltyCapabilitiesResponse},
+}
+
+
+def get_capabilities(request):
+    return LoyaltyCapabilitiesResponse(
+        can_manage=can_manage_buyback(request.user),
+        can_trade=can_use_feature(request.user, "industry.loyalty.trade")
+        or request.user.is_staff,
+    )

--- a/backend/industry/endpoints/loyalty/schemas.py
+++ b/backend/industry/endpoints/loyalty/schemas.py
@@ -14,6 +14,11 @@ class LoyaltyCurrencyResponse(Schema):
     is_active: bool
 
 
+class LoyaltyCapabilitiesResponse(Schema):
+    can_manage: bool
+    can_trade: bool
+
+
 class LoyaltyMarketOrderClaimResponse(Schema):
     id: int
     amount: int

--- a/backend/industry/tests/test_loyalty_buyback.py
+++ b/backend/industry/tests/test_loyalty_buyback.py
@@ -164,6 +164,28 @@ class LoyaltyBuybackApiTestCase(AppTestCase):
         self.assertIn("Tribal Liberation Force", names)
         self.assertEqual(len(response.json()), 4)
 
+    def test_capabilities_for_manager_and_trader(self):
+        anon = self.client.get("/api/industry/loyalty/capabilities")
+        self.assertEqual(anon.status_code, 401)
+
+        trader = self.client.get(
+            "/api/industry/loyalty/capabilities",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        self.assertEqual(trader.status_code, 200)
+        self.assertFalse(trader.json()["can_manage"])
+        self.assertTrue(trader.json()["can_trade"])
+
+        manager = self.client.get(
+            "/api/industry/loyalty/capabilities",
+            HTTP_AUTHORIZATION=f"Bearer {self.manager_token}",
+        )
+        self.assertEqual(manager.status_code, 200)
+        self.assertTrue(manager.json()["can_manage"])
+        # Manage is tribe-gated; trade is affiliation-gated. This manager has
+        # Conversion tribe membership only, so can_trade stays false.
+        self.assertFalse(manager.json()["can_trade"])
+
     def test_get_stockpiles_public(self):
         response = self.client.get("/api/industry/loyalty/stockpiles")
         self.assertEqual(response.status_code, 200)

--- a/frontend/app/src/components/blocks/LoyaltyOrderBook.astro
+++ b/frontend/app/src/components/blocks/LoyaltyOrderBook.astro
@@ -20,6 +20,7 @@ interface Props {
     orders: LoyaltyMarketOrder[]
     currencies: LoyaltyCurrency[]
     is_logged_in: boolean
+    can_manage_buyback?: boolean
     highlight_order_id: string | null
     default_currency_id: number | null
     default_isk_per_lp: number
@@ -37,6 +38,7 @@ const {
     orders,
     currencies,
     is_logged_in,
+    can_manage_buyback = false,
     highlight_order_id,
     default_currency_id,
     default_isk_per_lp,
@@ -160,6 +162,7 @@ const order_purchasers = (order: LoyaltyMarketOrder): PurchaserIcon[] => {
         max_sell_lp: 2500000,
         currencies: ${JSON.stringify(currencies)},
         is_logged_in: ${JSON.stringify(is_logged_in)},
+        can_manage_buyback: ${JSON.stringify(can_manage_buyback)},
         format_thousands(val) {
             const n = Number(String(val).replace(/,/g, '')) || 0
             return n.toLocaleString('en-US', {
@@ -260,6 +263,12 @@ const order_purchasers = (order: LoyaltyMarketOrder): PurchaserIcon[] => {
                 const data = await response.json()
                 if (typeof data.detail === 'string') detail = data.detail
             } catch (e) {}
+            const normalized = String(detail).toLowerCase()
+            if (normalized === 'feature_denied') {
+                detail = this.form_side === 'buy'
+                    ? ${JSON.stringify(t('industry.loyalty.feature_denied_buy'))}
+                    : ${JSON.stringify(t('industry.loyalty.feature_denied'))}
+            }
             await show_alert_dialog({ title: detail })
         },
         async post_order() {
@@ -453,7 +462,13 @@ const order_purchasers = (order: LoyaltyMarketOrder): PurchaserIcon[] => {
             this.post_dialog_open = true
             this.$nextTick(() => document.getElementById('loyalty-post-quantity')?.focus())
         },
-        open_buy() {
+        async open_buy() {
+            if (!this.can_manage_buyback) {
+                await show_alert_dialog({
+                    title: ${JSON.stringify(t('industry.loyalty.feature_denied_buy'))},
+                })
+                return
+            }
             this.claim_dialog_open = false
             this.await_lp_dialog_open = false
             this.form_side = 'buy'

--- a/frontend/app/src/helpers/api.minmatar.org/loyalty.ts
+++ b/frontend/app/src/helpers/api.minmatar.org/loyalty.ts
@@ -8,6 +8,27 @@ import { get_error_message, query_string } from '@helpers/string'
 
 const API_ENDPOINT = `${import.meta.env.API_URL}/api/industry/loyalty`
 
+export interface LoyaltyCapabilities {
+    can_manage: boolean
+    can_trade: boolean
+}
+
+export async function get_loyalty_capabilities(access_token: string) {
+    const ENDPOINT = `${API_ENDPOINT}/capabilities`
+    console.log(`Requesting: ${ENDPOINT}`)
+    const headers = {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${access_token}`,
+    }
+    const response = await fetch(ENDPOINT, { headers })
+    if (!response.ok) {
+        throw new Error(get_error_message(response.status, `GET ${ENDPOINT}`), {
+            cause: response.status,
+        })
+    }
+    return await response.json() as LoyaltyCapabilities
+}
+
 export async function get_loyalty_currencies() {
     const ENDPOINT = `${API_ENDPOINT}/currencies`
     console.log(`Requesting: ${ENDPOINT}`)

--- a/frontend/app/src/i18n/ui.ts
+++ b/frontend/app/src/i18n/ui.ts
@@ -662,6 +662,10 @@ export const ui = {
         'industry.loyalty.status.cancelled': 'Cancelled',
         'industry.loyalty.post_sell': 'Sell Loyalty Points',
         'industry.loyalty.post_buy': 'Purchase Loyalty Points',
+        'industry.loyalty.feature_denied_buy':
+            'Only Conversion Team members can post buy orders. To sell your LP, use Sell Loyalty Points.',
+        'industry.loyalty.feature_denied':
+            'You do not have permission for this loyalty action.',
         'industry.loyalty.login_required': 'Log in to post or manage LP orders.',
         'industry.loyalty.form.currency': 'Currency',
         'industry.loyalty.form.quantity': 'Quantity',

--- a/frontend/app/src/pages/industry/loyalty.astro
+++ b/frontend/app/src/pages/industry/loyalty.astro
@@ -16,6 +16,7 @@ import type {
     OrderLpStockpile,
 } from '@dtypes/api.minmatar.org'
 import {
+    get_loyalty_capabilities,
     get_loyalty_currencies,
     get_loyalty_orders,
     get_loyalty_stockpiles,
@@ -35,6 +36,7 @@ let claim_characters: {
 let claim_corporations: string[] = []
 let default_claim_corporation = ''
 let default_claim_character = ''
+let can_manage_buyback = false
 
 try {
     [currencies, orders, order_history, stockpiles] = await Promise.all([
@@ -49,7 +51,11 @@ try {
 
 if (is_logged_in && auth_token) {
     try {
-        const summary = await get_characters_summary(auth_token)
+        const [summary, capabilities] = await Promise.all([
+            get_characters_summary(auth_token),
+            get_loyalty_capabilities(auth_token),
+        ])
+        can_manage_buyback = Boolean(capabilities.can_manage)
         claim_characters = (summary.characters ?? [])
             .map((character) => ({
                 character_name: character.character_name,
@@ -166,19 +172,22 @@ const admin_loyalty_url = `${api_base}/admin/industry/loyalty/`
                             >
                                 {t('industry.loyalty.post_sell')}
                             </Button>
-                            <Button
-                                class="[ loyalty-cta-row__button ]"
-                                color="green"
-                                x-on:click="$dispatch('loyalty-open-buy')"
-                            >
-                                {t('industry.loyalty.post_buy')}
-                            </Button>
+                            {can_manage_buyback && (
+                                <Button
+                                    class="[ loyalty-cta-row__button ]"
+                                    color="green"
+                                    x-on:click="$dispatch('loyalty-open-buy')"
+                                >
+                                    {t('industry.loyalty.post_buy')}
+                                </Button>
+                            )}
                         </div>
                     )}
                     <LoyaltyOrderBook
                         orders={orders}
                         currencies={currencies}
                         is_logged_in={is_logged_in}
+                        can_manage_buyback={can_manage_buyback}
                         highlight_order_id={highlight_order_id}
                         default_currency_id={default_currency_id}
                         default_isk_per_lp={default_isk_per_lp}


### PR DESCRIPTION
## Summary
- Add `GET /api/industry/loyalty/capabilities` and use `can_manage` to show **Purchase Loyalty Points** only for Conversion Team / staff.
- Map API `feature_denied` to clear copy (and block `open_buy` the same way) so members are directed to **Sell Loyalty Points** instead of a raw error dialog.

## Test plan
- [ ] As a non–Conversion member: loyalty page shows Sell only; no Purchase button
- [ ] As Conversion Team: Purchase button still appears and creates buy orders
- [ ] If buy is attempted without manage (e.g. dispatched event): alert says Conversion Team only / use Sell
- [ ] Backend: `pipenv run python manage.py test industry.tests.test_loyalty_buyback.LoyaltyBuybackApiTestCase.test_capabilities_for_manager_and_trader --settings=app.settings_test`


Made with [Cursor](https://cursor.com)