### PR TITLE
Keep LP store offer item names visible in admin

### DIFF
--- a/backend/industry/admin.py
+++ b/backend/industry/admin.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 
-from eveuniverse.models import EveGroup
+from eveuniverse.models import EveGroup, EveType
 
 from industry.admin_views import (
     industry_loyalty_home_view,
@@ -708,11 +708,13 @@ class IndustryLpStoreCurrencyListFilter(admin.SimpleListFilter):
 class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
     _request_stash = None
 
+    change_list_template = (
+        "admin/industry/industrylpstoreoffer/change_list.html"
+    )
     list_display = (
         "type_name_display",
         "currency_display",
         "kind_display",
-        "type_id",
         "lp_cost",
         "isk_cost",
         "ak_cost",
@@ -774,6 +776,24 @@ class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
             .prefetch_related("required_items")
         )
 
+    def get_search_results(self, request, queryset, search_term):
+        queryset, use_distinct = super().get_search_results(
+            request, queryset, search_term
+        )
+        term = (search_term or "").strip()
+        if not term:
+            return queryset, use_distinct
+        type_ids = list(
+            EveType.objects.filter(name__icontains=term).values_list(
+                "id", flat=True
+            )
+        )
+        if type_ids:
+            by_name = self.get_queryset(request).filter(type_id__in=type_ids)
+            queryset |= by_name
+            use_distinct = True
+        return queryset, use_distinct
+
     def get_changelist_instance(self, request):
         cl = super().get_changelist_instance(request)
         IndustryLpStoreOfferAdmin._request_stash = (
@@ -820,10 +840,22 @@ class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
     def type_name_display(self, obj):
         econ = self._econ_for(obj)
         if econ is None:
-            return str(obj.type_id)
-        if econ.kind == "blueprint" and econ.market_type_id != econ.type_id:
-            return f"{econ.market_type_name} (BPC {econ.type_id})"
-        return econ.type_name
+            name = str(obj.type_id)
+            type_id = obj.type_id
+        elif econ.kind == "blueprint" and econ.market_type_id != econ.type_id:
+            name = f"{econ.market_type_name} (BPC {econ.type_id})"
+            type_id = econ.type_id
+        else:
+            name = econ.type_name
+            type_id = econ.type_id
+        return format_html(
+            '<span class="lp-store-offer-item">'
+            '<span class="lp-store-offer-item__name">{}</span>'
+            '<span class="lp-store-offer-item__type">type {}</span>'
+            "</span>",
+            name,
+            type_id,
+        )
 
     @admin.display(description="Currency")
     def currency_display(self, obj):

--- a/backend/industry/tests/test_lp_store_economics.py
+++ b/backend/industry/tests/test_lp_store_economics.py
@@ -2,6 +2,7 @@
 
 from datetime import date
 from decimal import Decimal
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.contrib.admin.sites import AdminSite
@@ -297,7 +298,19 @@ class LpStoreOfferAdminTestCase(TestCase):
         IndustryLoyaltyPoint.objects.exclude(
             corporation_id=TLIB_CORP_ID
         ).update(is_active=False)
-        IndustryLpStoreOffer.objects.create(
+        category = EveCategory.objects.create(
+            id=6, name="Ship", published=True
+        )
+        group = EveGroup.objects.create(
+            id=27, name="Battleship", published=True, eve_category=category
+        )
+        self.input_type = EveType.objects.create(
+            id=INPUT_TYPE_ID,
+            name="LP Input Item",
+            published=True,
+            eve_group=group,
+        )
+        self.offer = IndustryLpStoreOffer.objects.create(
             offer_id=2001,
             corporation_id=TLIB_CORP_ID,
             type_id=INPUT_TYPE_ID,
@@ -329,6 +342,41 @@ class LpStoreOfferAdminTestCase(TestCase):
         qs = self.admin.get_queryset(request)
         self.assertEqual(list(qs.values_list("offer_id", flat=True)), [2001])
 
+    def test_list_display_omits_type_id_column(self):
+        self.assertNotIn("type_id", self.admin.list_display)
+        self.assertIn("type_name_display", self.admin.list_display)
+
+    def test_type_name_display_includes_name_and_type_id(self):
+        # pylint: disable=protected-access
+        IndustryLpStoreOfferAdmin._request_stash = {
+            self.offer.pk: SimpleNamespace(
+                kind="input",
+                type_id=INPUT_TYPE_ID,
+                type_name="LP Input Item",
+                market_type_id=INPUT_TYPE_ID,
+                market_type_name="LP Input Item",
+            )
+        }
+        try:
+            html = str(self.admin.type_name_display(self.offer))
+        finally:
+            IndustryLpStoreOfferAdmin._request_stash = None
+        self.assertIn("LP Input Item", html)
+        self.assertIn(f"type {INPUT_TYPE_ID}", html)
+        self.assertIn("lp-store-offer-item__name", html)
+
+    def test_search_by_type_name(self):
+        request = self.factory.get(
+            "/admin/industry/industrylpstoreoffer/",
+            {"q": "LP Input"},
+        )
+        request.user = self.user
+        qs = self.admin.get_queryset(request)
+        result, _ = self.admin.get_search_results(request, qs, "LP Input")
+        self.assertEqual(
+            list(result.values_list("offer_id", flat=True)), [2001]
+        )
+
     @patch(
         "industry.admin.offer_economics_for_queryset",
         return_value={},
@@ -344,3 +392,21 @@ class LpStoreOfferAdminTestCase(TestCase):
         self.assertIn("conversion_sell_display", self.admin.list_display)
         self.assertIn("conversion_buy_display", self.admin.list_display)
         self.assertIn("cost_display", self.admin.list_display)
+
+    @patch(
+        "industry.admin.offer_economics_for_queryset",
+        return_value={},
+    )
+    def test_changelist_uses_sticky_item_template(self, mock_econ):
+        request = self.factory.get("/admin/industry/industrylpstoreoffer/")
+        request.user = self.user
+        response = self.admin.changelist_view(request)
+        self.assertEqual(response.status_code, 200)
+        response.render()
+        content = response.content.decode()
+        self.assertIn("position: sticky", content)
+        self.assertIn("field-type_name_display", content)
+        self.assertIn(
+            "admin/industry/industrylpstoreoffer/change_list.html",
+            self.admin.change_list_template,
+        )

--- a/backend/templates/admin/industry/industrylpstoreoffer/change_list.html
+++ b/backend/templates/admin/industry/industrylpstoreoffer/change_list.html
@@ -1,0 +1,75 @@
+{% extends "admin/change_list.html" %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <style>
+    /*
+     * Wide economics table: keep checkbox + Item visible while scrolling
+     * horizontally, and allow long type names to wrap.
+     */
+    #changelist #result_list {
+      border-collapse: separate;
+      border-spacing: 0;
+    }
+
+    #changelist #result_list th.action-checkbox-column,
+    #changelist #result_list td.action-checkbox {
+      position: sticky;
+      left: 0;
+      z-index: 2;
+      background: var(--body-bg);
+      box-shadow: 1px 0 0 var(--hairline-color, #ccc);
+    }
+
+    #changelist #result_list thead th.action-checkbox-column {
+      z-index: 3;
+    }
+
+    #changelist #result_list th.column-type_name_display,
+    #changelist #result_list td.field-type_name_display {
+      position: sticky;
+      left: 2.5em;
+      z-index: 1;
+      background: var(--body-bg);
+      min-width: 14em;
+      max-width: 22em;
+      box-shadow: 1px 0 0 var(--hairline-color, #ccc);
+    }
+
+    #changelist #result_list thead th.column-type_name_display {
+      z-index: 2;
+      white-space: nowrap;
+    }
+
+    #changelist #result_list td.field-type_name_display {
+      white-space: normal;
+      vertical-align: top;
+    }
+
+    #changelist #result_list tbody tr:nth-child(even) td.action-checkbox,
+    #changelist #result_list tbody tr:nth-child(even) td.field-type_name_display {
+      background: var(--darkened-bg);
+    }
+
+    #changelist #result_list tbody tr.selected td.action-checkbox,
+    #changelist #result_list tbody tr.selected td.field-type_name_display {
+      background: var(--selected-row);
+    }
+
+    .lp-store-offer-item {
+      display: flex;
+      flex-direction: column;
+      gap: 0.15em;
+      line-height: 1.3;
+    }
+
+    .lp-store-offer-item__name {
+      font-weight: 600;
+    }
+
+    .lp-store-offer-item__type {
+      color: var(--body-quiet-color, #888);
+      font-size: 0.85em;
+    }
+  </style>
+{% endblock %}


### PR DESCRIPTION
## Summary
- **Bugfix:** economics stash was cleared in `changelist_view` before `TemplateResponse` rendered, so Item showed raw type IDs and every market column was `—`
- Sticky Item column with type icon + name, Fuzzwork-like column order (costs → required → Jita → ISK/LP rates → volume)
- Search by EveType name; harden missing `required_items` table so the list still loads pre-migration

## Test plan
- [ ] Open Admin → Loyalty points → LP store offers
- [ ] Confirm Item shows human-readable names (with icons), not just type IDs
- [ ] Confirm Currency shows names (e.g. Tribal Liberation Force), not corp IDs
- [ ] Confirm Jita / ISK/LP / volume columns populate when price history exists
- [ ] Scroll horizontally and confirm Item stays pinned
- [ ] Search for a known type name and confirm matches
- [ ] `pipenv run python manage.py test industry.tests.test_lp_store_economics --settings=app.settings_test`