### PR TITLE
Fix LP store offer names blanking after admin render

### DIFF
--- a/.cursor/rules/market-pricing.mdc
+++ b/.cursor/rules/market-pricing.mdc
@@ -24,7 +24,7 @@ See also: `docs/market-pricing.md`.
 
 - For **Jita guide prices**, call `get_prices_by_type_id` / `get_baseline_buy_prices`. Never query `EveMarketItemLocationPrice` alone as “Jita”.
 - Jita NPC station buy orders are often **empty** in LocationPrice; that broke buyback when LocationPrice was used as the guide (#2548).
-- LP store **conversion** rates use baseline LocationPrice sell/buy when present, else regional history (`get_prices_by_type_id`). Buyback / markup baselines use **regional history**, not live station rows alone.
+- LP store **conversion** rates use baseline LocationPrice sell/buy when present, else regional history (`get_prices_by_type_id`). Blueprint other cost includes manufacturing BOM × qty (Fuzzwork materials-to-build). Buyback / markup baselines use **regional history**, not live station rows alone.
 - `EveLocation.price_baseline` → which location’s **region** drives guide history (exactly one).
 - `EveLocation.prices_active` → sync LocationPrice from ESI (Jita can be prices_active without being a structure market).
 - `EveLocation.market_active` → alliance market sell-order / expectation flows — **not** the same as prices_active.

--- a/backend/industry/admin.py
+++ b/backend/industry/admin.py
@@ -715,21 +715,23 @@ class IndustryLpStoreExcludeTagsFilter(admin.SimpleListFilter):
     parameter_name = "exclude_tags"
 
     def lookups(self, request, model_admin):
-        return (("1", "Yes"),)
+        return (("1", "Yes"), ("0", "No"))
 
     def queryset(self, request, queryset):
-        if self.value() != "1":
+        value = self.value()
+        if value not in ("0", "1"):
             return queryset
         tag_ids = tag_type_ids()
         if not tag_ids:
             return queryset
-        # Hide offers that *are* tags or that require a tag as input.
+        # Offers that *are* tags or that require a tag as input.
         req_offer_ids = IndustryLpStoreOfferRequiredItem.objects.filter(
             type_id__in=tag_ids
         ).values("offer_id")
-        return queryset.exclude(
-            Q(type_id__in=tag_ids) | Q(pk__in=req_offer_ids)
-        )
+        tag_q = Q(type_id__in=tag_ids) | Q(pk__in=req_offer_ids)
+        if value == "1":
+            return queryset.exclude(tag_q)
+        return queryset.filter(tag_q)
 
 
 class IndustryLpStoreExcludeSupplyPackagesFilter(admin.SimpleListFilter):
@@ -737,21 +739,23 @@ class IndustryLpStoreExcludeSupplyPackagesFilter(admin.SimpleListFilter):
     parameter_name = "exclude_supply_packages"
 
     def lookups(self, request, model_admin):
-        return (("1", "Yes"),)
+        return (("1", "Yes"), ("0", "No"))
 
     def queryset(self, request, queryset):
-        if self.value() != "1":
+        value = self.value()
+        if value not in ("0", "1"):
             return queryset
         package_ids = supply_package_type_ids()
         if not package_ids:
             return queryset
-        # Hide offers that *are* supply packages or require one as input.
+        # Offers that *are* supply packages or require one as input.
         req_offer_ids = IndustryLpStoreOfferRequiredItem.objects.filter(
             type_id__in=package_ids
         ).values("offer_id")
-        return queryset.exclude(
-            Q(type_id__in=package_ids) | Q(pk__in=req_offer_ids)
-        )
+        package_q = Q(type_id__in=package_ids) | Q(pk__in=req_offer_ids)
+        if value == "1":
+            return queryset.exclude(package_q)
+        return queryset.filter(package_q)
 
 
 @admin.register(IndustryLpStoreOffer)

--- a/backend/industry/admin.py
+++ b/backend/industry/admin.py
@@ -2,9 +2,10 @@ import logging
 
 from django.contrib import admin
 from django.contrib import messages
+from django.contrib.admin.views.main import ChangeList
 from django import forms
 from django.core.cache import cache
-from django.db.models import Count, Max, Q, Sum
+from django.db.models import Case, Count, IntegerField, Max, Q, Sum, When
 from django.http import HttpResponseRedirect
 from django.middleware.csrf import get_token
 from django.urls import path, reverse
@@ -930,6 +931,70 @@ class IndustryLpStoreExcludeBelowSetLpPriceFilter(admin.SimpleListFilter):
         return queryset.filter(pk__in=below)
 
 
+# Map admin order_by annotation names → LpStoreOfferEconomics attributes.
+# Approximate SQL annotations ignore other_cost/BOM/hull mapping; when these
+# keys appear in ordering we re-sort from request economics so the UI matches
+# displayed ISK/LP and volume columns.
+_LP_OFFER_ECON_ORDER_ATTR = {
+    "sort_conversion_sell": "conversion_isk_per_lp_sell",
+    "sort_conversion_buy": "conversion_isk_per_lp_buy",
+    "sort_jita_sell": "jita_sell",
+    "sort_jita_buy": "jita_buy",
+    "sort_volume_1d": "volume_1d",
+    "sort_volume_7d": "volume_7d",
+    "sort_volume_30d": "volume_30d",
+    "sort_acquisition": "acquisition_isk_per_unit",
+    "sort_profit": "profit_vs_sell",
+}
+
+
+class LpStoreOfferChangeList(ChangeList):
+    """ChangeList that sorts economics columns by display economics."""
+
+    def get_queryset(self, request, exclude_parameters=None):
+        qs = super().get_queryset(
+            request, exclude_parameters=exclude_parameters
+        )
+        ordering = list(self.get_ordering(request, qs) or [])
+        econ_terms = []
+        for term in ordering:
+            desc = term.startswith("-")
+            field = term[1:] if desc else term
+            if field in _LP_OFFER_ECON_ORDER_ATTR:
+                econ_terms.append((field, desc))
+        if not econ_terms:
+            return qs
+
+        economics = ensure_lp_offer_econ_on_request(request)
+        # Primary econ key only (matches typical single-column admin sort).
+        field, descending = econ_terms[0]
+        attr = _LP_OFFER_ECON_ORDER_ATTR[field]
+
+        def sort_key(obj):
+            econ = economics.get(obj.pk) if economics else None
+            if econ is None:
+                return (1, 0.0)
+            value = getattr(econ, attr, None)
+            if value is None:
+                return (1, 0.0)
+            return (0, float(value))
+
+        ordered = sorted(qs.order_by("pk"), key=sort_key, reverse=descending)
+        if not ordered:
+            return qs.order_by()
+        pk_order = [obj.pk for obj in ordered]
+        preserved = Case(
+            *[When(pk=pk, then=pos) for pos, pk in enumerate(pk_order)],
+            output_field=IntegerField(),
+        )
+        return (
+            qs.order_by()
+            .filter(pk__in=pk_order)
+            .annotate(_lp_econ_ord=preserved)
+            .order_by("_lp_econ_ord")
+        )
+
+
 @admin.register(IndustryLpStoreOffer)
 class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
     _request_stash = None
@@ -1006,6 +1071,9 @@ class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
             .filter(corporation_id__in=tracked_corporation_ids())
         )
         return annotate_lp_store_offer_sort_fields(qs)
+
+    def get_changelist(self, request, **kwargs):
+        return LpStoreOfferChangeList
 
     def get_search_results(self, request, queryset, search_term):
         # queryset already has list filters applied (e.g. currency). Keep a
@@ -1192,11 +1260,11 @@ class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
     def conversion_buy_display(self, obj):
         return self._format_rate(obj, "conversion_isk_per_lp_buy")
 
-    @admin.display(description="Jita sell", ordering="sort_jita_price")
+    @admin.display(description="Jita sell", ordering="sort_jita_sell")
     def jita_sell_display(self, obj):
         return self._format_isk(obj, "jita_sell")
 
-    @admin.display(description="Jita buy", ordering="sort_jita_price")
+    @admin.display(description="Jita buy", ordering="sort_jita_buy")
     def jita_buy_display(self, obj):
         return self._format_isk(obj, "jita_buy")
 

--- a/backend/industry/admin.py
+++ b/backend/industry/admin.py
@@ -49,9 +49,9 @@ from industry.helpers.lp_catalog import (
 from industry.helpers.lp_store_economics import (
     annotate_lp_store_offer_sort_fields,
     offer_economics_for_queryset,
-    offer_type_ids_with_viable_forge_volume,
     tracked_corporation_ids,
 )
+from industry.helpers.lp_store_useless import useless_offer_pks
 from industry.tasks import (
     compute_order_profit_breakdown_task,
     sync_loyalty_store_offers_task,
@@ -784,16 +784,18 @@ class IndustryLpStoreExcludeChipsFilter(admin.SimpleListFilter):
         return queryset.filter(chip_q)
 
 
-class IndustryLpStoreExcludeNegligibleVolumeFilter(admin.SimpleListFilter):
+class IndustryLpStoreExcludeUselessOffersFilter(admin.SimpleListFilter):
     """
-    Hide (or isolate) offers with no/negligible Forge 30d market volume.
+    Hide (or isolate) offers that are useless for LP conversion screening.
 
-    Uses market_type_id (hull for navy BPCs). Missing history counts as
-    negligible — run market history sync for LP catalog types first.
+    Yes = hide useless; No = show only useless. Uses offer_is_useless:
+    stockpile usefulness, profit vs buyback, below peer median, and
+    volume/volatility (Forge 30d + spread proxy). See
+    industry.helpers.lp_store_useless.
     """
 
-    title = "exclude negligible volume"
-    parameter_name = "exclude_negligible_volume"
+    title = "exclude useless offers"
+    parameter_name = "exclude_useless_offers"
 
     def lookups(self, request, model_admin):
         return (("1", "Yes"), ("0", "No"))
@@ -802,11 +804,11 @@ class IndustryLpStoreExcludeNegligibleVolumeFilter(admin.SimpleListFilter):
         value = self.value()
         if value not in ("0", "1"):
             return queryset
-        offer_type_ids = set(queryset.values_list("type_id", flat=True))
-        viable = offer_type_ids_with_viable_forge_volume(offer_type_ids)
+        # ~1.5k tracked offers is fine to evaluate in Python via economics.
+        useless = useless_offer_pks(queryset)
         if value == "1":
-            return queryset.filter(type_id__in=viable)
-        return queryset.exclude(type_id__in=viable)
+            return queryset.exclude(pk__in=useless)
+        return queryset.filter(pk__in=useless)
 
 
 @admin.register(IndustryLpStoreOffer)
@@ -839,7 +841,7 @@ class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
         IndustryLpStoreExcludeTagsFilter,
         IndustryLpStoreExcludeSupplyPackagesFilter,
         IndustryLpStoreExcludeChipsFilter,
-        IndustryLpStoreExcludeNegligibleVolumeFilter,
+        IndustryLpStoreExcludeUselessOffersFilter,
     )
     search_fields = ("offer_id", "type_id", "corporation_id")
     ordering = ("corporation_id", "type_id")

--- a/backend/industry/admin.py
+++ b/backend/industry/admin.py
@@ -711,22 +711,21 @@ class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
     change_list_template = (
         "admin/industry/industrylpstoreoffer/change_list.html"
     )
+    # Fuzzwork-like order: identity, offer costs, requirements, market, rates.
     list_display = (
         "type_name_display",
         "currency_display",
-        "kind_display",
         "lp_cost",
         "isk_cost",
-        "ak_cost",
         "quantity",
         "required_items_display",
         "other_cost_display",
-        "isk_per_lp_display",
-        "conversion_sell_display",
-        "conversion_buy_display",
         "jita_sell_display",
         "jita_buy_display",
+        "conversion_sell_display",
+        "conversion_buy_display",
         "volume_90d_display",
+        "isk_per_lp_display",
         "cost_display",
         "profit_vs_sell_display",
         "updated_at",
@@ -773,7 +772,6 @@ class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
             super()
             .get_queryset(request)
             .filter(corporation_id__in=tracked_corporation_ids())
-            .prefetch_related("required_items")
         )
 
     def get_search_results(self, request, queryset, search_term):
@@ -802,10 +800,16 @@ class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
         return cl
 
     def changelist_view(self, request, extra_context=None):
+        # TemplateResponse renders after this method returns; force render
+        # while economics stash is still populated so list_display methods
+        # can resolve type names and market columns.
         try:
-            return super().changelist_view(
+            response = super().changelist_view(
                 request, extra_context=extra_context
             )
+            if hasattr(response, "render"):
+                response.render()
+            return response
         finally:
             IndustryLpStoreOfferAdmin._request_stash = None
 
@@ -839,35 +843,53 @@ class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
     @admin.display(description="Item")
     def type_name_display(self, obj):
         econ = self._econ_for(obj)
+        type_id = obj.type_id
+        kind = ""
         if econ is None:
-            name = str(obj.type_id)
-            type_id = obj.type_id
+            name = (
+                EveType.objects.filter(id=type_id)
+                .values_list("name", flat=True)
+                .first()
+            ) or str(type_id)
         elif econ.kind == "blueprint" and econ.market_type_id != econ.type_id:
-            name = f"{econ.market_type_name} (BPC {econ.type_id})"
+            name = f"{econ.market_type_name} (BPC)"
             type_id = econ.type_id
+            kind = "blueprint"
         else:
             name = econ.type_name
             type_id = econ.type_id
+            kind = econ.kind or ""
+        meta = f"type {type_id}"
+        if kind:
+            meta = f"{kind} · {meta}"
         return format_html(
             '<span class="lp-store-offer-item">'
+            '<img class="lp-store-offer-item__icon" '
+            'src="https://images.evetech.net/types/{}/icon?size=32" '
+            'width="32" height="32" alt="" loading="lazy" />'
+            '<span class="lp-store-offer-item__text">'
             '<span class="lp-store-offer-item__name">{}</span>'
-            '<span class="lp-store-offer-item__type">type {}</span>'
+            '<span class="lp-store-offer-item__type">{}</span>'
+            "</span>"
             "</span>",
-            name,
             type_id,
+            name,
+            meta,
         )
 
     @admin.display(description="Currency")
     def currency_display(self, obj):
         econ = self._econ_for(obj)
-        return (
-            econ.currency_name if econ is not None else str(obj.corporation_id)
+        if econ is not None:
+            return econ.currency_name
+        currency = (
+            IndustryLoyaltyPoint.objects.filter(
+                corporation_id=obj.corporation_id
+            )
+            .values_list("name", flat=True)
+            .first()
         )
-
-    @admin.display(description="Kind")
-    def kind_display(self, obj):
-        econ = self._econ_for(obj)
-        return econ.kind if econ is not None else "—"
+        return currency or str(obj.corporation_id)
 
     @admin.display(description="Required")
     def required_items_display(self, obj):

--- a/backend/industry/admin.py
+++ b/backend/industry/admin.py
@@ -41,7 +41,12 @@ from industry.helpers.lp_ledger import (
     resolve_offer_isk_per_lp,
     weighted_average_cost_isk_per_lp,
 )
+from industry.helpers.lp_catalog import (
+    supply_package_type_ids,
+    tag_type_ids,
+)
 from industry.helpers.lp_store_economics import (
+    annotate_lp_store_offer_sort_fields,
     offer_economics_for_queryset,
     tracked_corporation_ids,
 )
@@ -57,6 +62,7 @@ from industry.models import (
     IndustryLoyaltyPointLedgerEntry,
     IndustryLoyaltyPointPriceHistory,
     IndustryLpStoreOffer,
+    IndustryLpStoreOfferRequiredItem,
     IndustryOrder,
     IndustryOrderBlueprintCoordinator,
     IndustryOrderItem,
@@ -701,7 +707,51 @@ class IndustryLpStoreCurrencyListFilter(admin.SimpleListFilter):
     def queryset(self, request, queryset):
         if self.value() is None:
             return queryset
-        return queryset.filter(corporation_id=self.value())
+        return queryset.filter(corporation_id=int(self.value()))
+
+
+class IndustryLpStoreExcludeTagsFilter(admin.SimpleListFilter):
+    title = "exclude tags"
+    parameter_name = "exclude_tags"
+
+    def lookups(self, request, model_admin):
+        return (("1", "Yes"),)
+
+    def queryset(self, request, queryset):
+        if self.value() != "1":
+            return queryset
+        tag_ids = tag_type_ids()
+        if not tag_ids:
+            return queryset
+        # Hide offers that *are* tags or that require a tag as input.
+        req_offer_ids = IndustryLpStoreOfferRequiredItem.objects.filter(
+            type_id__in=tag_ids
+        ).values("offer_id")
+        return queryset.exclude(
+            Q(type_id__in=tag_ids) | Q(pk__in=req_offer_ids)
+        )
+
+
+class IndustryLpStoreExcludeSupplyPackagesFilter(admin.SimpleListFilter):
+    title = "exclude supply packages"
+    parameter_name = "exclude_supply_packages"
+
+    def lookups(self, request, model_admin):
+        return (("1", "Yes"),)
+
+    def queryset(self, request, queryset):
+        if self.value() != "1":
+            return queryset
+        package_ids = supply_package_type_ids()
+        if not package_ids:
+            return queryset
+        # Hide offers that *are* supply packages or require one as input.
+        req_offer_ids = IndustryLpStoreOfferRequiredItem.objects.filter(
+            type_id__in=package_ids
+        ).values("offer_id")
+        return queryset.exclude(
+            Q(type_id__in=package_ids) | Q(pk__in=req_offer_ids)
+        )
 
 
 @admin.register(IndustryLpStoreOffer)
@@ -715,8 +765,8 @@ class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
     list_display = (
         "type_name_display",
         "currency_display",
-        "lp_cost",
-        "isk_cost",
+        "lp_cost_display",
+        "isk_cost_display",
         "quantity",
         "required_items_display",
         "other_cost_display",
@@ -724,13 +774,16 @@ class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
         "jita_buy_display",
         "conversion_sell_display",
         "conversion_buy_display",
-        "volume_90d_display",
-        "isk_per_lp_display",
-        "cost_display",
-        "profit_vs_sell_display",
+        "volume_1d_display",
+        "volume_7d_display",
+        "volume_30d_display",
         "updated_at",
     )
-    list_filter = (IndustryLpStoreCurrencyListFilter,)
+    list_filter = (
+        IndustryLpStoreCurrencyListFilter,
+        IndustryLpStoreExcludeTagsFilter,
+        IndustryLpStoreExcludeSupplyPackagesFilter,
+    )
     search_fields = ("offer_id", "type_id", "corporation_id")
     ordering = ("corporation_id", "type_id")
     actions = ("sync_loyalty_store_offers_action",)
@@ -768,13 +821,17 @@ class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
     )
 
     def get_queryset(self, request):
-        return (
+        qs = (
             super()
             .get_queryset(request)
             .filter(corporation_id__in=tracked_corporation_ids())
         )
+        return annotate_lp_store_offer_sort_fields(qs)
 
     def get_search_results(self, request, queryset, search_term):
+        # queryset already has list filters applied (e.g. currency). Keep a
+        # copy so name search cannot reintroduce rows those filters excluded.
+        filtered_qs = queryset
         queryset, use_distinct = super().get_search_results(
             request, queryset, search_term
         )
@@ -787,7 +844,7 @@ class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
             )
         )
         if type_ids:
-            by_name = self.get_queryset(request).filter(type_id__in=type_ids)
+            by_name = filtered_qs.filter(type_id__in=type_ids)
             queryset |= by_name
             use_distinct = True
         return queryset, use_distinct
@@ -840,42 +897,71 @@ class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
             return "—"
         return f"{value:,.1f}"
 
-    @admin.display(description="Item")
+    @admin.display(description="Item", ordering="sort_type_name")
     def type_name_display(self, obj):
         econ = self._econ_for(obj)
         type_id = obj.type_id
-        kind = ""
+        is_blueprint = False
         if econ is None:
             name = (
                 EveType.objects.filter(id=type_id)
                 .values_list("name", flat=True)
                 .first()
-            ) or str(type_id)
+            )
+            resolved = bool(name)
+            name = name or str(type_id)
+            # Heuristic when stash is cold; prefer economics.kind when live.
+            is_blueprint = "blueprint" in str(name).lower()
         elif econ.kind == "blueprint" and econ.market_type_id != econ.type_id:
             name = f"{econ.market_type_name} (BPC)"
             type_id = econ.type_id
-            kind = "blueprint"
+            is_blueprint = True
+            resolved = bool(econ.market_type_name) and (
+                econ.market_type_name != str(econ.market_type_id)
+            )
         else:
             name = econ.type_name
             type_id = econ.type_id
-            kind = econ.kind or ""
-        meta = f"type {type_id}"
-        if kind:
-            meta = f"{kind} · {meta}"
+            is_blueprint = econ.kind == "blueprint"
+            resolved = bool(econ.type_name) and econ.type_name != str(type_id)
+
+        title = f"Type {type_id}"
+        image_path = "bp" if is_blueprint else "icon"
+        if resolved:
+            return format_html(
+                '<span class="lp-store-offer-item" title="{}">'
+                '<img class="lp-store-offer-item__icon" '
+                'src="https://images.evetech.net/types/{}/{}?size=32" '
+                'width="32" height="32" alt="" loading="lazy" '
+                'onerror="this.hidden=true;'
+                'this.nextElementSibling.hidden=false;" />'
+                '<span class="lp-store-offer-item__placeholder" '
+                'aria-hidden="true" hidden></span>'
+                '<span class="lp-store-offer-item__name">{}</span>'
+                "</span>",
+                title,
+                type_id,
+                image_path,
+                name,
+            )
         return format_html(
-            '<span class="lp-store-offer-item">'
-            '<img class="lp-store-offer-item__icon" '
-            'src="https://images.evetech.net/types/{}/icon?size=32" '
-            'width="32" height="32" alt="" loading="lazy" />'
-            '<span class="lp-store-offer-item__text">'
+            '<span class="lp-store-offer-item '
+            'lp-store-offer-item--missing" title="{}">'
+            '<span class="lp-store-offer-item__placeholder" '
+            'aria-hidden="true"></span>'
             '<span class="lp-store-offer-item__name">{}</span>'
-            '<span class="lp-store-offer-item__type">{}</span>'
-            "</span>"
             "</span>",
-            type_id,
+            title,
             name,
-            meta,
         )
+
+    @admin.display(description="LP cost", ordering="lp_cost")
+    def lp_cost_display(self, obj):
+        return f"{obj.lp_cost:,}"
+
+    @admin.display(description="ISK cost", ordering="isk_cost")
+    def isk_cost_display(self, obj):
+        return f"{obj.isk_cost:,}"
 
     @admin.display(description="Currency")
     def currency_display(self, obj):
@@ -909,31 +995,39 @@ class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
             return "—"
         return f"{econ.isk_per_lp:,.0f}"
 
-    @admin.display(description="ISK/LP sell")
+    @admin.display(description="ISK/LP sell", ordering="sort_conversion_sell")
     def conversion_sell_display(self, obj):
         return self._format_rate(obj, "conversion_isk_per_lp_sell")
 
-    @admin.display(description="ISK/LP buy")
+    @admin.display(description="ISK/LP buy", ordering="sort_conversion_buy")
     def conversion_buy_display(self, obj):
         return self._format_rate(obj, "conversion_isk_per_lp_buy")
 
-    @admin.display(description="Jita sell")
+    @admin.display(description="Jita sell", ordering="sort_jita_price")
     def jita_sell_display(self, obj):
         return self._format_isk(obj, "jita_sell")
 
-    @admin.display(description="Jita buy")
+    @admin.display(description="Jita buy", ordering="sort_jita_price")
     def jita_buy_display(self, obj):
         return self._format_isk(obj, "jita_buy")
 
-    @admin.display(description="90d volume")
-    def volume_90d_display(self, obj):
-        return self._format_isk(obj, "volume_90d")
+    @admin.display(description="1d vol", ordering="sort_volume_1d")
+    def volume_1d_display(self, obj):
+        return self._format_isk(obj, "volume_1d")
 
-    @admin.display(description="Cost")
+    @admin.display(description="7d vol", ordering="sort_volume_7d")
+    def volume_7d_display(self, obj):
+        return self._format_isk(obj, "volume_7d")
+
+    @admin.display(description="30d vol", ordering="sort_volume_30d")
+    def volume_30d_display(self, obj):
+        return self._format_isk(obj, "volume_30d")
+
+    @admin.display(description="Acquisition", ordering="sort_acquisition")
     def cost_display(self, obj):
         return self._format_isk(obj, "cost_per_unit")
 
-    @admin.display(description="Profit vs sell")
+    @admin.display(description="Profit vs sell", ordering="sort_profit")
     def profit_vs_sell_display(self, obj):
         return self._format_isk(obj, "profit_vs_sell")
 

--- a/backend/industry/admin.py
+++ b/backend/industry/admin.py
@@ -49,6 +49,7 @@ from industry.helpers.lp_catalog import (
 from industry.helpers.lp_store_economics import (
     annotate_lp_store_offer_sort_fields,
     offer_economics_for_queryset,
+    offer_type_ids_with_viable_forge_volume,
     tracked_corporation_ids,
 )
 from industry.tasks import (
@@ -783,6 +784,31 @@ class IndustryLpStoreExcludeChipsFilter(admin.SimpleListFilter):
         return queryset.filter(chip_q)
 
 
+class IndustryLpStoreExcludeNegligibleVolumeFilter(admin.SimpleListFilter):
+    """
+    Hide (or isolate) offers with no/negligible Forge 30d market volume.
+
+    Uses market_type_id (hull for navy BPCs). Missing history counts as
+    negligible — run market history sync for LP catalog types first.
+    """
+
+    title = "exclude negligible volume"
+    parameter_name = "exclude_negligible_volume"
+
+    def lookups(self, request, model_admin):
+        return (("1", "Yes"), ("0", "No"))
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value not in ("0", "1"):
+            return queryset
+        offer_type_ids = set(queryset.values_list("type_id", flat=True))
+        viable = offer_type_ids_with_viable_forge_volume(offer_type_ids)
+        if value == "1":
+            return queryset.filter(type_id__in=viable)
+        return queryset.exclude(type_id__in=viable)
+
+
 @admin.register(IndustryLpStoreOffer)
 class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
     _request_stash = None
@@ -813,6 +839,7 @@ class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
         IndustryLpStoreExcludeTagsFilter,
         IndustryLpStoreExcludeSupplyPackagesFilter,
         IndustryLpStoreExcludeChipsFilter,
+        IndustryLpStoreExcludeNegligibleVolumeFilter,
     )
     search_fields = ("offer_id", "type_id", "corporation_id")
     ordering = ("corporation_id", "type_id")

--- a/backend/industry/admin.py
+++ b/backend/industry/admin.py
@@ -42,6 +42,7 @@ from industry.helpers.lp_ledger import (
     weighted_average_cost_isk_per_lp,
 )
 from industry.helpers.lp_catalog import (
+    chip_type_ids,
     supply_package_type_ids,
     tag_type_ids,
 )
@@ -758,6 +759,30 @@ class IndustryLpStoreExcludeSupplyPackagesFilter(admin.SimpleListFilter):
         return queryset.filter(package_q)
 
 
+class IndustryLpStoreExcludeChipsFilter(admin.SimpleListFilter):
+    title = "exclude chips"
+    parameter_name = "exclude_chips"
+
+    def lookups(self, request, model_admin):
+        return (("1", "Yes"), ("0", "No"))
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value not in ("0", "1"):
+            return queryset
+        chip_ids = chip_type_ids()
+        if not chip_ids:
+            return queryset
+        # Offers that *are* nexus chips or require one as input.
+        req_offer_ids = IndustryLpStoreOfferRequiredItem.objects.filter(
+            type_id__in=chip_ids
+        ).values("offer_id")
+        chip_q = Q(type_id__in=chip_ids) | Q(pk__in=req_offer_ids)
+        if value == "1":
+            return queryset.exclude(chip_q)
+        return queryset.filter(chip_q)
+
+
 @admin.register(IndustryLpStoreOffer)
 class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
     _request_stash = None
@@ -787,6 +812,7 @@ class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
         IndustryLpStoreCurrencyListFilter,
         IndustryLpStoreExcludeTagsFilter,
         IndustryLpStoreExcludeSupplyPackagesFilter,
+        IndustryLpStoreExcludeChipsFilter,
     )
     search_fields = ("offer_id", "type_id", "corporation_id")
     ordering = ("corporation_id", "type_id")

--- a/backend/industry/admin.py
+++ b/backend/industry/admin.py
@@ -49,6 +49,7 @@ from industry.helpers.lp_catalog import (
 from industry.helpers.lp_store_economics import (
     annotate_lp_store_offer_sort_fields,
     offer_economics_for_queryset,
+    offer_pks_below_set_lp_price,
     tracked_corporation_ids,
 )
 from industry.helpers.lp_store_useless import useless_offer_pks
@@ -811,6 +812,32 @@ class IndustryLpStoreExcludeUselessOffersFilter(admin.SimpleListFilter):
         return queryset.filter(pk__in=useless)
 
 
+class IndustryLpStoreExcludeBelowSetLpPriceFilter(admin.SimpleListFilter):
+    """
+    Hide (or isolate) offers whose ISK/LP sell is below set buyback.
+
+    Compares conversion_isk_per_lp_sell to IndustryLoyaltyPoint
+    default_isk_per_lp for the offer's corporation. Null conversion
+    counts as below set (missing prices → cannot beat buyback).
+    """
+
+    title = "exclude below set LP price"
+    parameter_name = "exclude_below_set_lp_price"
+
+    def lookups(self, request, model_admin):
+        return (("1", "Yes"), ("0", "No"))
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value not in ("0", "1"):
+            return queryset
+        # ~1.5k tracked offers is fine to evaluate via economics helpers.
+        below = offer_pks_below_set_lp_price(queryset)
+        if value == "1":
+            return queryset.exclude(pk__in=below)
+        return queryset.filter(pk__in=below)
+
+
 @admin.register(IndustryLpStoreOffer)
 class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
     _request_stash = None
@@ -842,6 +869,7 @@ class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
         IndustryLpStoreExcludeSupplyPackagesFilter,
         IndustryLpStoreExcludeChipsFilter,
         IndustryLpStoreExcludeUselessOffersFilter,
+        IndustryLpStoreExcludeBelowSetLpPriceFilter,
     )
     search_fields = ("offer_id", "type_id", "corporation_id")
     ordering = ("corporation_id", "type_id")

--- a/backend/industry/admin.py
+++ b/backend/industry/admin.py
@@ -3,13 +3,16 @@ import logging
 from django.contrib import admin
 from django.contrib import messages
 from django import forms
-from django.db.models import Q, Sum
+from django.core.cache import cache
+from django.db.models import Count, Max, Q, Sum
 from django.http import HttpResponseRedirect
 from django.middleware.csrf import get_token
 from django.urls import path, reverse
 from django.utils import timezone
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
+
+from market.models.history import EveMarketItemHistory
 
 from eveuniverse.models import EveGroup, EveType
 
@@ -82,6 +85,11 @@ logger = logging.getLogger(__name__)
 # Request attribute for one shared tracked-catalog economics map per
 # changelist (filters + list_display stash). Avoids N× full recomputes.
 _LP_OFFER_ECON_ATTR = "_lp_offer_econ"
+# Short-lived cross-request cache so toggling filters does not recompute
+# ~1.5k offers every time. Invalidates when offer/currency/history inputs
+# change; TTL bounds LocationPrice / planner staleness.
+_LP_OFFER_ECON_CACHE_PREFIX = "industry:lp_offer_econ:v1"
+_LP_OFFER_ECON_CACHE_TTL = 180
 _LP_ECON_FILTER_PARAMS = (
     "exclude_useless_offers",
     "exclude_below_set_lp_price",
@@ -95,17 +103,58 @@ def _lp_econ_filters_active(request) -> bool:
     )
 
 
+def lp_offer_econ_cache_key() -> str:
+    """
+    Cache key for the full tracked-catalog economics map.
+
+    Fingerprint includes tracked corps, offer count + max(updated_at),
+    active currency default_isk_per_lp rates, and max Forge history date
+    so offer sync / buyback edits / daily history refresh invalidate.
+    """
+    corp_ids = tracked_corporation_ids()
+    corp_key = ",".join(str(c) for c in sorted(corp_ids)) or "none"
+    if corp_ids:
+        offer_stats = IndustryLpStoreOffer.objects.filter(
+            corporation_id__in=corp_ids
+        ).aggregate(n=Count("pk"), max_u=Max("updated_at"))
+    else:
+        offer_stats = {"n": 0, "max_u": None}
+    currency_fp = (
+        ",".join(
+            f"{row.corporation_id}:{row.default_isk_per_lp}"
+            for row in IndustryLoyaltyPoint.objects.filter(
+                is_active=True
+            ).order_by("corporation_id")
+        )
+        or "none"
+    )
+    hist_max = EveMarketItemHistory.objects.aggregate(m=Max("date"))["m"]
+    n = int(offer_stats["n"] or 0)
+    max_u = offer_stats["max_u"]
+    max_u_s = max_u.isoformat() if max_u is not None else "none"
+    hist_s = hist_max.isoformat() if hist_max is not None else "none"
+    return (
+        f"{_LP_OFFER_ECON_CACHE_PREFIX}:{corp_key}|n={n}|u={max_u_s}"
+        f"|lp={currency_fp}|h={hist_s}"
+    )
+
+
 def ensure_lp_offer_econ_on_request(request):
     """
-    Compute economics for all tracked LP store offers once per request.
+    Resolve economics for all tracked LP store offers.
 
-    Admin filters and list_display share this map so changelist loads with
-    exclude-useless / exclude-below-set do not recompute ~1.5k offers
-    multiple times.
+    Lookup order: request stash → Django cache → compute. Filters and
+    list_display share the request-scoped map; the cross-request cache
+    avoids recomputing when operators re-toggle exclude filters.
     """
     cached = getattr(request, _LP_OFFER_ECON_ATTR, None)
     if cached is not None:
         return cached
+    cache_key = lp_offer_econ_cache_key()
+    economics = cache.get(cache_key)
+    if economics is not None:
+        setattr(request, _LP_OFFER_ECON_ATTR, economics)
+        return economics
     offers = list(
         IndustryLpStoreOffer.objects.filter(
             corporation_id__in=tracked_corporation_ids()
@@ -113,6 +162,7 @@ def ensure_lp_offer_econ_on_request(request):
     )
     economics = offer_economics_for_queryset(offers)
     setattr(request, _LP_OFFER_ECON_ATTR, economics)
+    cache.set(cache_key, economics, timeout=_LP_OFFER_ECON_CACHE_TTL)
     return economics
 
 

--- a/backend/industry/admin.py
+++ b/backend/industry/admin.py
@@ -79,6 +79,42 @@ from tribes.models import TribeGroup
 
 logger = logging.getLogger(__name__)
 
+# Request attribute for one shared tracked-catalog economics map per
+# changelist (filters + list_display stash). Avoids N× full recomputes.
+_LP_OFFER_ECON_ATTR = "_lp_offer_econ"
+_LP_ECON_FILTER_PARAMS = (
+    "exclude_useless_offers",
+    "exclude_below_set_lp_price",
+)
+
+
+def _lp_econ_filters_active(request) -> bool:
+    params = getattr(request, "GET", {})
+    return any(
+        params.get(name) in ("0", "1") for name in _LP_ECON_FILTER_PARAMS
+    )
+
+
+def ensure_lp_offer_econ_on_request(request):
+    """
+    Compute economics for all tracked LP store offers once per request.
+
+    Admin filters and list_display share this map so changelist loads with
+    exclude-useless / exclude-below-set do not recompute ~1.5k offers
+    multiple times.
+    """
+    cached = getattr(request, _LP_OFFER_ECON_ATTR, None)
+    if cached is not None:
+        return cached
+    offers = list(
+        IndustryLpStoreOffer.objects.filter(
+            corporation_id__in=tracked_corporation_ids()
+        )
+    )
+    economics = offer_economics_for_queryset(offers)
+    setattr(request, _LP_OFFER_ECON_ATTR, economics)
+    return economics
+
 
 class IndustryLoyaltyPointAccountInline(admin.TabularInline):
     """Edit seller/stockpile holders directly from a loyalty currency."""
@@ -793,6 +829,9 @@ class IndustryLpStoreExcludeUselessOffersFilter(admin.SimpleListFilter):
     stockpile usefulness, profit vs buyback, below peer median, and
     volume/volatility (Forge 30d + spread proxy). See
     industry.helpers.lp_store_useless.
+
+    Economics come from ensure_lp_offer_econ_on_request (shared with the
+    below-set filter and list_display stash for this request).
     """
 
     title = "exclude useless offers"
@@ -805,8 +844,8 @@ class IndustryLpStoreExcludeUselessOffersFilter(admin.SimpleListFilter):
         value = self.value()
         if value not in ("0", "1"):
             return queryset
-        # ~1.5k tracked offers is fine to evaluate in Python via economics.
-        useless = useless_offer_pks(queryset)
+        economics = ensure_lp_offer_econ_on_request(request)
+        useless = useless_offer_pks(queryset, economics=economics)
         if value == "1":
             return queryset.exclude(pk__in=useless)
         return queryset.filter(pk__in=useless)
@@ -819,6 +858,9 @@ class IndustryLpStoreExcludeBelowSetLpPriceFilter(admin.SimpleListFilter):
     Compares conversion_isk_per_lp_sell to IndustryLoyaltyPoint
     default_isk_per_lp for the offer's corporation. Null conversion
     counts as below set (missing prices → cannot beat buyback).
+
+    Reuses request-scoped catalog economics from
+    ensure_lp_offer_econ_on_request when already warmed.
     """
 
     title = "exclude below set LP price"
@@ -831,8 +873,8 @@ class IndustryLpStoreExcludeBelowSetLpPriceFilter(admin.SimpleListFilter):
         value = self.value()
         if value not in ("0", "1"):
             return queryset
-        # ~1.5k tracked offers is fine to evaluate via economics helpers.
-        below = offer_pks_below_set_lp_price(queryset)
+        economics = ensure_lp_offer_econ_on_request(request)
+        below = offer_pks_below_set_lp_price(queryset, economics=economics)
         if value == "1":
             return queryset.exclude(pk__in=below)
         return queryset.filter(pk__in=below)
@@ -937,10 +979,18 @@ class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
         return queryset, use_distinct
 
     def get_changelist_instance(self, request):
+        # Warm full-catalog economics before ChangeList applies filters so
+        # exclude-useless / exclude-below-set share one compute with stash.
+        if _lp_econ_filters_active(request):
+            ensure_lp_offer_econ_on_request(request)
         cl = super().get_changelist_instance(request)
-        IndustryLpStoreOfferAdmin._request_stash = (
-            offer_economics_for_queryset(list(cl.result_list))
-        )
+        cached = getattr(request, _LP_OFFER_ECON_ATTR, None)
+        if cached is not None:
+            IndustryLpStoreOfferAdmin._request_stash = cached
+        else:
+            IndustryLpStoreOfferAdmin._request_stash = (
+                offer_economics_for_queryset(list(cl.result_list))
+            )
         return cl
 
     def changelist_view(self, request, extra_context=None):
@@ -956,6 +1006,8 @@ class IndustryLpStoreOfferAdmin(admin.ModelAdmin):
             return response
         finally:
             IndustryLpStoreOfferAdmin._request_stash = None
+            if hasattr(request, _LP_OFFER_ECON_ATTR):
+                delattr(request, _LP_OFFER_ECON_ATTR)
 
     @classmethod
     def _econ_for(cls, obj):

--- a/backend/industry/helpers/loyalty_store.py
+++ b/backend/industry/helpers/loyalty_store.py
@@ -13,6 +13,7 @@ from django.utils import timezone
 
 from eveonline.client import _esi_to_python, esi_provider
 from eveonline.models import EveLocation
+from industry.helpers.lp_catalog import ensure_eve_types
 from industry.models import (
     IndustryLoyaltyPoint,
     IndustryLpStoreOffer,
@@ -285,6 +286,7 @@ def sync_loyalty_store_offers(
     catalog_types: Set[int] = {b.offer.type_id for b in builds}
     for build in builds:
         catalog_types.update(tid for tid, _ in build.required)
+    ensure_eve_types(catalog_types)
     if enqueue_history:
         _enqueue_history_for_missing_types(catalog_types)
     logger.info(

--- a/backend/industry/helpers/loyalty_store.py
+++ b/backend/industry/helpers/loyalty_store.py
@@ -13,7 +13,10 @@ from django.utils import timezone
 
 from eveonline.client import _esi_to_python, esi_provider
 from eveonline.models import EveLocation
-from industry.helpers.lp_catalog import ensure_eve_types
+from industry.helpers.lp_catalog import (
+    ensure_eve_types,
+    expand_with_navy_hull_type_ids,
+)
 from industry.models import (
     IndustryLoyaltyPoint,
     IndustryLpStoreOffer,
@@ -286,6 +289,8 @@ def sync_loyalty_store_offers(
     catalog_types: Set[int] = {b.offer.type_id for b in builds}
     for build in builds:
         catalog_types.update(tid for tid, _ in build.required)
+    # Include mapped navy hulls — volume/price use hull for BPC offers.
+    catalog_types = expand_with_navy_hull_type_ids(catalog_types)
     ensure_eve_types(catalog_types)
     if enqueue_history:
         _enqueue_history_for_missing_types(catalog_types)

--- a/backend/industry/helpers/lp_catalog.py
+++ b/backend/industry/helpers/lp_catalog.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
-from typing import List
+import logging
+from typing import Iterable, List, Set
+
+from django.db.models import Q
+from eveuniverse.models import EveType
 
 from industry.models import (
     IndustryLpStoreOffer,
     IndustryLpStoreOfferRequiredItem,
 )
+
+logger = logging.getLogger(__name__)
+
+# Eve SDE: Criminal Tags (Angel/Blood/Domination/Navy tags, etc.)
+CRIMINAL_TAGS_GROUP_ID = 370
 
 
 def lp_catalog_type_ids() -> List[int]:
@@ -19,3 +28,57 @@ def lp_catalog_type_ids() -> List[int]:
         "type_id", flat=True
     ).distinct()
     return sorted({int(t) for t in offer_types} | {int(t) for t in req_types})
+
+
+def ensure_eve_types(type_ids: Iterable[int]) -> Set[int]:
+    """
+    Load missing EveType rows from ESI.
+
+    Batch-checks local existence, then calls get_or_create_esi only for
+    missing IDs (no admin N+1). Returns the set of type IDs that were
+    fetched (or attempted). Failures are logged and skipped so one bad
+    type does not break sync / economics.
+    """
+    unique = sorted({int(t) for t in type_ids if int(t) > 0})
+    if not unique:
+        return set()
+    existing = set(
+        EveType.objects.filter(id__in=unique).values_list("id", flat=True)
+    )
+    missing = [tid for tid in unique if tid not in existing]
+    fetched: Set[int] = set()
+    for type_id in missing:
+        try:
+            EveType.objects.get_or_create_esi(id=type_id)
+            fetched.add(type_id)
+        except Exception:  # noqa: BLE001 — ESI / SDE edge cases
+            logger.warning(
+                "Failed to ensure EveType %s for LP catalog",
+                type_id,
+                exc_info=True,
+            )
+    if fetched:
+        logger.info(
+            "Loaded %s missing EveType(s) for LP catalog", len(fetched)
+        )
+    return fetched
+
+
+def tag_type_ids() -> List[int]:
+    """
+    EveType IDs that are LP-store tags (Criminal Tags group or '* Tag' name).
+    """
+    return list(
+        EveType.objects.filter(
+            Q(eve_group_id=CRIMINAL_TAGS_GROUP_ID) | Q(name__iendswith=" Tag")
+        ).values_list("id", flat=True)
+    )
+
+
+def supply_package_type_ids() -> List[int]:
+    """EveType IDs whose name contains 'Supply Package' (militia LP crates)."""
+    return list(
+        EveType.objects.filter(name__icontains="Supply Package").values_list(
+            "id", flat=True
+        )
+    )

--- a/backend/industry/helpers/lp_catalog.py
+++ b/backend/industry/helpers/lp_catalog.py
@@ -82,3 +82,18 @@ def supply_package_type_ids() -> List[int]:
             "id", flat=True
         )
     )
+
+
+def chip_type_ids() -> List[int]:
+    """
+    EveType IDs whose name contains 'Nexus Chip' (faction LP store chips).
+
+    Matches Minmatar/Caldari/Gallente/Amarr Nexus Chips used as required
+    items. Deliberately avoids a broad '* Chip' suffix, which would also
+    catch Social Adaptation Chip implants.
+    """
+    return list(
+        EveType.objects.filter(name__icontains="Nexus Chip").values_list(
+            "id", flat=True
+        )
+    )

--- a/backend/industry/helpers/lp_catalog.py
+++ b/backend/industry/helpers/lp_catalog.py
@@ -3,20 +3,27 @@
 from __future__ import annotations
 
 import logging
-from typing import Iterable, List, Set
+from typing import Dict, Iterable, List, Set
 
 from django.db.models import Q
 from eveuniverse.models import EveType
 
+from industry.helpers.blueprint_efficiency import is_faction_navy_hull
+from industry.helpers.type_breakdown import get_blueprint_or_reaction_type_id
 from industry.models import (
     IndustryLpStoreOffer,
     IndustryLpStoreOfferRequiredItem,
+    IndustryProduct,
 )
 
 logger = logging.getLogger(__name__)
 
 # Eve SDE: Criminal Tags (Angel/Blood/Domination/Navy tags, etc.)
 CRIMINAL_TAGS_GROUP_ID = 370
+
+# Duplicated from product_unit_cost to avoid loyalty_store circular imports.
+TALWAR_FI_TYPE_ID = 91858
+TALWAR_FI_BPC_TYPE_ID = 91862
 
 
 def lp_catalog_type_ids() -> List[int]:
@@ -28,6 +35,46 @@ def lp_catalog_type_ids() -> List[int]:
         "type_id", flat=True
     ).distinct()
     return sorted({int(t) for t in offer_types} | {int(t) for t in req_types})
+
+
+def navy_bpc_to_hull_type_ids() -> Dict[int, int]:
+    """Map faction navy BPC type_id → tradeable hull type_id."""
+    mapping: Dict[int, int] = {TALWAR_FI_BPC_TYPE_ID: TALWAR_FI_TYPE_ID}
+    products = IndustryProduct.objects.select_related(
+        "eve_type", "eve_type__eve_group", "eve_type__eve_group__eve_category"
+    ).filter(eve_type_id__isnull=False)
+    for product in products:
+        eve_type = product.eve_type
+        if not is_faction_navy_hull(eve_type):
+            continue
+        bpc_id = get_blueprint_or_reaction_type_id(eve_type)
+        if bpc_id is None:
+            continue
+        mapping[int(bpc_id)] = int(eve_type.id)
+    return mapping
+
+
+def expand_with_navy_hull_type_ids(type_ids: Iterable[int]) -> Set[int]:
+    """
+    Add mapped navy hulls when a BPC type is present.
+
+    LP offer volume/price columns look up the hull for BPC offers, so Forge
+    history must cover those hulls even when only the BPC is in the catalog.
+    """
+    ids = {int(t) for t in type_ids if int(t) > 0}
+    if not ids:
+        return set()
+    bpc_map = navy_bpc_to_hull_type_ids()
+    for tid in list(ids):
+        hull_id = bpc_map.get(tid)
+        if hull_id is not None:
+            ids.add(int(hull_id))
+    return ids
+
+
+def lp_market_history_type_ids() -> List[int]:
+    """Type IDs that need Forge market history for LP store economics."""
+    return sorted(expand_with_navy_hull_type_ids(lp_catalog_type_ids()))
 
 
 def ensure_eve_types(type_ids: Iterable[int]) -> Set[int]:

--- a/backend/industry/helpers/lp_catalog.py
+++ b/backend/industry/helpers/lp_catalog.py
@@ -113,11 +113,17 @@ def ensure_eve_types(type_ids: Iterable[int]) -> Set[int]:
 
 def tag_type_ids() -> List[int]:
     """
-    EveType IDs that are LP-store tags (Criminal Tags group or '* Tag' name).
+    EveType IDs that are LP-store tags / faction insignias.
+
+    Matches Criminal Tags group, names ending '* Tag', or names containing
+    'Insignia' (Imperial/Caldari/Gallente/Minmatar navy rank insignias used
+    as LP required items).
     """
     return list(
         EveType.objects.filter(
-            Q(eve_group_id=CRIMINAL_TAGS_GROUP_ID) | Q(name__iendswith=" Tag")
+            Q(eve_group_id=CRIMINAL_TAGS_GROUP_ID)
+            | Q(name__iendswith=" Tag")
+            | Q(name__icontains="Insignia")
         ).values_list("id", flat=True)
     )
 

--- a/backend/industry/helpers/lp_store_economics.py
+++ b/backend/industry/helpers/lp_store_economics.py
@@ -424,6 +424,8 @@ def annotate_lp_store_offer_sort_fields(queryset):
     qs = queryset.annotate(
         sort_type_name=Subquery(type_name_sq),
         sort_jita_price=Subquery(hist_avg_sq),
+        sort_jita_sell=Subquery(hist_avg_sq),
+        sort_jita_buy=Subquery(hist_avg_sq),
         sort_volume_1d=Subquery(_volume_sq(1)),
         sort_volume_7d=Subquery(_volume_sq(7)),
         sort_volume_30d=Subquery(_volume_sq(30)),

--- a/backend/industry/helpers/lp_store_economics.py
+++ b/backend/industry/helpers/lp_store_economics.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 from django.db import ProgrammingError
 from django.db.models import (
@@ -58,6 +58,13 @@ from market.helpers.pricing import (
 )
 from market.models import EveMarketItemLocationPrice
 from market.models.history import EveMarketItemHistory
+
+# Forge 30d traded units below this (or missing history) = negligible LP
+# liquidity. Fuzzwork's "5% Volume" is order-book depth (qty within 5% of
+# best price); we only store LocationPrice bests, so 30d history volume is
+# the pragmatic viability proxy. Threshold 1 keeps thin ship markets
+# (1–5 hulls/month) while dropping truly dead / unsynced types.
+NEGLIGIBLE_LP_FORGE_VOLUME_30D = 1
 
 
 @dataclass(frozen=True)
@@ -120,6 +127,64 @@ def bpc_type_id_to_product_type_id() -> Dict[int, int]:
             continue
         mapping[int(bpc_id)] = int(eve_type.id)
     return mapping
+
+
+def market_type_ids_with_viable_forge_volume(
+    type_ids: Optional[Iterable[int]] = None,
+    *,
+    min_volume_30d: int = NEGLIGIBLE_LP_FORGE_VOLUME_30D,
+) -> Set[int]:
+    """
+    Market type IDs with Forge 30d history volume >= ``min_volume_30d``.
+
+    Types with no recent history rows are omitted (treated as negligible by
+    callers). Requires EveMarketItemHistory sync for LP catalog types.
+    When ``type_ids`` is given, only those IDs are considered.
+    """
+    region_id = _baseline_region_id()
+    cutoff = timezone.now().date() - timedelta(days=30)
+    qs = EveMarketItemHistory.objects.filter(
+        region_id=region_id,
+        date__gte=cutoff,
+    )
+    if type_ids is not None:
+        unique = {int(t) for t in type_ids if int(t) > 0}
+        if not unique:
+            return set()
+        qs = qs.filter(item_id__in=unique)
+    rows = (
+        qs.values("item_id")
+        .annotate(total=Sum("volume"))
+        .filter(total__gte=int(min_volume_30d))
+        .values_list("item_id", flat=True)
+    )
+    return {int(item_id) for item_id in rows}
+
+
+def offer_type_ids_with_viable_forge_volume(
+    offer_type_ids: Iterable[int],
+    *,
+    min_volume_30d: int = NEGLIGIBLE_LP_FORGE_VOLUME_30D,
+    bpc_to_hull: Optional[Dict[int, int]] = None,
+) -> Set[int]:
+    """
+    Offer ``type_id``s whose market type (hull for navy BPCs) clears the
+    30d Forge volume floor. Missing history → not viable.
+    """
+    unique = {int(t) for t in offer_type_ids if int(t) > 0}
+    if not unique:
+        return set()
+    mapping = (
+        bpc_to_hull
+        if bpc_to_hull is not None
+        else bpc_type_id_to_product_type_id()
+    )
+    market_ids = {mapping.get(tid, tid) for tid in unique}
+    viable_market = market_type_ids_with_viable_forge_volume(
+        market_ids,
+        min_volume_30d=min_volume_30d,
+    )
+    return {tid for tid in unique if mapping.get(tid, tid) in viable_market}
 
 
 def _acquisition_isk_per_unit(

--- a/backend/industry/helpers/lp_store_economics.py
+++ b/backend/industry/helpers/lp_store_economics.py
@@ -1,20 +1,34 @@
 """Economics helpers for admin LP store offer price tracking.
 
 Conversion rates (isk/lp buy & sell) use baseline LocationPrice buy/sell when
-present, else Forge history via get_prices_by_type_id. Alliance buyback
-acquisition/profit columns remain separate.
+present, else Forge history via get_prices_by_type_id. Admin Cost / Profit
+columns use per-offer acquisition (LP×buyback rate + ISK + required items),
+not planner build cost — Fuzzwork-style offer comparison.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Dict, Iterable, List, Optional, Tuple
 
 from django.db import ProgrammingError
+from django.db.models import (
+    ExpressionWrapper,
+    F,
+    FloatField,
+    OuterRef,
+    Subquery,
+    Sum,
+    Value,
+)
+from django.db.models.functions import Coalesce, Greatest
+from django.utils import timezone
 from eveonline.models import EveLocation
 from eveuniverse.models import EveType
 
 from industry.helpers.blueprint_efficiency import is_faction_navy_hull
+from industry.helpers.lp_catalog import ensure_eve_types
 from industry.helpers.loyalty_store import resolve_isk_per_lp
 from industry.helpers.product_unit_cost import (
     TALWAR_FI_BPC_TYPE_ID,
@@ -29,10 +43,13 @@ from industry.models import (
     IndustryProduct,
 )
 from market.helpers.pricing import (
+    VOLUME_WINDOWS,
+    _baseline_region_id,
     get_prices_by_type_id,
-    get_volume_90d_by_type_id,
+    get_volume_windows_by_type_id,
 )
 from market.models import EveMarketItemLocationPrice
+from market.models.history import EveMarketItemHistory
 
 
 @dataclass(frozen=True)
@@ -57,7 +74,9 @@ class LpStoreOfferEconomics:
     jita_buy: Optional[int]
     conversion_isk_per_lp_sell: Optional[float]
     conversion_isk_per_lp_buy: Optional[float]
-    volume_90d: Optional[int]
+    volume_1d: Optional[int]
+    volume_7d: Optional[int]
+    volume_30d: Optional[int]
     build_cost_per_unit: Optional[int]
     cost_per_unit: Optional[int]
     kind: str
@@ -164,6 +183,96 @@ def _conversion_isk_per_lp(
     return (market_price * offer_qty - isk_cost - extras) / float(lp_cost)
 
 
+def annotate_lp_store_offer_sort_fields(queryset):
+    """
+    Annotate admin sort keys for economics columns.
+
+    Display values still come from offer_economics_for_queryset (accurate
+    hull mapping, required-item other cost). Sort annotations use offer
+    type_id history + currency default ISK/LP and ignore required-item
+    other cost — good enough for Fuzzwork-style ranking.
+    """
+    region_id = _baseline_region_id()
+    today = timezone.now().date()
+
+    type_name_sq = EveType.objects.filter(id=OuterRef("type_id")).values(
+        "name"
+    )[:1]
+    hist_avg_sq = (
+        EveMarketItemHistory.objects.filter(
+            region_id=region_id,
+            item_id=OuterRef("type_id"),
+        )
+        .order_by("-date")
+        .values("average")[:1]
+    )
+    currency_ipl_sq = IndustryLoyaltyPoint.objects.filter(
+        corporation_id=OuterRef("corporation_id"),
+        is_active=True,
+    ).values("default_isk_per_lp")[:1]
+
+    def _volume_sq(days: int):
+        cutoff = today - timedelta(days=days)
+        return (
+            EveMarketItemHistory.objects.filter(
+                region_id=region_id,
+                item_id=OuterRef("type_id"),
+                date__gte=cutoff,
+            )
+            .values("item_id")
+            .annotate(total=Sum("volume"))
+            .values("total")[:1]
+        )
+
+    qs = queryset.annotate(
+        sort_type_name=Subquery(type_name_sq),
+        sort_jita_price=Subquery(hist_avg_sq),
+        sort_volume_1d=Subquery(_volume_sq(1)),
+        sort_volume_7d=Subquery(_volume_sq(7)),
+        sort_volume_30d=Subquery(_volume_sq(30)),
+        sort_isk_per_lp=Subquery(currency_ipl_sq),
+    )
+    # Acquisition / conversion / profit approximations without other_cost.
+    qs = qs.annotate(
+        sort_acquisition=ExpressionWrapper(
+            (
+                F("lp_cost") * Coalesce(F("sort_isk_per_lp"), Value(0.0))
+                + F("isk_cost")
+            )
+            / Greatest(F("quantity"), Value(1)),
+            output_field=FloatField(),
+        ),
+        sort_conversion_sell=ExpressionWrapper(
+            (
+                Coalesce(F("sort_jita_price"), Value(0.0)) * F("quantity")
+                - F("isk_cost")
+            )
+            / Greatest(F("lp_cost"), Value(1)),
+            output_field=FloatField(),
+        ),
+        sort_conversion_buy=ExpressionWrapper(
+            (
+                Coalesce(F("sort_jita_price"), Value(0.0)) * F("quantity")
+                - F("isk_cost")
+            )
+            / Greatest(F("lp_cost"), Value(1)),
+            output_field=FloatField(),
+        ),
+        sort_profit=ExpressionWrapper(
+            Coalesce(F("sort_jita_price"), Value(0.0))
+            - (
+                (
+                    F("lp_cost") * Coalesce(F("sort_isk_per_lp"), Value(0.0))
+                    + F("isk_cost")
+                )
+                / Greatest(F("quantity"), Value(1))
+            ),
+            output_field=FloatField(),
+        ),
+    )
+    return qs
+
+
 def offer_economics_for_queryset(
     offers: Iterable[IndustryLpStoreOffer],
 ) -> Dict[int, LpStoreOfferEconomics]:
@@ -203,9 +312,12 @@ def offer_economics_for_queryset(
     }
     req_type_ids = {tid for items in req_by_offer.values() for tid, _ in items}
     market_type_ids = sorted(offer_type_ids | product_type_ids | req_type_ids)
+    ensure_eve_types(market_type_ids)
     history_prices = get_prices_by_type_id(market_type_ids)
     location_prices = _baseline_location_prices(market_type_ids)
-    volumes = get_volume_90d_by_type_id(market_type_ids)
+    volume_windows = get_volume_windows_by_type_id(
+        market_type_ids, windows=VOLUME_WINDOWS
+    )
     type_names = {
         tid: (name or str(tid))
         for tid, name in EveType.objects.filter(
@@ -258,12 +370,14 @@ def offer_economics_for_queryset(
             kind = "blueprint"
             market_type_id = product_type_id
             build_cost = build_costs.get(product_type_id)
-            cost_per_unit = build_cost
         else:
             kind = "input"
             market_type_id = type_id
             build_cost = None
-            cost_per_unit = acquisition
+
+        # Fuzzwork-style: Cost/Profit compare LP-store acquisition per unit,
+        # not planner build cost (which is identical across same-hull BPCs).
+        cost_per_unit = acquisition
 
         jita_sell, jita_buy = _resolve_sell_buy(
             market_type_id,
@@ -289,6 +403,7 @@ def offer_economics_for_queryset(
             other_cost=other_cost,
             lp_cost=offer.lp_cost,
         )
+        vols = volume_windows.get(market_type_id) or {}
 
         out[offer.pk] = LpStoreOfferEconomics(
             pk=offer.pk,
@@ -313,7 +428,9 @@ def offer_economics_for_queryset(
             jita_buy=jita_buy,
             conversion_isk_per_lp_sell=conv_sell,
             conversion_isk_per_lp_buy=conv_buy,
-            volume_90d=volumes.get(market_type_id),
+            volume_1d=vols.get(1),
+            volume_7d=vols.get(7),
+            volume_30d=vols.get(30),
             build_cost_per_unit=build_cost,
             cost_per_unit=cost_per_unit,
             kind=kind,

--- a/backend/industry/helpers/lp_store_economics.py
+++ b/backend/industry/helpers/lp_store_economics.py
@@ -187,42 +187,6 @@ def offer_type_ids_with_viable_forge_volume(
     return {tid for tid in unique if mapping.get(tid, tid) in viable_market}
 
 
-def offer_is_below_set_lp_price(econ: LpStoreOfferEconomics) -> bool:
-    """
-    True when ISK/LP sell conversion is worse than alliance buyback.
-
-    Below-set means ``conversion_isk_per_lp_sell`` is null or strictly
-    less than the currency's ``default_isk_per_lp`` (``econ.isk_per_lp``).
-    Exact equality counts as at/above the set buy price.
-    """
-    rate = econ.conversion_isk_per_lp_sell
-    if rate is None:
-        return True
-    buyback = econ.isk_per_lp
-    if buyback is None:
-        return True
-    return float(rate) < float(buyback)
-
-
-def offer_pks_below_set_lp_price(
-    offers: Iterable[IndustryLpStoreOffer],
-) -> Set[int]:
-    """Primary keys of offers below the currency's set LP buy price."""
-    rows = list(offers)
-    if not rows:
-        return set()
-    economics = offer_economics_for_queryset(rows)
-    below: Set[int] = set()
-    for offer in rows:
-        pk = offer.pk
-        if pk is None:
-            continue
-        row = economics.get(pk)
-        if row is None or offer_is_below_set_lp_price(row):
-            below.add(pk)
-    return below
-
-
 def _acquisition_isk_per_unit(
     offer: IndustryLpStoreOffer,
     isk_per_lp: Optional[float],

--- a/backend/industry/helpers/lp_store_economics.py
+++ b/backend/industry/helpers/lp_store_economics.py
@@ -1,9 +1,14 @@
 """Economics helpers for admin LP store offer price tracking.
 
-Conversion rates (isk/lp buy & sell) use baseline LocationPrice buy/sell when
-present, else Forge history via get_prices_by_type_id. Admin Cost / Profit
-columns use per-offer acquisition (LP×buyback rate + ISK + required items),
-not planner build cost — Fuzzwork-style offer comparison.
+Conversion rates (isk/lp buy & sell) follow Fuzzwork's LP store formula:
+  (market_price * qty - isk_cost - other_cost) / lp_cost
+where other_cost is LP-store required items plus, for blueprints, SDE
+manufacturing materials × offer quantity (Fuzzwork "Materials to build" at
+PE5 / ME0). Market prices use baseline LocationPrice buy/sell when present,
+else Forge history via get_prices_by_type_id.
+
+Acquisition (LP×buyback rate + ISK + LP required items only) stays separate
+from conversion — it is the LP-desk cost, not finished-hull build cost.
 """
 
 from __future__ import annotations
@@ -25,7 +30,7 @@ from django.db.models import (
 from django.db.models.functions import Coalesce, Greatest
 from django.utils import timezone
 from eveonline.models import EveLocation
-from eveuniverse.models import EveType
+from eveuniverse.models import EveIndustryActivityMaterial, EveType
 
 from industry.helpers.blueprint_efficiency import is_faction_navy_hull
 from industry.helpers.lp_catalog import ensure_eve_types
@@ -35,7 +40,10 @@ from industry.helpers.product_unit_cost import (
     TALWAR_FI_TYPE_ID,
     plan_product_unit_cost,
 )
-from industry.helpers.type_breakdown import get_blueprint_or_reaction_type_id
+from industry.helpers.type_breakdown import (
+    ACTIVITY_MANUFACTURING,
+    get_blueprint_or_reaction_type_id,
+)
 from industry.models import (
     IndustryLoyaltyPoint,
     IndustryLpStoreOffer,
@@ -183,6 +191,87 @@ def _conversion_isk_per_lp(
     return (market_price * offer_qty - isk_cost - extras) / float(lp_cost)
 
 
+def manufacturing_materials_by_blueprint_type_id(
+    type_ids: Iterable[int],
+) -> Dict[int, List[Tuple[int, int]]]:
+    """
+    SDE manufacturing bill of materials keyed by blueprint type_id.
+
+    Quantities are ME0 / max Production Efficiency (Fuzzwork PE5) base runs.
+    Blueprints with no manufacturing rows are omitted.
+    """
+    unique = list({int(t) for t in type_ids})
+    if not unique:
+        return {}
+    out: Dict[int, List[Tuple[int, int]]] = {}
+    for bpc_id, mat_id, qty in EveIndustryActivityMaterial.objects.filter(
+        eve_type_id__in=unique,
+        activity_id=ACTIVITY_MANUFACTURING,
+    ).values_list("eve_type_id", "material_eve_type_id", "quantity"):
+        out.setdefault(int(bpc_id), []).append((int(mat_id), int(qty)))
+    return out
+
+
+def _priced_material_pack_cost(
+    materials: List[Tuple[int, int]],
+    *,
+    runs: int,
+    location_prices: Dict[int, Tuple[Optional[int], Optional[int]]],
+    history_prices: Dict[int, int],
+) -> Optional[int]:
+    """Sum sell×qty×runs for a BOM; None if any material lacks a price."""
+    if not materials:
+        return 0
+    total = 0
+    for mat_type_id, mat_qty in materials:
+        sell, _ = _resolve_sell_buy(
+            mat_type_id,
+            location_prices=location_prices,
+            history_prices=history_prices,
+        )
+        if sell is None:
+            return None
+        total += sell * mat_qty * runs
+    return total
+
+
+def _lp_store_required_cost(
+    required: List[Tuple[int, int]],
+    *,
+    location_prices: Dict[int, Tuple[Optional[int], Optional[int]]],
+    history_prices: Dict[int, int],
+    type_names: Dict[int, str],
+) -> Tuple[Optional[int], List[str]]:
+    """Return (LP-desk other cost, summary parts) for required items."""
+    if not required:
+        return 0, []
+    total = 0
+    priced = True
+    parts: List[str] = []
+    for req_type_id, req_qty in required:
+        sell, _ = _resolve_sell_buy(
+            req_type_id,
+            location_prices=location_prices,
+            history_prices=history_prices,
+        )
+        name = type_names.get(req_type_id, str(req_type_id))
+        parts.append(f"{name} x{req_qty}")
+        if sell is None:
+            priced = False
+        else:
+            total += sell * req_qty
+    return (total if priced else None), parts
+
+
+def _fuzzwork_other_cost(
+    lp_store_other: Optional[int],
+    build_mats_other: Optional[int],
+) -> Optional[int]:
+    if lp_store_other is None or build_mats_other is None:
+        return None
+    return int(lp_store_other) + int(build_mats_other)
+
+
 def annotate_lp_store_offer_sort_fields(queryset):
     """
     Annotate admin sort keys for economics columns.
@@ -311,7 +400,13 @@ def offer_economics_for_queryset(
         bpc_to_product[tid] for tid in offer_type_ids if tid in bpc_to_product
     }
     req_type_ids = {tid for items in req_by_offer.values() for tid, _ in items}
-    market_type_ids = sorted(offer_type_ids | product_type_ids | req_type_ids)
+    bom_by_bpc = manufacturing_materials_by_blueprint_type_id(offer_type_ids)
+    bom_type_ids = {
+        mat_id for mats in bom_by_bpc.values() for mat_id, _ in mats
+    }
+    market_type_ids = sorted(
+        offer_type_ids | product_type_ids | req_type_ids | bom_type_ids
+    )
     ensure_eve_types(market_type_ids)
     history_prices = get_prices_by_type_id(market_type_ids)
     location_prices = _baseline_location_prices(market_type_ids)
@@ -344,26 +439,27 @@ def offer_economics_for_queryset(
         isk_per_lp = resolve_isk_per_lp(requested=None, corporation_id=corp_id)
 
         required = req_by_offer.get(int(offer.pk), []) if offer.pk else []
-        other_cost: Optional[int] = 0 if not required else None
-        req_parts: List[str] = []
-        if required:
-            total = 0
-            priced = True
-            for req_type_id, req_qty in required:
-                sell, _ = _resolve_sell_buy(
-                    req_type_id,
-                    location_prices=location_prices,
-                    history_prices=history_prices,
-                )
-                name = type_names.get(req_type_id, str(req_type_id))
-                req_parts.append(f"{name} x{req_qty}")
-                if sell is None:
-                    priced = False
-                else:
-                    total += sell * req_qty
-            other_cost = total if priced else None
+        lp_store_other, req_parts = _lp_store_required_cost(
+            required,
+            location_prices=location_prices,
+            history_prices=history_prices,
+            type_names=type_names,
+        )
 
-        acquisition = _acquisition_isk_per_unit(offer, isk_per_lp, other_cost)
+        # Fuzzwork: Other Cost = LP required items + materials to build
+        # (manufacturing BOM × offer quantity). Acquisition stays LP-desk only.
+        runs = max(offer.quantity, 1)
+        build_mats_other = _priced_material_pack_cost(
+            bom_by_bpc.get(type_id, []),
+            runs=runs,
+            location_prices=location_prices,
+            history_prices=history_prices,
+        )
+        other_cost = _fuzzwork_other_cost(lp_store_other, build_mats_other)
+
+        acquisition = _acquisition_isk_per_unit(
+            offer, isk_per_lp, lp_store_other
+        )
 
         product_type_id = bpc_to_product.get(type_id)
         if product_type_id is not None:
@@ -375,8 +471,8 @@ def offer_economics_for_queryset(
             market_type_id = type_id
             build_cost = None
 
-        # Fuzzwork-style: Cost/Profit compare LP-store acquisition per unit,
-        # not planner build cost (which is identical across same-hull BPCs).
+        # Cost/Profit compare LP-store acquisition per unit, not planner
+        # build cost (identical across same-hull BPCs) and not BOM other cost.
         cost_per_unit = acquisition
 
         jita_sell, jita_buy = _resolve_sell_buy(
@@ -391,14 +487,14 @@ def offer_economics_for_queryset(
         )
         conv_sell = _conversion_isk_per_lp(
             market_price=jita_sell,
-            offer_qty=max(offer.quantity, 1),
+            offer_qty=runs,
             isk_cost=offer.isk_cost,
             other_cost=other_cost,
             lp_cost=offer.lp_cost,
         )
         conv_buy = _conversion_isk_per_lp(
             market_price=jita_buy,
-            offer_qty=max(offer.quantity, 1),
+            offer_qty=runs,
             isk_cost=offer.isk_cost,
             other_cost=other_cost,
             lp_cost=offer.lp_cost,

--- a/backend/industry/helpers/lp_store_economics.py
+++ b/backend/industry/helpers/lp_store_economics.py
@@ -206,12 +206,19 @@ def offer_is_below_set_lp_price(econ: LpStoreOfferEconomics) -> bool:
 
 def offer_pks_below_set_lp_price(
     offers: Iterable[IndustryLpStoreOffer],
+    *,
+    economics: Optional[Dict[int, LpStoreOfferEconomics]] = None,
 ) -> Set[int]:
-    """Primary keys of offers below the currency's set LP buy price."""
+    """Primary keys of offers below the currency's set LP buy price.
+
+    Pass a precomputed ``economics`` map (e.g. request-scoped catalog cache)
+    to avoid recomputing offer_economics_for_queryset per filter.
+    """
     rows = list(offers)
     if not rows:
         return set()
-    economics = offer_economics_for_queryset(rows)
+    if economics is None:
+        economics = offer_economics_for_queryset(rows)
     below: Set[int] = set()
     for offer in rows:
         pk = offer.pk

--- a/backend/industry/helpers/lp_store_economics.py
+++ b/backend/industry/helpers/lp_store_economics.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Iterable, List, Optional, Tuple
 
+from django.db import ProgrammingError
 from eveonline.models import EveLocation
 from eveuniverse.models import EveType
 
@@ -179,15 +180,16 @@ def offer_economics_for_queryset(
         pk: [] for pk in offer_ids
     }
 
-    for (
-        offer_pk,
-        type_id,
-        qty,
-    ) in IndustryLpStoreOfferRequiredItem.objects.filter(
-        offer_id__in=offer_ids
-    ).values_list(
-        "offer_id", "type_id", "quantity"
-    ):
+    try:
+        req_rows = list(
+            IndustryLpStoreOfferRequiredItem.objects.filter(
+                offer_id__in=offer_ids
+            ).values_list("offer_id", "type_id", "quantity")
+        )
+    except ProgrammingError:
+        # Migration for required-items table may not be applied yet.
+        req_rows = []
+    for offer_pk, type_id, qty in req_rows:
         req_by_offer.setdefault(int(offer_pk), []).append(
             (int(type_id), int(qty))
         )

--- a/backend/industry/helpers/lp_store_economics.py
+++ b/backend/industry/helpers/lp_store_economics.py
@@ -187,6 +187,42 @@ def offer_type_ids_with_viable_forge_volume(
     return {tid for tid in unique if mapping.get(tid, tid) in viable_market}
 
 
+def offer_is_below_set_lp_price(econ: LpStoreOfferEconomics) -> bool:
+    """
+    True when ISK/LP sell conversion is worse than alliance buyback.
+
+    Below-set means ``conversion_isk_per_lp_sell`` is null or strictly
+    less than the currency's ``default_isk_per_lp`` (``econ.isk_per_lp``).
+    Exact equality counts as at/above the set buy price.
+    """
+    rate = econ.conversion_isk_per_lp_sell
+    if rate is None:
+        return True
+    buyback = econ.isk_per_lp
+    if buyback is None:
+        return True
+    return float(rate) < float(buyback)
+
+
+def offer_pks_below_set_lp_price(
+    offers: Iterable[IndustryLpStoreOffer],
+) -> Set[int]:
+    """Primary keys of offers below the currency's set LP buy price."""
+    rows = list(offers)
+    if not rows:
+        return set()
+    economics = offer_economics_for_queryset(rows)
+    below: Set[int] = set()
+    for offer in rows:
+        pk = offer.pk
+        if pk is None:
+            continue
+        row = economics.get(pk)
+        if row is None or offer_is_below_set_lp_price(row):
+            below.add(pk)
+    return below
+
+
 def _acquisition_isk_per_unit(
     offer: IndustryLpStoreOffer,
     isk_per_lp: Optional[float],

--- a/backend/industry/helpers/lp_store_useless.py
+++ b/backend/industry/helpers/lp_store_useless.py
@@ -229,12 +229,20 @@ def offer_is_useless(
 
 def useless_offer_pks(
     offers: Iterable[IndustryLpStoreOffer],
+    *,
+    economics: Optional[Dict[int, LpStoreOfferEconomics]] = None,
 ) -> Set[int]:
-    """Compute primary keys of useless offers for an admin filter queryset."""
+    """Compute primary keys of useless offers for an admin filter queryset.
+
+    Pass a precomputed ``economics`` map (e.g. request-scoped full catalog)
+    to avoid recomputing offer_economics_for_queryset. Peer medians always
+    come from that map so they stay stable across stacked admin filters.
+    """
     rows = list(offers)
     if not rows:
         return set()
-    economics = offer_economics_for_queryset(rows)
+    if economics is None:
+        economics = offer_economics_for_queryset(rows)
     peers = peer_stats_by_corporation(economics)
     useless: Set[int] = set()
     for offer in rows:

--- a/backend/industry/helpers/lp_store_useless.py
+++ b/backend/industry/helpers/lp_store_useless.py
@@ -1,0 +1,250 @@
+"""Exclude-useless-offers screening for LP store admin.
+
+An offer is useless when it fails any of:
+1. Stockpile usefulness — cannot clear meaningful LP/ISK from a 250k–1M
+   dump, or Forge 30d volume cannot absorb that dump.
+2. Profit — conversion sell ISK/LP is null or ≤ alliance buyback
+   (``default_isk_per_lp``), or acquisition ≥ jita sell.
+3. Below peer average — conversion sell < ratio × median of
+   volume-viable same-currency peers.
+4. Volume / volatility — negligible Forge 30d volume (null or < 1),
+   missing jita buy, or wide relative spread.
+
+Volatility/depth proxy: we do not store Fuzzwork "5% Volume" order-book
+depth (qty within 5% of best). Missing buy or ``(sell−buy)/sell`` above
+``USELESS_MAX_RELATIVE_SPREAD`` stands in for shallow books; 30d history
+volume remains the liquidity floor.
+"""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Set
+
+from industry.helpers.lp_store_economics import (
+    NEGLIGIBLE_LP_FORGE_VOLUME_30D,
+    LpStoreOfferEconomics,
+    offer_economics_for_queryset,
+)
+from industry.models import IndustryLpStoreOffer
+
+# ---------------------------------------------------------------------------
+# Tunable thresholds
+# ---------------------------------------------------------------------------
+# Typical alliance LP stockpile band for conversion-desk dumps.
+USELESS_STOCKPILE_LP_LOW = 250_000
+USELESS_STOCKPILE_LP_HIGH = 1_000_000
+# Absolute ISK floor from dumping LOW stockpile (or one purchase when LP
+# cost exceeds LOW but not HIGH). ~200 isk/lp × 250k LP ≈ 50M — soft floor
+# for "trivial cash"; offers below buyback still fail the profit rule.
+USELESS_MIN_ISK_FROM_STOCKPILE = 50_000_000
+# Conversion sell below this fraction of same-currency median among
+# volume-viable peers → significantly below average.
+USELESS_BELOW_MEDIAN_RATIO = 0.75
+# Relative bid/ask spread (sell − buy) / sell. Above this ⇒ too thin /
+# volatile (depth proxy; see module docstring).
+USELESS_MAX_RELATIVE_SPREAD = 0.40
+
+
+@dataclass(frozen=True)
+class CurrencyPeerStats:
+    """Per-currency stats for below-average checks among volume-viable peers."""
+
+    median_conversion_sell: Optional[float]
+    viable_count: int
+
+
+def _purchases_for_stockpile(lp_cost: int, stockpile_lp: int) -> int:
+    if lp_cost <= 0:
+        return 0
+    return int(stockpile_lp) // int(lp_cost)
+
+
+def _stockpile_dump_lp_spent(lp_cost: int) -> Optional[int]:
+    """
+    LP spent when dumping a typical stockpile through this offer.
+
+    Prefer a LOW-band dump when at least one purchase fits; otherwise one
+    purchase if the offer is still affordable from the HIGH band.
+    """
+    if lp_cost <= 0:
+        return None
+    low_buys = _purchases_for_stockpile(lp_cost, USELESS_STOCKPILE_LP_LOW)
+    if low_buys >= 1:
+        return low_buys * lp_cost
+    high_buys = _purchases_for_stockpile(lp_cost, USELESS_STOCKPILE_LP_HIGH)
+    if high_buys >= 1:
+        return lp_cost
+    return None
+
+
+def _stockpile_dump_units(econ: LpStoreOfferEconomics) -> int:
+    """Units from dumping HIGH stockpile through this offer."""
+    buys = _purchases_for_stockpile(econ.lp_cost, USELESS_STOCKPILE_LP_HIGH)
+    return buys * max(int(econ.quantity), 1)
+
+
+def _relative_spread(
+    jita_sell: Optional[int], jita_buy: Optional[int]
+) -> Optional[float]:
+    if jita_sell is None or jita_buy is None or jita_sell <= 0:
+        return None
+    return (float(jita_sell) - float(jita_buy)) / float(jita_sell)
+
+
+def _has_viable_forge_volume(econ: LpStoreOfferEconomics) -> bool:
+    return (
+        econ.volume_30d is not None
+        and int(econ.volume_30d) >= NEGLIGIBLE_LP_FORGE_VOLUME_30D
+    )
+
+
+def peer_stats_by_corporation(
+    economics: Dict[int, LpStoreOfferEconomics],
+) -> Dict[int, CurrencyPeerStats]:
+    """
+    Median conversion ISK/LP (sell) per corporation among volume-viable offers.
+
+    Peers need Forge 30d volume and a finite conversion_isk_per_lp_sell.
+    """
+    by_corp: Dict[int, List[float]] = {}
+    for econ in economics.values():
+        if not _has_viable_forge_volume(econ):
+            continue
+        rate = econ.conversion_isk_per_lp_sell
+        if rate is None:
+            continue
+        by_corp.setdefault(int(econ.corporation_id), []).append(float(rate))
+
+    out: Dict[int, CurrencyPeerStats] = {}
+    for corp_id, rates in by_corp.items():
+        out[corp_id] = CurrencyPeerStats(
+            median_conversion_sell=float(statistics.median(rates)),
+            viable_count=len(rates),
+        )
+    return out
+
+
+def offer_fails_stockpile_usefulness(econ: LpStoreOfferEconomics) -> bool:
+    """
+    Offer cannot meaningfully clear a 250k–1M LP stockpile.
+
+    True when: unaffordable from 1M LP; ISK from a typical dump is below
+    ``USELESS_MIN_ISK_FROM_STOCKPILE``; or 30d Forge volume cannot absorb
+    units from dumping the HIGH stockpile through this offer.
+    """
+    if econ.lp_cost <= 0:
+        return True
+    if _purchases_for_stockpile(econ.lp_cost, USELESS_STOCKPILE_LP_HIGH) < 1:
+        return True
+
+    lp_spent = _stockpile_dump_lp_spent(econ.lp_cost)
+    rate = econ.conversion_isk_per_lp_sell
+    if lp_spent is not None and rate is not None:
+        if float(rate) * float(lp_spent) < USELESS_MIN_ISK_FROM_STOCKPILE:
+            return True
+
+    if _has_viable_forge_volume(econ):
+        units = _stockpile_dump_units(econ)
+        if units > int(econ.volume_30d or 0):
+            return True
+    return False
+
+
+def offer_fails_profit(econ: LpStoreOfferEconomics) -> bool:
+    """
+    Conversion sell ISK/LP at or below alliance buyback (opportunity cost).
+
+    Null conversion (missing prices / costs) counts as not profitable.
+    Also true when acquisition cost ≥ jita sell when both are known.
+    """
+    rate = econ.conversion_isk_per_lp_sell
+    buyback = econ.isk_per_lp
+    if rate is None:
+        return True
+    if buyback is not None and float(rate) <= float(buyback):
+        return True
+    if (
+        econ.acquisition_isk_per_unit is not None
+        and econ.jita_sell is not None
+        and int(econ.acquisition_isk_per_unit) >= int(econ.jita_sell)
+    ):
+        return True
+    return False
+
+
+def offer_fails_below_peer_average(
+    econ: LpStoreOfferEconomics,
+    peers_stats: Optional[CurrencyPeerStats],
+) -> bool:
+    """Conversion sell meaningfully below median of volume-viable peers."""
+    if peers_stats is None or peers_stats.median_conversion_sell is None:
+        return False
+    if peers_stats.viable_count < 1:
+        return False
+    rate = econ.conversion_isk_per_lp_sell
+    if rate is None:
+        return False
+    floor = USELESS_BELOW_MEDIAN_RATIO * float(
+        peers_stats.median_conversion_sell
+    )
+    return float(rate) < floor
+
+
+def offer_fails_volume_or_volatility(econ: LpStoreOfferEconomics) -> bool:
+    """
+    Negligible Forge volume and/or too-wide / missing bid-ask.
+
+    Volume: 30d null or < ``NEGLIGIBLE_LP_FORGE_VOLUME_30D``.
+    Volatility proxy: jita buy missing, or relative spread above
+    ``USELESS_MAX_RELATIVE_SPREAD`` (stand-in for Fuzzwork 5% depth).
+    """
+    if not _has_viable_forge_volume(econ):
+        return True
+    if econ.jita_buy is None:
+        return True
+    spread = _relative_spread(econ.jita_sell, econ.jita_buy)
+    if spread is not None and spread > USELESS_MAX_RELATIVE_SPREAD:
+        return True
+    return False
+
+
+def offer_is_useless(
+    econ: LpStoreOfferEconomics,
+    peers_stats: Optional[CurrencyPeerStats] = None,
+) -> bool:
+    """
+    True when the offer is useless for LP conversion desk screening.
+
+    See module docstring for the four criteria (OR).
+    """
+    return (
+        offer_fails_stockpile_usefulness(econ)
+        or offer_fails_profit(econ)
+        or offer_fails_below_peer_average(econ, peers_stats)
+        or offer_fails_volume_or_volatility(econ)
+    )
+
+
+def useless_offer_pks(
+    offers: Iterable[IndustryLpStoreOffer],
+) -> Set[int]:
+    """Compute primary keys of useless offers for an admin filter queryset."""
+    rows = list(offers)
+    if not rows:
+        return set()
+    economics = offer_economics_for_queryset(rows)
+    peers = peer_stats_by_corporation(economics)
+    useless: Set[int] = set()
+    for offer in rows:
+        pk = offer.pk
+        if pk is None:
+            continue
+        econ = economics.get(pk)
+        if econ is None:
+            useless.add(pk)
+            continue
+        if offer_is_useless(econ, peers.get(int(econ.corporation_id))):
+            useless.add(pk)
+    return useless

--- a/backend/industry/tests/test_loyalty_store.py
+++ b/backend/industry/tests/test_loyalty_store.py
@@ -4,7 +4,11 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
-from industry.helpers.lp_catalog import lp_catalog_type_ids
+from industry.helpers.lp_catalog import (
+    expand_with_navy_hull_type_ids,
+    lp_catalog_type_ids,
+    lp_market_history_type_ids,
+)
 from industry.helpers.loyalty_store import (
     ensure_loyalty_store_offers_for_product,
     get_offer_for_blueprint_type,
@@ -210,6 +214,23 @@ class LoyaltyStoreHelperTestCase(TestCase):
         self.assertIn(17814, ids)
         self.assertIn(17305, ids)
         self.assertIn(93609, ids)
+
+    def test_lp_market_history_type_ids_includes_navy_hull(self):
+        sync_loyalty_store_offers(
+            corporation_ids=[TLIB_CORP_ID],
+            offers=TYFI_OFFERS,
+            enqueue_history=False,
+        )
+        hull_id = 17740
+        with patch(
+            "industry.helpers.lp_catalog.navy_bpc_to_hull_type_ids",
+            return_value={TYFI_BP_TYPE_ID: hull_id},
+        ):
+            expanded = expand_with_navy_hull_type_ids([TYFI_BP_TYPE_ID, 3895])
+            self.assertEqual(expanded, {TYFI_BP_TYPE_ID, hull_id, 3895})
+            history_ids = set(lp_market_history_type_ids())
+        self.assertIn(TYFI_BP_TYPE_ID, history_ids)
+        self.assertIn(hull_id, history_ids)
 
     def test_resolve_isk_per_lp_uses_loyalty_point_default(self):
         IndustryLoyaltyPoint.objects.update_or_create(

--- a/backend/industry/tests/test_lp_store_economics.py
+++ b/backend/industry/tests/test_lp_store_economics.py
@@ -29,6 +29,7 @@ from industry.admin import (
     IndustryLpStoreExcludeTagsFilter,
     IndustryLpStoreExcludeUselessOffersFilter,
     IndustryLpStoreOfferAdmin,
+    ensure_lp_offer_econ_on_request,
 )
 from industry.helpers.lp_store_economics import (
     NEGLIGIBLE_LP_FORGE_VOLUME_30D,
@@ -1196,6 +1197,67 @@ class LpStoreOfferAdminTestCase(TestCase):
             IndustryLpStoreExcludeBelowSetLpPriceFilter,
             self.admin.list_filter,
         )
+
+    @patch("industry.admin.offer_economics_for_queryset")
+    def test_filters_reuse_request_scoped_economics(self, mock_econ):
+        """Both econ filters share one catalog map; no second compute."""
+        mock_econ.return_value = {
+            self.offer.pk: _econ(
+                pk=self.offer.pk,
+                offer_id=self.offer.offer_id,
+                conversion_isk_per_lp_sell=1_500.0,
+                volume_30d=10_000,
+            )
+        }
+        request = self.factory.get(
+            "/admin/industry/industrylpstoreoffer/"
+            "?exclude_useless_offers=1&exclude_below_set_lp_price=1"
+        )
+        request.user = self.user
+        qs = self.admin.get_queryset(request)
+
+        ensure_lp_offer_econ_on_request(request)
+        self.assertEqual(mock_econ.call_count, 1)
+
+        useless = IndustryLpStoreExcludeUselessOffersFilter(
+            request,
+            {"exclude_useless_offers": "1"},
+            IndustryLpStoreOffer,
+            self.admin,
+        )
+        below = IndustryLpStoreExcludeBelowSetLpPriceFilter(
+            request,
+            {"exclude_below_set_lp_price": "1"},
+            IndustryLpStoreOffer,
+            self.admin,
+        )
+        list(useless.queryset(request, qs))
+        list(below.queryset(request, qs))
+        # Filters must reuse request._lp_offer_econ, not recompute.
+        self.assertEqual(mock_econ.call_count, 1)
+
+    @patch("industry.admin.offer_economics_for_queryset")
+    def test_changelist_both_econ_filters_computes_once(self, mock_econ):
+        """Changelist with both Yes filters warms economics a single time."""
+        mock_econ.return_value = {
+            self.offer.pk: _econ(
+                pk=self.offer.pk,
+                offer_id=self.offer.offer_id,
+                conversion_isk_per_lp_sell=1_500.0,
+                volume_30d=10_000,
+            )
+        }
+        request = self.factory.get(
+            "/admin/industry/industrylpstoreoffer/"
+            "?exclude_useless_offers=1&exclude_below_set_lp_price=1"
+        )
+        request.user = self.user
+        response = self.admin.changelist_view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(mock_econ.call_count, 1)
+        # pylint: disable=protected-access
+        self.assertIsNone(IndustryLpStoreOfferAdmin._request_stash)
+        self.assertFalse(hasattr(request, "_lp_offer_econ"))
 
     @patch("industry.admin.offer_economics_for_queryset")
     def test_changelist_renders_names_before_stash_clear(self, mock_econ):

--- a/backend/industry/tests/test_lp_store_economics.py
+++ b/backend/industry/tests/test_lp_store_economics.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
+from django.db import ProgrammingError
 from django.test import RequestFactory, TestCase
 from eveonline.models import EveLocation
 from eveuniverse.models import (
@@ -284,6 +285,18 @@ class LpStoreEconomicsHelperTestCase(TestCase):
         self.assertIn(offer.pk, rows)
         self.assertEqual(rows[offer.pk].corporation_id, UNTRACKED_CORP_ID)
 
+    @patch(
+        "industry.helpers.lp_store_economics.IndustryLpStoreOfferRequiredItem.objects"
+    )
+    def test_missing_required_items_table_still_computes(self, mock_req):
+        mock_req.filter.side_effect = ProgrammingError("no such table")
+        offer = IndustryLpStoreOffer.objects.get(offer_id=1002)
+        rows = offer_economics_for_queryset([offer])
+        self.assertIn(offer.pk, rows)
+        self.assertEqual(rows[offer.pk].type_name, "LP Input Item")
+        self.assertEqual(rows[offer.pk].required_items_summary, "")
+        self.assertEqual(rows[offer.pk].other_cost, 0)
+
 
 class LpStoreOfferAdminTestCase(TestCase):
     def setUp(self):
@@ -364,6 +377,14 @@ class LpStoreOfferAdminTestCase(TestCase):
         self.assertIn("LP Input Item", html)
         self.assertIn(f"type {INPUT_TYPE_ID}", html)
         self.assertIn("lp-store-offer-item__name", html)
+        self.assertIn("images.evetech.net/types/", html)
+
+    def test_type_name_display_falls_back_to_eve_type(self):
+        # pylint: disable=protected-access
+        IndustryLpStoreOfferAdmin._request_stash = None
+        html = str(self.admin.type_name_display(self.offer))
+        self.assertIn("LP Input Item", html)
+        self.assertIn(f"type {INPUT_TYPE_ID}", html)
 
     def test_search_by_type_name(self):
         request = self.factory.get(
@@ -376,6 +397,52 @@ class LpStoreOfferAdminTestCase(TestCase):
         self.assertEqual(
             list(result.values_list("offer_id", flat=True)), [2001]
         )
+
+    def test_list_display_fuzzwork_column_order(self):
+        self.assertNotIn("kind_display", self.admin.list_display)
+        self.assertNotIn("ak_cost", self.admin.list_display)
+        self.assertEqual(self.admin.list_display[0], "type_name_display")
+        # Market prices before conversion rates (Fuzzwork-like).
+        sell_i = self.admin.list_display.index("jita_sell_display")
+        conv_i = self.admin.list_display.index("conversion_sell_display")
+        self.assertLess(sell_i, conv_i)
+
+    @patch("industry.admin.offer_economics_for_queryset")
+    def test_changelist_renders_names_before_stash_clear(self, mock_econ):
+        """Regression: TemplateResponse must render while stash is live."""
+        mock_econ.return_value = {
+            self.offer.pk: SimpleNamespace(
+                kind="input",
+                type_id=INPUT_TYPE_ID,
+                type_name="LP Input Item",
+                market_type_id=INPUT_TYPE_ID,
+                market_type_name="LP Input Item",
+                currency_name="Tribal Liberation Force",
+                required_items_summary="",
+                other_cost=0,
+                jita_sell=1_000_000,
+                jita_buy=900_000,
+                conversion_isk_per_lp_sell=500.0,
+                conversion_isk_per_lp_buy=400.0,
+                volume_90d=12_000,
+                isk_per_lp=800.0,
+                cost_per_unit=800_000,
+                profit_vs_sell=200_000,
+            )
+        }
+        request = self.factory.get("/admin/industry/industrylpstoreoffer/")
+        request.user = self.user
+        response = self.admin.changelist_view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(getattr(response, "is_rendered", False))
+        content = response.content.decode()
+        self.assertIn("LP Input Item", content)
+        self.assertIn("Tribal Liberation Force", content)
+        self.assertIn("1,000,000", content)
+        self.assertIn("500.0", content)
+        # Stash cleared after render.
+        # pylint: disable=protected-access
+        self.assertIsNone(IndustryLpStoreOfferAdmin._request_stash)
 
     @patch(
         "industry.admin.offer_economics_for_queryset",
@@ -402,7 +469,6 @@ class LpStoreOfferAdminTestCase(TestCase):
         request.user = self.user
         response = self.admin.changelist_view(request)
         self.assertEqual(response.status_code, 200)
-        response.render()
         content = response.content.decode()
         self.assertIn("position: sticky", content)
         self.assertIn("field-type_name_display", content)

--- a/backend/industry/tests/test_lp_store_economics.py
+++ b/backend/industry/tests/test_lp_store_economics.py
@@ -234,9 +234,11 @@ class LpStoreEconomicsHelperTestCase(TestCase):
         self.assertEqual(econ.profit_vs_sell, 150_000_000)
         self.assertEqual(econ.isk_per_lp, 800.0)
         self.assertEqual(econ.acquisition_isk_per_unit, 100_000_000)
-        # (250M - 20M) / 100k LP = 2300
-        self.assertAlmostEqual(econ.conversion_isk_per_lp_sell, 2300.0)
-        self.assertAlmostEqual(econ.conversion_isk_per_lp_buy, 2300.0)
+        # Other cost includes SDE manufacturing BOM (1× LP Input Item @ 1.5M).
+        self.assertEqual(econ.other_cost, 1_500_000)
+        # (250M - 20M - 1.5M) / 100k LP = 2285
+        self.assertAlmostEqual(econ.conversion_isk_per_lp_sell, 2285.0)
+        self.assertAlmostEqual(econ.conversion_isk_per_lp_buy, 2285.0)
 
     @patch(
         "industry.helpers.lp_store_economics.plan_product_unit_cost",
@@ -276,6 +278,32 @@ class LpStoreEconomicsHelperTestCase(TestCase):
         self.assertEqual(cheap_econ.profit_vs_sell, 218_000_000)
         self.assertEqual(dear_econ.profit_vs_sell, 208_000_000)
         self.assertNotEqual(cheap_econ.cost_per_unit, dear_econ.cost_per_unit)
+        # Conversion subtracts BOM (1.5M); acquisition does not.
+        # cheap: (250M - 0 - 1.5M) / 40k = 6212.5
+        self.assertAlmostEqual(cheap_econ.conversion_isk_per_lp_sell, 6212.5)
+        self.assertEqual(cheap_econ.other_cost, 1_500_000)
+
+    def test_blueprint_pack_multiplies_build_materials_in_other_cost(self):
+        """Fuzzwork scales Materials to build by offer quantity."""
+        pack = IndustryLpStoreOffer.objects.create(
+            offer_id=1012,
+            corporation_id=TLIB_CORP_ID,
+            type_id=BPC_TYPE_ID,
+            lp_cost=100_000,
+            isk_cost=100_000_000,
+            quantity=10,
+        )
+        with patch(
+            "industry.helpers.lp_store_economics.plan_product_unit_cost",
+            return_value=type("U", (), {"cost_per": 180_000_000})(),
+        ):
+            econ = offer_economics_for_queryset([pack])[pack.pk]
+        # 10 runs × 1 input @ 1.5M
+        self.assertEqual(econ.other_cost, 15_000_000)
+        # (250M * 10 - 100M - 15M) / 100k = 23850
+        self.assertAlmostEqual(econ.conversion_isk_per_lp_sell, 23850.0)
+        # Acquisition ignores BOM: (100k*800 + 100M) / 10 = 18M
+        self.assertEqual(econ.acquisition_isk_per_unit, 18_000_000)
 
     def test_volume_windows_sum_daily_history(self):
         today = timezone.now().date()
@@ -530,13 +558,15 @@ class LpStoreOfferAdminTestCase(TestCase):
         )
         request.user = self.user
         qs = self.admin.get_queryset(request)
+        # Django 5.2 SimpleListFilter stores params[name][-1].
         currency_filter = IndustryLpStoreCurrencyListFilter(
             request,
-            {"currency": str(TLIB_CORP_ID)},
+            {"currency": [str(TLIB_CORP_ID)]},
             IndustryLpStoreOffer,
             self.admin,
         )
         qs = currency_filter.queryset(request, qs)
+        self.assertEqual(list(qs.values_list("offer_id", flat=True)), [2001])
         result, _ = self.admin.get_search_results(request, qs, "LP Input")
         self.assertEqual(
             list(result.values_list("offer_id", flat=True)), [2001]
@@ -550,21 +580,23 @@ class LpStoreOfferAdminTestCase(TestCase):
         self.assertNotIn("kind_display", self.admin.list_display)
         self.assertNotIn("ak_cost", self.admin.list_display)
         self.assertNotIn("volume_90d_display", self.admin.list_display)
+        # Fuzzwork conversion rates only — not acquisition / buyback columns.
+        self.assertNotIn("isk_per_lp_display", self.admin.list_display)
+        self.assertNotIn("cost_display", self.admin.list_display)
+        self.assertNotIn("profit_vs_sell_display", self.admin.list_display)
         self.assertEqual(self.admin.list_display[0], "type_name_display")
         # Market prices before conversion rates (Fuzzwork-like).
         sell_i = self.admin.list_display.index("jita_sell_display")
         conv_i = self.admin.list_display.index("conversion_sell_display")
         self.assertLess(sell_i, conv_i)
+        self.assertIn("conversion_buy_display", self.admin.list_display)
         self.assertIn("volume_1d_display", self.admin.list_display)
         self.assertIn("volume_7d_display", self.admin.list_display)
         self.assertIn("volume_30d_display", self.admin.list_display)
 
-    def test_lp_cost_and_acquisition_columns_are_sortable(self):
+    def test_lp_cost_column_is_sortable(self):
         self.assertEqual(
             self.admin.lp_cost_display.admin_order_field, "lp_cost"
-        )
-        self.assertEqual(
-            self.admin.cost_display.admin_order_field, "sort_acquisition"
         )
         request = self.factory.get("/admin/industry/industrylpstoreoffer/")
         request.user = self.user
@@ -573,12 +605,6 @@ class LpStoreOfferAdminTestCase(TestCase):
             qs.order_by("lp_cost").values_list("offer_id", flat=True)
         )
         self.assertEqual(ordered, [2001])
-        # Sort annotation is queryable.
-        self.assertIsNotNone(
-            qs.order_by("sort_acquisition")
-            .values_list("sort_acquisition", flat=True)
-            .first()
-        )
 
     def test_exclude_supply_packages_hides_required_package_offers(self):
         """BPC output + Supply Package required item → excluded."""
@@ -626,18 +652,39 @@ class LpStoreOfferAdminTestCase(TestCase):
         )
         request = self.factory.get("/admin/industry/industrylpstoreoffer/")
         request.user = self.user
-        filt = IndustryLpStoreExcludeSupplyPackagesFilter(
+        yes = IndustryLpStoreExcludeSupplyPackagesFilter(
             request,
             {"exclude_supply_packages": "1"},
             IndustryLpStoreOffer,
             self.admin,
         )
-        qs = filt.queryset(request, self.admin.get_queryset(request))
-        offer_ids = set(qs.values_list("offer_id", flat=True))
-        self.assertIn(clean.offer_id, offer_ids)
-        self.assertIn(self.offer.offer_id, offer_ids)
-        self.assertNotIn(with_pkg.offer_id, offer_ids)
-        self.assertNotIn(package_offer.offer_id, offer_ids)
+        yes_ids = set(
+            yes.queryset(
+                request, self.admin.get_queryset(request)
+            ).values_list("offer_id", flat=True)
+        )
+        self.assertIn(clean.offer_id, yes_ids)
+        self.assertIn(self.offer.offer_id, yes_ids)
+        self.assertNotIn(with_pkg.offer_id, yes_ids)
+        self.assertNotIn(package_offer.offer_id, yes_ids)
+
+        no = IndustryLpStoreExcludeSupplyPackagesFilter(
+            request,
+            {"exclude_supply_packages": "0"},
+            IndustryLpStoreOffer,
+            self.admin,
+        )
+        no_ids = set(
+            no.queryset(request, self.admin.get_queryset(request)).values_list(
+                "offer_id", flat=True
+            )
+        )
+        self.assertNotIn(clean.offer_id, no_ids)
+        self.assertIn(with_pkg.offer_id, no_ids)
+        self.assertIn(package_offer.offer_id, no_ids)
+        self.assertEqual(
+            yes.lookups(request, self.admin), (("1", "Yes"), ("0", "No"))
+        )
 
     def test_exclude_tags_hides_required_tag_offers(self):
         tags_group = EveGroup.objects.create(
@@ -683,14 +730,32 @@ class LpStoreOfferAdminTestCase(TestCase):
         )
         request = self.factory.get("/admin/industry/industrylpstoreoffer/")
         request.user = self.user
-        filt = IndustryLpStoreExcludeTagsFilter(
+        yes = IndustryLpStoreExcludeTagsFilter(
             request, {"exclude_tags": "1"}, IndustryLpStoreOffer, self.admin
         )
-        qs = filt.queryset(request, self.admin.get_queryset(request))
-        offer_ids = set(qs.values_list("offer_id", flat=True))
-        self.assertIn(clean.offer_id, offer_ids)
-        self.assertNotIn(with_tag.offer_id, offer_ids)
-        self.assertNotIn(tag_offer.offer_id, offer_ids)
+        yes_ids = set(
+            yes.queryset(
+                request, self.admin.get_queryset(request)
+            ).values_list("offer_id", flat=True)
+        )
+        self.assertIn(clean.offer_id, yes_ids)
+        self.assertNotIn(with_tag.offer_id, yes_ids)
+        self.assertNotIn(tag_offer.offer_id, yes_ids)
+
+        no = IndustryLpStoreExcludeTagsFilter(
+            request, {"exclude_tags": "0"}, IndustryLpStoreOffer, self.admin
+        )
+        no_ids = set(
+            no.queryset(request, self.admin.get_queryset(request)).values_list(
+                "offer_id", flat=True
+            )
+        )
+        self.assertNotIn(clean.offer_id, no_ids)
+        self.assertIn(with_tag.offer_id, no_ids)
+        self.assertIn(tag_offer.offer_id, no_ids)
+        self.assertEqual(
+            yes.lookups(request, self.admin), (("1", "Yes"), ("0", "No"))
+        )
 
     @patch("industry.admin.offer_economics_for_queryset")
     def test_changelist_renders_names_before_stash_clear(self, mock_econ):

--- a/backend/industry/tests/test_lp_store_economics.py
+++ b/backend/industry/tests/test_lp_store_economics.py
@@ -737,6 +737,19 @@ class LpStoreOfferAdminTestCase(TestCase):
             published=True,
             eve_group=tags_group,
         )
+        # Navy rank insignias (not Criminal Tags group / '* Tag' suffix).
+        misc = EveGroup.objects.create(
+            id=314,
+            name="Miscellaneous",
+            published=True,
+            eve_category=EveCategory.objects.get(id=6),
+        )
+        insignia = EveType.objects.create(
+            id=15627,
+            name="Imperial Navy Colonel Insignia I",
+            published=True,
+            eve_group=misc,
+        )
         clean = IndustryLpStoreOffer.objects.create(
             offer_id=2200,
             corporation_id=TLIB_CORP_ID,
@@ -758,11 +771,32 @@ class LpStoreOfferAdminTestCase(TestCase):
             type_id=tag.id,
             quantity=2,
         )
+        with_insignia = IndustryLpStoreOffer.objects.create(
+            offer_id=2203,
+            corporation_id=TLIB_CORP_ID,
+            type_id=INPUT_TYPE_ID,
+            lp_cost=3_000,
+            isk_cost=0,
+            quantity=1,
+        )
+        IndustryLpStoreOfferRequiredItem.objects.create(
+            offer=with_insignia,
+            type_id=insignia.id,
+            quantity=10,
+        )
         tag_offer = IndustryLpStoreOffer.objects.create(
             offer_id=2202,
             corporation_id=TLIB_CORP_ID,
             type_id=tag.id,
             lp_cost=500,
+            isk_cost=0,
+            quantity=1,
+        )
+        insignia_offer = IndustryLpStoreOffer.objects.create(
+            offer_id=2204,
+            corporation_id=TLIB_CORP_ID,
+            type_id=insignia.id,
+            lp_cost=400,
             isk_cost=0,
             quantity=1,
         )
@@ -778,7 +812,9 @@ class LpStoreOfferAdminTestCase(TestCase):
         )
         self.assertIn(clean.offer_id, yes_ids)
         self.assertNotIn(with_tag.offer_id, yes_ids)
+        self.assertNotIn(with_insignia.offer_id, yes_ids)
         self.assertNotIn(tag_offer.offer_id, yes_ids)
+        self.assertNotIn(insignia_offer.offer_id, yes_ids)
 
         no = IndustryLpStoreExcludeTagsFilter(
             request, {"exclude_tags": "0"}, IndustryLpStoreOffer, self.admin
@@ -790,7 +826,9 @@ class LpStoreOfferAdminTestCase(TestCase):
         )
         self.assertNotIn(clean.offer_id, no_ids)
         self.assertIn(with_tag.offer_id, no_ids)
+        self.assertIn(with_insignia.offer_id, no_ids)
         self.assertIn(tag_offer.offer_id, no_ids)
+        self.assertIn(insignia_offer.offer_id, no_ids)
         self.assertEqual(
             yes.lookups(request, self.admin), (("1", "Yes"), ("0", "No"))
         )

--- a/backend/industry/tests/test_lp_store_economics.py
+++ b/backend/industry/tests/test_lp_store_economics.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.db import ProgrammingError
 from django.test import RequestFactory, TestCase
 from django.utils import timezone
@@ -30,6 +31,7 @@ from industry.admin import (
     IndustryLpStoreExcludeUselessOffersFilter,
     IndustryLpStoreOfferAdmin,
     ensure_lp_offer_econ_on_request,
+    lp_offer_econ_cache_key,
 )
 from industry.helpers.lp_store_economics import (
     NEGLIGIBLE_LP_FORGE_VOLUME_30D,
@@ -532,6 +534,7 @@ class LpStoreEconomicsHelperTestCase(TestCase):
 
 class LpStoreOfferAdminTestCase(TestCase):
     def setUp(self):
+        cache.clear()
         IndustryLoyaltyPoint.objects.update_or_create(
             corporation_id=TLIB_CORP_ID,
             defaults={
@@ -1235,6 +1238,34 @@ class LpStoreOfferAdminTestCase(TestCase):
         list(below.queryset(request, qs))
         # Filters must reuse request._lp_offer_econ, not recompute.
         self.assertEqual(mock_econ.call_count, 1)
+
+    @patch("industry.admin.offer_economics_for_queryset")
+    def test_ensure_populates_django_cache(self, mock_econ):
+        """Cold ensure stores catalog map; second request hits Django cache."""
+        economics = {
+            self.offer.pk: _econ(
+                pk=self.offer.pk,
+                offer_id=self.offer.offer_id,
+                conversion_isk_per_lp_sell=1_500.0,
+                volume_30d=10_000,
+            )
+        }
+        mock_econ.return_value = economics
+        request_a = self.factory.get("/admin/industry/industrylpstoreoffer/")
+        request_a.user = self.user
+        first = ensure_lp_offer_econ_on_request(request_a)
+        self.assertEqual(mock_econ.call_count, 1)
+        self.assertEqual(first, economics)
+        cache_key = lp_offer_econ_cache_key()
+        self.assertEqual(cache.get(cache_key), economics)
+
+        request_b = self.factory.get("/admin/industry/industrylpstoreoffer/")
+        request_b.user = self.user
+        second = ensure_lp_offer_econ_on_request(request_b)
+        self.assertEqual(mock_econ.call_count, 1)
+        self.assertEqual(second, economics)
+        # pylint: disable=protected-access
+        self.assertIs(getattr(request_b, "_lp_offer_econ"), second)
 
     @patch("industry.admin.offer_economics_for_queryset")
     def test_changelist_both_econ_filters_computes_once(self, mock_econ):

--- a/backend/industry/tests/test_lp_store_economics.py
+++ b/backend/industry/tests/test_lp_store_economics.py
@@ -30,6 +30,7 @@ from industry.admin import (
     IndustryLpStoreExcludeTagsFilter,
     IndustryLpStoreExcludeUselessOffersFilter,
     IndustryLpStoreOfferAdmin,
+    LpStoreOfferChangeList,
     ensure_lp_offer_econ_on_request,
     lp_offer_econ_cache_key,
 )
@@ -726,6 +727,70 @@ class LpStoreOfferAdminTestCase(TestCase):
             qs.order_by("lp_cost").values_list("offer_id", flat=True)
         )
         self.assertEqual(ordered, [2001])
+
+    @patch("industry.admin.offer_economics_for_queryset")
+    def test_conversion_sell_sort_matches_display_economics(self, mock_econ):
+        """o=-10 must order by real conversion sell, not SQL approx."""
+        other = IndustryLpStoreOffer.objects.create(
+            offer_id=2003,
+            corporation_id=TLIB_CORP_ID,
+            type_id=INPUT_TYPE_ID,
+            lp_cost=500,
+            isk_cost=0,
+            quantity=1,
+        )
+        low = self.offer
+        high = other
+        mock_econ.return_value = {
+            low.pk: SimpleNamespace(
+                conversion_isk_per_lp_sell=100.0,
+                conversion_isk_per_lp_buy=90.0,
+                jita_sell=1,
+                jita_buy=1,
+                volume_1d=0,
+                volume_7d=0,
+                volume_30d=10,
+                acquisition_isk_per_unit=1,
+                profit_vs_sell=1,
+            ),
+            high.pk: SimpleNamespace(
+                conversion_isk_per_lp_sell=9_000.0,
+                conversion_isk_per_lp_buy=8_000.0,
+                jita_sell=1,
+                jita_buy=1,
+                volume_1d=0,
+                volume_7d=0,
+                volume_30d=10,
+                acquisition_isk_per_unit=1,
+                profit_vs_sell=1,
+            ),
+        }
+        request = self.factory.get(
+            "/admin/industry/industrylpstoreoffer/",
+            {"o": "-10"},
+        )
+        request.user = self.user
+        cl = LpStoreOfferChangeList(
+            request,
+            IndustryLpStoreOffer,
+            list(self.admin.list_display),
+            self.admin.list_display_links,
+            self.admin.list_filter,
+            self.admin.date_hierarchy,
+            self.admin.search_fields,
+            self.admin.list_select_related,
+            self.admin.list_per_page,
+            self.admin.list_max_show_all,
+            self.admin.list_editable,
+            self.admin,
+            sortable_by=self.admin.get_sortable_by(request),
+            search_help_text=None,
+        )
+        ordered_pks = list(
+            cl.get_queryset(request).values_list("pk", flat=True)
+        )
+        self.assertEqual(ordered_pks[0], high.pk)
+        self.assertEqual(ordered_pks[1], low.pk)
 
     def test_exclude_supply_packages_hides_required_package_offers(self):
         """BPC output + Supply Package required item → excluded."""

--- a/backend/industry/tests/test_lp_store_economics.py
+++ b/backend/industry/tests/test_lp_store_economics.py
@@ -22,6 +22,7 @@ from eveuniverse.models import (
 from market.models import EveMarketItemHistory, EveMarketItemLocationPrice
 
 from industry.admin import (
+    IndustryLpStoreExcludeBelowSetLpPriceFilter,
     IndustryLpStoreCurrencyListFilter,
     IndustryLpStoreExcludeChipsFilter,
     IndustryLpStoreExcludeSupplyPackagesFilter,
@@ -34,6 +35,8 @@ from industry.helpers.lp_store_economics import (
     LpStoreOfferEconomics,
     bpc_type_id_to_product_type_id,
     offer_economics_for_queryset,
+    offer_is_below_set_lp_price,
+    offer_pks_below_set_lp_price,
     offer_type_ids_with_viable_forge_volume,
     tracked_corporation_ids,
 )
@@ -463,6 +466,67 @@ class LpStoreEconomicsHelperTestCase(TestCase):
         self.assertEqual(rows[offer.pk].type_name, "LP Input Item")
         self.assertEqual(rows[offer.pk].required_items_summary, "")
         self.assertEqual(rows[offer.pk].other_cost, 0)
+
+    def test_offer_is_below_set_lp_price_vs_buyback(self):
+        """Null or conversion < default_isk_per_lp is below set; equal is not."""
+        offer = IndustryLpStoreOffer.objects.get(offer_id=1002)
+        # History average 1.5M, isk 500k, lp 1000 → conversion 1000; buyback 800.
+        econ = offer_economics_for_queryset([offer])[offer.pk]
+        self.assertAlmostEqual(econ.conversion_isk_per_lp_sell, 1000.0)
+        self.assertEqual(econ.isk_per_lp, 800.0)
+        self.assertFalse(offer_is_below_set_lp_price(econ))
+
+        # Force below via high ISK cost: (1.5M - 1.4M) / 1000 = 100 < 800.
+        below = IndustryLpStoreOffer.objects.create(
+            offer_id=1050,
+            corporation_id=TLIB_CORP_ID,
+            type_id=INPUT_TYPE_ID,
+            lp_cost=1_000,
+            isk_cost=1_400_000,
+            quantity=1,
+        )
+        below_econ = offer_economics_for_queryset([below])[below.pk]
+        self.assertAlmostEqual(below_econ.conversion_isk_per_lp_sell, 100.0)
+        self.assertTrue(offer_is_below_set_lp_price(below_econ))
+
+        # Exact equality is at/above set price.
+        equal = IndustryLpStoreOffer.objects.create(
+            offer_id=1051,
+            corporation_id=TLIB_CORP_ID,
+            type_id=INPUT_TYPE_ID,
+            lp_cost=1_000,
+            isk_cost=700_000,  # (1.5M - 0.7M) / 1000 = 800
+            quantity=1,
+        )
+        equal_econ = offer_economics_for_queryset([equal])[equal.pk]
+        self.assertAlmostEqual(equal_econ.conversion_isk_per_lp_sell, 800.0)
+        self.assertFalse(offer_is_below_set_lp_price(equal_econ))
+
+        # No market price → null conversion → below set.
+        dead = EveType.objects.create(
+            id=42499,
+            name="Unpriced LP Cosmetic",
+            published=True,
+            eve_group=EveGroup.objects.get(id=27),
+        )
+        null_offer = IndustryLpStoreOffer.objects.create(
+            offer_id=1052,
+            corporation_id=TLIB_CORP_ID,
+            type_id=dead.id,
+            lp_cost=1_000,
+            isk_cost=0,
+            quantity=1,
+        )
+        null_econ = offer_economics_for_queryset([null_offer])[null_offer.pk]
+        self.assertIsNone(null_econ.conversion_isk_per_lp_sell)
+        self.assertTrue(offer_is_below_set_lp_price(null_econ))
+        below_pks = offer_pks_below_set_lp_price(
+            [offer, below, equal, null_offer]
+        )
+        self.assertNotIn(offer.pk, below_pks)
+        self.assertIn(below.pk, below_pks)
+        self.assertNotIn(equal.pk, below_pks)
+        self.assertIn(null_offer.pk, below_pks)
 
 
 class LpStoreOfferAdminTestCase(TestCase):
@@ -1031,6 +1095,105 @@ class LpStoreOfferAdminTestCase(TestCase):
         )
         self.assertIn(
             IndustryLpStoreExcludeUselessOffersFilter,
+            self.admin.list_filter,
+        )
+
+    def test_exclude_below_set_lp_price_yes_no(self):
+        """Yes hides below/null conversion; No isolates them."""
+        EveLocation.objects.create(
+            location_id=60003760,
+            location_name="Jita IV - Moon 4 - Caldari Navy Assembly Plant",
+            solar_system_id=30000142,
+            solar_system_name="Jita",
+            short_name="Jita",
+            region_id=JITA_REGION_ID,
+            price_baseline=True,
+            prices_active=True,
+        )
+        today = timezone.now().date()
+        EveMarketItemHistory.objects.create(
+            region_id=JITA_REGION_ID,
+            item=self.input_type,
+            date=today - timedelta(days=1),
+            average=Decimal("1500000"),
+            highest=Decimal("1600000"),
+            lowest=Decimal("1400000"),
+            order_count=5,
+            volume=50,
+        )
+        # Above set: (1.5M - 0) / 1000 = 1500 >= 800
+        above = IndustryLpStoreOffer.objects.create(
+            offer_id=2500,
+            corporation_id=TLIB_CORP_ID,
+            type_id=INPUT_TYPE_ID,
+            lp_cost=1_000,
+            isk_cost=0,
+            quantity=1,
+        )
+        # Below set: (1.5M - 1.4M) / 1000 = 100 < 800
+        below = IndustryLpStoreOffer.objects.create(
+            offer_id=2501,
+            corporation_id=TLIB_CORP_ID,
+            type_id=INPUT_TYPE_ID,
+            lp_cost=1_000,
+            isk_cost=1_400_000,
+            quantity=1,
+        )
+        dead = EveType.objects.create(
+            id=42498,
+            name="Dead Unpriced LP Item",
+            published=True,
+            eve_group=EveGroup.objects.get(id=27),
+        )
+        # Null conversion (no history) counts as below set.
+        no_price = IndustryLpStoreOffer.objects.create(
+            offer_id=2502,
+            corporation_id=TLIB_CORP_ID,
+            type_id=dead.id,
+            lp_cost=500,
+            isk_cost=0,
+            quantity=1,
+        )
+        # self.offer: lp 1000 isk 500k → conversion 1000 >= 800 → above
+
+        request = self.factory.get("/admin/industry/industrylpstoreoffer/")
+        request.user = self.user
+        yes = IndustryLpStoreExcludeBelowSetLpPriceFilter(
+            request,
+            {"exclude_below_set_lp_price": "1"},
+            IndustryLpStoreOffer,
+            self.admin,
+        )
+        yes_ids = set(
+            yes.queryset(
+                request, self.admin.get_queryset(request)
+            ).values_list("offer_id", flat=True)
+        )
+        self.assertIn(above.offer_id, yes_ids)
+        self.assertIn(self.offer.offer_id, yes_ids)
+        self.assertNotIn(below.offer_id, yes_ids)
+        self.assertNotIn(no_price.offer_id, yes_ids)
+
+        no = IndustryLpStoreExcludeBelowSetLpPriceFilter(
+            request,
+            {"exclude_below_set_lp_price": "0"},
+            IndustryLpStoreOffer,
+            self.admin,
+        )
+        no_ids = set(
+            no.queryset(request, self.admin.get_queryset(request)).values_list(
+                "offer_id", flat=True
+            )
+        )
+        self.assertIn(below.offer_id, no_ids)
+        self.assertIn(no_price.offer_id, no_ids)
+        self.assertNotIn(above.offer_id, no_ids)
+        self.assertNotIn(self.offer.offer_id, no_ids)
+        self.assertEqual(
+            yes.lookups(request, self.admin), (("1", "Yes"), ("0", "No"))
+        )
+        self.assertIn(
+            IndustryLpStoreExcludeBelowSetLpPriceFilter,
             self.admin.list_filter,
         )
 

--- a/backend/industry/tests/test_lp_store_economics.py
+++ b/backend/industry/tests/test_lp_store_economics.py
@@ -24,17 +24,32 @@ from market.models import EveMarketItemHistory, EveMarketItemLocationPrice
 from industry.admin import (
     IndustryLpStoreCurrencyListFilter,
     IndustryLpStoreExcludeChipsFilter,
-    IndustryLpStoreExcludeNegligibleVolumeFilter,
     IndustryLpStoreExcludeSupplyPackagesFilter,
     IndustryLpStoreExcludeTagsFilter,
+    IndustryLpStoreExcludeUselessOffersFilter,
     IndustryLpStoreOfferAdmin,
 )
 from industry.helpers.lp_store_economics import (
     NEGLIGIBLE_LP_FORGE_VOLUME_30D,
+    LpStoreOfferEconomics,
     bpc_type_id_to_product_type_id,
     offer_economics_for_queryset,
     offer_type_ids_with_viable_forge_volume,
     tracked_corporation_ids,
+)
+from industry.helpers.lp_store_useless import (
+    USELESS_BELOW_MEDIAN_RATIO,
+    USELESS_MAX_RELATIVE_SPREAD,
+    USELESS_MIN_ISK_FROM_STOCKPILE,
+    USELESS_STOCKPILE_LP_HIGH,
+    USELESS_STOCKPILE_LP_LOW,
+    CurrencyPeerStats,
+    offer_fails_below_peer_average,
+    offer_fails_profit,
+    offer_fails_stockpile_usefulness,
+    offer_fails_volume_or_volatility,
+    offer_is_useless,
+    peer_stats_by_corporation,
 )
 from industry.helpers.loyalty_store import sync_loyalty_store_offers
 from industry.models import (
@@ -922,63 +937,43 @@ class LpStoreOfferAdminTestCase(TestCase):
             yes.lookups(request, self.admin), (("1", "Yes"), ("0", "No"))
         )
 
-    def test_exclude_negligible_volume_uses_market_type_and_history(self):
-        """Missing/zero 30d Forge volume → negligible; hull history covers BPC."""
+    def test_exclude_useless_offers_filter_yes_no(self):
+        """Yes hides useless; No shows only useless (chip-filter pattern)."""
+        jita = EveLocation.objects.create(
+            location_id=60003760,
+            location_name="Jita IV - Moon 4 - Caldari Navy Assembly Plant",
+            solar_system_id=30000142,
+            solar_system_name="Jita",
+            short_name="Jita",
+            region_id=JITA_REGION_ID,
+            price_baseline=True,
+            prices_active=True,
+        )
         group = EveGroup.objects.get(id=27)
-        hull = EveType.objects.create(
-            id=HULL_TYPE_ID,
-            name="Typhoon Fleet Issue",
+        good_type = EveType.objects.create(
+            id=42430,
+            name="Useful LP Module",
             published=True,
             eve_group=group,
         )
-        bpc = EveType.objects.create(
-            id=BPC_TYPE_ID,
-            name="Typhoon Fleet Issue Blueprint",
-            published=True,
-            eve_group=group,
-        )
-        EveIndustryActivityProduct.objects.create(
-            eve_type=bpc,
-            activity_id=1,
-            product_eve_type=hull,
-            quantity=1,
-        )
-        EveIndustryActivityDuration.objects.create(
-            eve_type=bpc, activity_id=1, time=100
-        )
-        with patch(
-            "industry.tasks.ensure_loyalty_store_offers_for_product_task.delay"
-        ):
-            IndustryProduct.objects.create(
-                eve_type=hull, strategy=Strategy.IMPORTED
-            )
-
-        dead = EveType.objects.create(
-            id=42427,
+        dead_type = EveType.objects.create(
+            id=42431,
             name="Dead LP Cosmetic",
             published=True,
             eve_group=group,
         )
-        bpc_offer = IndustryLpStoreOffer.objects.create(
-            offer_id=2400,
+        good = IndustryLpStoreOffer.objects.create(
+            offer_id=2500,
             corporation_id=TLIB_CORP_ID,
-            type_id=BPC_TYPE_ID,
-            lp_cost=100_000,
-            isk_cost=20_000_000,
-            quantity=1,
-        )
-        liquid = IndustryLpStoreOffer.objects.create(
-            offer_id=2401,
-            corporation_id=TLIB_CORP_ID,
-            type_id=INPUT_TYPE_ID,
+            type_id=good_type.id,
             lp_cost=1_000,
             isk_cost=0,
             quantity=1,
         )
-        dead_offer = IndustryLpStoreOffer.objects.create(
-            offer_id=2402,
+        dead = IndustryLpStoreOffer.objects.create(
+            offer_id=2501,
             corporation_id=TLIB_CORP_ID,
-            type_id=dead.id,
+            type_id=dead_type.id,
             lp_cost=500,
             isk_cost=0,
             quantity=1,
@@ -986,30 +981,27 @@ class LpStoreOfferAdminTestCase(TestCase):
         today = timezone.now().date()
         EveMarketItemHistory.objects.create(
             region_id=JITA_REGION_ID,
-            item=hull,
+            item=good_type,
             date=today - timedelta(days=1),
-            average=Decimal("250000000"),
-            highest=Decimal("260000000"),
-            lowest=Decimal("240000000"),
-            order_count=2,
-            volume=3,
+            average=Decimal("2000000"),
+            highest=Decimal("2100000"),
+            lowest=Decimal("1900000"),
+            order_count=50,
+            volume=5_000,
         )
-        EveMarketItemHistory.objects.create(
-            region_id=JITA_REGION_ID,
-            item=self.input_type,
-            date=today - timedelta(days=1),
-            average=Decimal("1500000"),
-            highest=Decimal("1600000"),
-            lowest=Decimal("1400000"),
-            order_count=5,
-            volume=50,
+        EveMarketItemLocationPrice.objects.create(
+            location=jita,
+            item=good_type,
+            sell_price=Decimal("2000000"),
+            buy_price=Decimal("1900000"),
+            split_price=Decimal("1950000"),
         )
 
         request = self.factory.get("/admin/industry/industrylpstoreoffer/")
         request.user = self.user
-        yes = IndustryLpStoreExcludeNegligibleVolumeFilter(
+        yes = IndustryLpStoreExcludeUselessOffersFilter(
             request,
-            {"exclude_negligible_volume": "1"},
+            {"exclude_useless_offers": "1"},
             IndustryLpStoreOffer,
             self.admin,
         )
@@ -1018,13 +1010,12 @@ class LpStoreOfferAdminTestCase(TestCase):
                 request, self.admin.get_queryset(request)
             ).values_list("offer_id", flat=True)
         )
-        self.assertIn(bpc_offer.offer_id, yes_ids)
-        self.assertIn(liquid.offer_id, yes_ids)
-        self.assertNotIn(dead_offer.offer_id, yes_ids)
+        self.assertIn(good.offer_id, yes_ids)
+        self.assertNotIn(dead.offer_id, yes_ids)
 
-        no = IndustryLpStoreExcludeNegligibleVolumeFilter(
+        no = IndustryLpStoreExcludeUselessOffersFilter(
             request,
-            {"exclude_negligible_volume": "0"},
+            {"exclude_useless_offers": "0"},
             IndustryLpStoreOffer,
             self.admin,
         )
@@ -1033,14 +1024,13 @@ class LpStoreOfferAdminTestCase(TestCase):
                 "offer_id", flat=True
             )
         )
-        self.assertIn(dead_offer.offer_id, no_ids)
-        self.assertNotIn(bpc_offer.offer_id, no_ids)
-        self.assertNotIn(liquid.offer_id, no_ids)
+        self.assertIn(dead.offer_id, no_ids)
+        self.assertNotIn(good.offer_id, no_ids)
         self.assertEqual(
             yes.lookups(request, self.admin), (("1", "Yes"), ("0", "No"))
         )
         self.assertIn(
-            IndustryLpStoreExcludeNegligibleVolumeFilter,
+            IndustryLpStoreExcludeUselessOffersFilter,
             self.admin.list_filter,
         )
 
@@ -1120,4 +1110,170 @@ class LpStoreOfferAdminTestCase(TestCase):
         self.assertIn(
             "admin/industry/industrylpstoreoffer/change_list.html",
             self.admin.change_list_template,
+        )
+
+
+def _econ(**overrides) -> LpStoreOfferEconomics:
+    """Minimal viable economics row; override fields under test."""
+    base = {
+        "pk": 1,
+        "offer_id": 1,
+        "corporation_id": TLIB_CORP_ID,
+        "type_id": INPUT_TYPE_ID,
+        "type_name": "Test Offer",
+        "currency_name": "Tribal Liberation Force",
+        "isk_per_lp": 800.0,
+        "lp_cost": 1_000,
+        "isk_cost": 0,
+        "ak_cost": 0,
+        "quantity": 1,
+        "required_items_summary": "",
+        "other_cost": 0,
+        "acquisition_isk_per_unit": 800_000,
+        "market_type_id": INPUT_TYPE_ID,
+        "market_type_name": "Test Offer",
+        "jita_sell": 2_000_000,
+        "jita_buy": 1_900_000,
+        "conversion_isk_per_lp_sell": 2_000.0,
+        "conversion_isk_per_lp_buy": 1_900.0,
+        "volume_1d": 100,
+        "volume_7d": 700,
+        "volume_30d": 10_000,
+        "build_cost_per_unit": None,
+        "cost_per_unit": 800_000,
+        "kind": "input",
+        "profit_vs_sell": 1_200_000,
+    }
+    base.update(overrides)
+    return LpStoreOfferEconomics(**base)
+
+
+class OfferIsUselessHelperTestCase(TestCase):
+    def test_stockpile_unaffordable_from_high_band(self):
+        econ = _econ(lp_cost=USELESS_STOCKPILE_LP_HIGH + 1)
+        self.assertTrue(offer_fails_stockpile_usefulness(econ))
+        self.assertTrue(offer_is_useless(econ))
+
+    def test_stockpile_trivial_isk_from_low_dump(self):
+        econ = _econ(conversion_isk_per_lp_sell=100.0, volume_30d=1_000_000)
+        self.assertTrue(offer_fails_stockpile_usefulness(econ))
+        self.assertLess(
+            100.0 * USELESS_STOCKPILE_LP_LOW, USELESS_MIN_ISK_FROM_STOCKPILE
+        )
+
+    def test_stockpile_liquidity_exceeds_30d_volume(self):
+        econ = _econ(lp_cost=1_000, quantity=1, volume_30d=50)
+        self.assertTrue(offer_fails_stockpile_usefulness(econ))
+
+    def test_stockpile_useful_passes(self):
+        econ = _econ(
+            lp_cost=1_000,
+            conversion_isk_per_lp_sell=2_000.0,
+            volume_30d=50_000,
+        )
+        self.assertFalse(offer_fails_stockpile_usefulness(econ))
+
+    def test_profit_null_conversion(self):
+        self.assertTrue(
+            offer_fails_profit(_econ(conversion_isk_per_lp_sell=None))
+        )
+
+    def test_profit_at_or_below_buyback(self):
+        self.assertTrue(
+            offer_fails_profit(_econ(conversion_isk_per_lp_sell=800.0))
+        )
+        self.assertTrue(
+            offer_fails_profit(_econ(conversion_isk_per_lp_sell=500.0))
+        )
+        self.assertFalse(
+            offer_fails_profit(_econ(conversion_isk_per_lp_sell=801.0))
+        )
+
+    def test_profit_acquisition_ge_jita_sell(self):
+        econ = _econ(
+            conversion_isk_per_lp_sell=2_000.0,
+            acquisition_isk_per_unit=2_000_000,
+            jita_sell=2_000_000,
+        )
+        self.assertTrue(offer_fails_profit(econ))
+
+    def test_below_peer_median_ratio(self):
+        peers = CurrencyPeerStats(
+            median_conversion_sell=2_000.0, viable_count=5
+        )
+        floor = USELESS_BELOW_MEDIAN_RATIO * 2_000.0
+        self.assertTrue(
+            offer_fails_below_peer_average(
+                _econ(conversion_isk_per_lp_sell=floor - 1), peers
+            )
+        )
+        self.assertFalse(
+            offer_fails_below_peer_average(
+                _econ(conversion_isk_per_lp_sell=floor), peers
+            )
+        )
+        self.assertFalse(
+            offer_fails_below_peer_average(
+                _econ(conversion_isk_per_lp_sell=2_000.0), None
+            )
+        )
+
+    def test_volume_missing_or_negligible(self):
+        self.assertTrue(
+            offer_fails_volume_or_volatility(_econ(volume_30d=None))
+        )
+        self.assertTrue(
+            offer_fails_volume_or_volatility(
+                _econ(volume_30d=NEGLIGIBLE_LP_FORGE_VOLUME_30D - 1)
+            )
+        )
+        self.assertFalse(
+            offer_fails_volume_or_volatility(
+                _econ(volume_30d=NEGLIGIBLE_LP_FORGE_VOLUME_30D)
+            )
+        )
+
+    def test_volatility_missing_buy_or_wide_spread(self):
+        self.assertTrue(offer_fails_volume_or_volatility(_econ(jita_buy=None)))
+        sell = 1_000_000
+        buy = int(sell * (1.0 - USELESS_MAX_RELATIVE_SPREAD - 0.1))
+        self.assertTrue(
+            offer_fails_volume_or_volatility(
+                _econ(jita_sell=sell, jita_buy=buy)
+            )
+        )
+        tight_buy = int(sell * 0.95)
+        self.assertFalse(
+            offer_fails_volume_or_volatility(
+                _econ(jita_sell=sell, jita_buy=tight_buy)
+            )
+        )
+
+    def test_offer_is_useless_combined_or(self):
+        peers = CurrencyPeerStats(
+            median_conversion_sell=2_000.0, viable_count=3
+        )
+        self.assertFalse(offer_is_useless(_econ(), peers))
+        weak = _econ(conversion_isk_per_lp_sell=1_000.0)
+        self.assertTrue(offer_is_useless(weak, peers))
+        self.assertTrue(offer_fails_below_peer_average(weak, peers))
+        self.assertFalse(offer_fails_profit(weak))
+
+    def test_peer_stats_median_among_volume_viable(self):
+        economics = {
+            1: _econ(pk=1, conversion_isk_per_lp_sell=1_000.0, volume_30d=10),
+            2: _econ(pk=2, conversion_isk_per_lp_sell=2_000.0, volume_30d=10),
+            3: _econ(pk=3, conversion_isk_per_lp_sell=3_000.0, volume_30d=10),
+            4: _econ(
+                pk=4, conversion_isk_per_lp_sell=9_999.0, volume_30d=None
+            ),
+        }
+        stats = peer_stats_by_corporation(economics)
+        self.assertEqual(stats[TLIB_CORP_ID].median_conversion_sell, 2_000.0)
+        self.assertEqual(stats[TLIB_CORP_ID].viable_count, 3)
+
+    def test_list_filter_registers_useless_offers(self):
+        self.assertIn(
+            IndustryLpStoreExcludeUselessOffersFilter,
+            IndustryLpStoreOfferAdmin.list_filter,
         )

--- a/backend/industry/tests/test_lp_store_economics.py
+++ b/backend/industry/tests/test_lp_store_economics.py
@@ -1,6 +1,6 @@
 """Tests for LP store offer economics (admin price tracking)."""
 
-from datetime import date
+from datetime import date, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -9,6 +9,7 @@ from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
 from django.db import ProgrammingError
 from django.test import RequestFactory, TestCase
+from django.utils import timezone
 from eveonline.models import EveLocation
 from eveuniverse.models import (
     EveCategory,
@@ -20,7 +21,12 @@ from eveuniverse.models import (
 )
 from market.models import EveMarketItemHistory, EveMarketItemLocationPrice
 
-from industry.admin import IndustryLpStoreOfferAdmin
+from industry.admin import (
+    IndustryLpStoreCurrencyListFilter,
+    IndustryLpStoreExcludeSupplyPackagesFilter,
+    IndustryLpStoreExcludeTagsFilter,
+    IndustryLpStoreOfferAdmin,
+)
 from industry.helpers.lp_store_economics import (
     bpc_type_id_to_product_type_id,
     offer_economics_for_queryset,
@@ -36,6 +42,7 @@ from industry.models import (
 )
 
 TLIB_CORP_ID = 1000182
+IMPERIAL_CORP_ID = 1000179
 UNTRACKED_CORP_ID = 9999999
 HULL_TYPE_ID = 17740
 BPC_TYPE_ID = 32312
@@ -222,13 +229,92 @@ class LpStoreEconomicsHelperTestCase(TestCase):
         self.assertEqual(econ.jita_sell, 250_000_000)
         self.assertEqual(econ.jita_buy, 250_000_000)
         self.assertEqual(econ.build_cost_per_unit, 180_000_000)
-        self.assertEqual(econ.cost_per_unit, 180_000_000)
-        self.assertEqual(econ.profit_vs_sell, 70_000_000)
+        # Cost/Profit are offer acquisition, not shared planner build cost.
+        self.assertEqual(econ.cost_per_unit, 100_000_000)
+        self.assertEqual(econ.profit_vs_sell, 150_000_000)
         self.assertEqual(econ.isk_per_lp, 800.0)
         self.assertEqual(econ.acquisition_isk_per_unit, 100_000_000)
         # (250M - 20M) / 100k LP = 2300
         self.assertAlmostEqual(econ.conversion_isk_per_lp_sell, 2300.0)
         self.assertAlmostEqual(econ.conversion_isk_per_lp_buy, 2300.0)
+
+    @patch(
+        "industry.helpers.lp_store_economics.plan_product_unit_cost",
+        return_value=type(
+            "U",
+            (),
+            {"cost_per": 180_000_000},
+        )(),
+    )
+    def test_blueprint_offers_differ_by_acquisition(self, mock_plan):
+        """Same hull BPC with different LP/ISK → different Cost/Profit."""
+        cheap = IndustryLpStoreOffer.objects.create(
+            offer_id=1010,
+            corporation_id=TLIB_CORP_ID,
+            type_id=BPC_TYPE_ID,
+            lp_cost=40_000,
+            isk_cost=0,
+            quantity=1,
+        )
+        dear = IndustryLpStoreOffer.objects.create(
+            offer_id=1011,
+            corporation_id=TLIB_CORP_ID,
+            type_id=BPC_TYPE_ID,
+            lp_cost=40_000,
+            isk_cost=10_000_000,
+            quantity=1,
+        )
+        rows = offer_economics_for_queryset([cheap, dear])
+        mock_plan.assert_called()
+        cheap_econ = rows[cheap.pk]
+        dear_econ = rows[dear.pk]
+        self.assertEqual(cheap_econ.build_cost_per_unit, 180_000_000)
+        self.assertEqual(dear_econ.build_cost_per_unit, 180_000_000)
+        # (40k*800 + 0) / 1 = 32M; (40k*800 + 10M) / 1 = 42M
+        self.assertEqual(cheap_econ.cost_per_unit, 32_000_000)
+        self.assertEqual(dear_econ.cost_per_unit, 42_000_000)
+        self.assertEqual(cheap_econ.profit_vs_sell, 218_000_000)
+        self.assertEqual(dear_econ.profit_vs_sell, 208_000_000)
+        self.assertNotEqual(cheap_econ.cost_per_unit, dear_econ.cost_per_unit)
+
+    def test_volume_windows_sum_daily_history(self):
+        today = timezone.now().date()
+        EveMarketItemHistory.objects.filter(item=self.input_type).delete()
+        EveMarketItemHistory.objects.create(
+            region_id=JITA_REGION_ID,
+            item=self.input_type,
+            date=today - timedelta(days=0),
+            average=Decimal("1500000"),
+            highest=Decimal("1600000"),
+            lowest=Decimal("1400000"),
+            order_count=1,
+            volume=10,
+        )
+        EveMarketItemHistory.objects.create(
+            region_id=JITA_REGION_ID,
+            item=self.input_type,
+            date=today - timedelta(days=3),
+            average=Decimal("1500000"),
+            highest=Decimal("1600000"),
+            lowest=Decimal("1400000"),
+            order_count=1,
+            volume=20,
+        )
+        EveMarketItemHistory.objects.create(
+            region_id=JITA_REGION_ID,
+            item=self.input_type,
+            date=today - timedelta(days=20),
+            average=Decimal("1500000"),
+            highest=Decimal("1600000"),
+            lowest=Decimal("1400000"),
+            order_count=1,
+            volume=40,
+        )
+        offer = IndustryLpStoreOffer.objects.get(offer_id=1002)
+        econ = offer_economics_for_queryset([offer])[offer.pk]
+        self.assertEqual(econ.volume_1d, 10)
+        self.assertEqual(econ.volume_7d, 30)
+        self.assertEqual(econ.volume_30d, 70)
 
     def test_input_row_uses_acquisition_and_own_type(self):
         offer = IndustryLpStoreOffer.objects.get(offer_id=1002)
@@ -375,16 +461,38 @@ class LpStoreOfferAdminTestCase(TestCase):
         finally:
             IndustryLpStoreOfferAdmin._request_stash = None
         self.assertIn("LP Input Item", html)
-        self.assertIn(f"type {INPUT_TYPE_ID}", html)
+        self.assertIn(f'Title="Type {INPUT_TYPE_ID}"'.lower(), html.lower())
+        self.assertNotIn("input ·", html)
+        self.assertNotIn(f"type {INPUT_TYPE_ID}", html)
         self.assertIn("lp-store-offer-item__name", html)
-        self.assertIn("images.evetech.net/types/", html)
+        self.assertIn("/icon?size=32", html)
+
+    def test_type_name_display_uses_bp_icon_for_blueprints(self):
+        # pylint: disable=protected-access
+        IndustryLpStoreOfferAdmin._request_stash = {
+            self.offer.pk: SimpleNamespace(
+                kind="blueprint",
+                type_id=32312,
+                type_name="Typhoon Fleet Issue Blueprint",
+                market_type_id=17740,
+                market_type_name="Typhoon Fleet Issue",
+            )
+        }
+        try:
+            html = str(self.admin.type_name_display(self.offer))
+        finally:
+            IndustryLpStoreOfferAdmin._request_stash = None
+        self.assertIn("Typhoon Fleet Issue (BPC)", html)
+        self.assertIn("/bp?size=32", html)
+        self.assertNotIn("blueprint ·", html)
 
     def test_type_name_display_falls_back_to_eve_type(self):
         # pylint: disable=protected-access
         IndustryLpStoreOfferAdmin._request_stash = None
         html = str(self.admin.type_name_display(self.offer))
         self.assertIn("LP Input Item", html)
-        self.assertIn(f"type {INPUT_TYPE_ID}", html)
+        self.assertIn(f'Title="Type {INPUT_TYPE_ID}"'.lower(), html.lower())
+        self.assertNotIn(f"type {INPUT_TYPE_ID}", html)
 
     def test_search_by_type_name(self):
         request = self.factory.get(
@@ -398,14 +506,191 @@ class LpStoreOfferAdminTestCase(TestCase):
             list(result.values_list("offer_id", flat=True)), [2001]
         )
 
+    def test_search_respects_currency_filter(self):
+        """Name search must not reintroduce offers from other currencies."""
+        IndustryLoyaltyPoint.objects.update_or_create(
+            corporation_id=IMPERIAL_CORP_ID,
+            defaults={
+                "name": "24th Imperial Crusade",
+                "default_isk_per_lp": 800,
+                "is_active": True,
+            },
+        )
+        IndustryLpStoreOffer.objects.create(
+            offer_id=2003,
+            corporation_id=IMPERIAL_CORP_ID,
+            type_id=INPUT_TYPE_ID,
+            lp_cost=2000,
+            isk_cost=100_000,
+            quantity=1,
+        )
+        request = self.factory.get(
+            "/admin/industry/industrylpstoreoffer/",
+            {"q": "LP Input", "currency": str(TLIB_CORP_ID)},
+        )
+        request.user = self.user
+        qs = self.admin.get_queryset(request)
+        currency_filter = IndustryLpStoreCurrencyListFilter(
+            request,
+            {"currency": str(TLIB_CORP_ID)},
+            IndustryLpStoreOffer,
+            self.admin,
+        )
+        qs = currency_filter.queryset(request, qs)
+        result, _ = self.admin.get_search_results(request, qs, "LP Input")
+        self.assertEqual(
+            list(result.values_list("offer_id", flat=True)), [2001]
+        )
+        self.assertEqual(
+            list(result.values_list("corporation_id", flat=True)),
+            [TLIB_CORP_ID],
+        )
+
     def test_list_display_fuzzwork_column_order(self):
         self.assertNotIn("kind_display", self.admin.list_display)
         self.assertNotIn("ak_cost", self.admin.list_display)
+        self.assertNotIn("volume_90d_display", self.admin.list_display)
         self.assertEqual(self.admin.list_display[0], "type_name_display")
         # Market prices before conversion rates (Fuzzwork-like).
         sell_i = self.admin.list_display.index("jita_sell_display")
         conv_i = self.admin.list_display.index("conversion_sell_display")
         self.assertLess(sell_i, conv_i)
+        self.assertIn("volume_1d_display", self.admin.list_display)
+        self.assertIn("volume_7d_display", self.admin.list_display)
+        self.assertIn("volume_30d_display", self.admin.list_display)
+
+    def test_lp_cost_and_acquisition_columns_are_sortable(self):
+        self.assertEqual(
+            self.admin.lp_cost_display.admin_order_field, "lp_cost"
+        )
+        self.assertEqual(
+            self.admin.cost_display.admin_order_field, "sort_acquisition"
+        )
+        request = self.factory.get("/admin/industry/industrylpstoreoffer/")
+        request.user = self.user
+        qs = self.admin.get_queryset(request)
+        ordered = list(
+            qs.order_by("lp_cost").values_list("offer_id", flat=True)
+        )
+        self.assertEqual(ordered, [2001])
+        # Sort annotation is queryable.
+        self.assertIsNotNone(
+            qs.order_by("sort_acquisition")
+            .values_list("sort_acquisition", flat=True)
+            .first()
+        )
+
+    def test_exclude_supply_packages_hides_required_package_offers(self):
+        """BPC output + Supply Package required item → excluded."""
+        misc = EveGroup.objects.create(
+            id=314,
+            name="Miscellaneous",
+            published=True,
+            eve_category=EveCategory.objects.get(id=6),
+        )
+        package = EveType.objects.create(
+            id=93609,
+            name="Imperial War Reserves Supply Package",
+            published=True,
+            eve_group=misc,
+        )
+        clean = IndustryLpStoreOffer.objects.create(
+            offer_id=2100,
+            corporation_id=TLIB_CORP_ID,
+            type_id=INPUT_TYPE_ID,
+            lp_cost=40_000,
+            isk_cost=0,
+            quantity=1,
+        )
+        with_pkg = IndustryLpStoreOffer.objects.create(
+            offer_id=2101,
+            corporation_id=TLIB_CORP_ID,
+            type_id=INPUT_TYPE_ID,
+            lp_cost=100_000,
+            isk_cost=100_000_000,
+            quantity=10,
+        )
+        IndustryLpStoreOfferRequiredItem.objects.create(
+            offer=with_pkg,
+            type_id=package.id,
+            quantity=3,
+        )
+        # Output itself is a supply package.
+        package_offer = IndustryLpStoreOffer.objects.create(
+            offer_id=2102,
+            corporation_id=TLIB_CORP_ID,
+            type_id=package.id,
+            lp_cost=5_000,
+            isk_cost=0,
+            quantity=1,
+        )
+        request = self.factory.get("/admin/industry/industrylpstoreoffer/")
+        request.user = self.user
+        filt = IndustryLpStoreExcludeSupplyPackagesFilter(
+            request,
+            {"exclude_supply_packages": "1"},
+            IndustryLpStoreOffer,
+            self.admin,
+        )
+        qs = filt.queryset(request, self.admin.get_queryset(request))
+        offer_ids = set(qs.values_list("offer_id", flat=True))
+        self.assertIn(clean.offer_id, offer_ids)
+        self.assertIn(self.offer.offer_id, offer_ids)
+        self.assertNotIn(with_pkg.offer_id, offer_ids)
+        self.assertNotIn(package_offer.offer_id, offer_ids)
+
+    def test_exclude_tags_hides_required_tag_offers(self):
+        tags_group = EveGroup.objects.create(
+            id=370,
+            name="Criminal Tags",
+            published=True,
+            eve_category=EveCategory.objects.get(id=6),
+        )
+        tag = EveType.objects.create(
+            id=17226,
+            name="Domination Gold Tag",
+            published=True,
+            eve_group=tags_group,
+        )
+        clean = IndustryLpStoreOffer.objects.create(
+            offer_id=2200,
+            corporation_id=TLIB_CORP_ID,
+            type_id=INPUT_TYPE_ID,
+            lp_cost=1_000,
+            isk_cost=0,
+            quantity=1,
+        )
+        with_tag = IndustryLpStoreOffer.objects.create(
+            offer_id=2201,
+            corporation_id=TLIB_CORP_ID,
+            type_id=INPUT_TYPE_ID,
+            lp_cost=2_000,
+            isk_cost=0,
+            quantity=1,
+        )
+        IndustryLpStoreOfferRequiredItem.objects.create(
+            offer=with_tag,
+            type_id=tag.id,
+            quantity=2,
+        )
+        tag_offer = IndustryLpStoreOffer.objects.create(
+            offer_id=2202,
+            corporation_id=TLIB_CORP_ID,
+            type_id=tag.id,
+            lp_cost=500,
+            isk_cost=0,
+            quantity=1,
+        )
+        request = self.factory.get("/admin/industry/industrylpstoreoffer/")
+        request.user = self.user
+        filt = IndustryLpStoreExcludeTagsFilter(
+            request, {"exclude_tags": "1"}, IndustryLpStoreOffer, self.admin
+        )
+        qs = filt.queryset(request, self.admin.get_queryset(request))
+        offer_ids = set(qs.values_list("offer_id", flat=True))
+        self.assertIn(clean.offer_id, offer_ids)
+        self.assertNotIn(with_tag.offer_id, offer_ids)
+        self.assertNotIn(tag_offer.offer_id, offer_ids)
 
     @patch("industry.admin.offer_economics_for_queryset")
     def test_changelist_renders_names_before_stash_clear(self, mock_econ):
@@ -424,7 +709,9 @@ class LpStoreOfferAdminTestCase(TestCase):
                 jita_buy=900_000,
                 conversion_isk_per_lp_sell=500.0,
                 conversion_isk_per_lp_buy=400.0,
-                volume_90d=12_000,
+                volume_1d=100,
+                volume_7d=700,
+                volume_30d=3_000,
                 isk_per_lp=800.0,
                 cost_per_unit=800_000,
                 profit_vs_sell=200_000,
@@ -458,7 +745,13 @@ class LpStoreOfferAdminTestCase(TestCase):
         self.assertIn("jita_buy_display", self.admin.list_display)
         self.assertIn("conversion_sell_display", self.admin.list_display)
         self.assertIn("conversion_buy_display", self.admin.list_display)
-        self.assertIn("cost_display", self.admin.list_display)
+        self.assertNotIn("isk_per_lp_display", self.admin.list_display)
+        self.assertNotIn("cost_display", self.admin.list_display)
+        self.assertNotIn("profit_vs_sell_display", self.admin.list_display)
+        self.assertIn("volume_1d_display", self.admin.list_display)
+        self.assertIn("volume_7d_display", self.admin.list_display)
+        self.assertIn("volume_30d_display", self.admin.list_display)
+        self.assertNotIn("volume_90d_display", self.admin.list_display)
 
     @patch(
         "industry.admin.offer_economics_for_queryset",

--- a/backend/industry/tests/test_lp_store_economics.py
+++ b/backend/industry/tests/test_lp_store_economics.py
@@ -24,13 +24,16 @@ from market.models import EveMarketItemHistory, EveMarketItemLocationPrice
 from industry.admin import (
     IndustryLpStoreCurrencyListFilter,
     IndustryLpStoreExcludeChipsFilter,
+    IndustryLpStoreExcludeNegligibleVolumeFilter,
     IndustryLpStoreExcludeSupplyPackagesFilter,
     IndustryLpStoreExcludeTagsFilter,
     IndustryLpStoreOfferAdmin,
 )
 from industry.helpers.lp_store_economics import (
+    NEGLIGIBLE_LP_FORGE_VOLUME_30D,
     bpc_type_id_to_product_type_id,
     offer_economics_for_queryset,
+    offer_type_ids_with_viable_forge_volume,
     tracked_corporation_ids,
 )
 from industry.helpers.loyalty_store import sync_loyalty_store_offers
@@ -344,6 +347,40 @@ class LpStoreEconomicsHelperTestCase(TestCase):
         self.assertEqual(econ.volume_1d, 10)
         self.assertEqual(econ.volume_7d, 30)
         self.assertEqual(econ.volume_30d, 70)
+
+    def test_offer_type_ids_viable_volume_uses_hull_for_bpc(self):
+        """Navy BPC offers are viable when the hull has 30d Forge volume."""
+        # History in setUp is on hull / input / req — not on BPC itself.
+        viable = offer_type_ids_with_viable_forge_volume(
+            [BPC_TYPE_ID, INPUT_TYPE_ID, 999001]
+        )
+        self.assertIn(BPC_TYPE_ID, viable)
+        self.assertIn(INPUT_TYPE_ID, viable)
+        self.assertNotIn(999001, viable)
+        self.assertGreaterEqual(NEGLIGIBLE_LP_FORGE_VOLUME_30D, 1)
+
+    def test_offer_type_ids_viable_volume_excludes_below_threshold(self):
+        dead = EveType.objects.create(
+            id=42426,
+            name="Dead LP Item",
+            published=True,
+            eve_group=self.hull.eve_group,
+        )
+        EveMarketItemHistory.objects.create(
+            region_id=JITA_REGION_ID,
+            item=dead,
+            date=timezone.now().date() - timedelta(days=2),
+            average=Decimal("100"),
+            highest=Decimal("100"),
+            lowest=Decimal("100"),
+            order_count=0,
+            volume=0,
+        )
+        viable = offer_type_ids_with_viable_forge_volume(
+            [dead.id],
+            min_volume_30d=1,
+        )
+        self.assertNotIn(dead.id, viable)
 
     def test_input_row_uses_acquisition_and_own_type(self):
         offer = IndustryLpStoreOffer.objects.get(offer_id=1002)
@@ -845,6 +882,128 @@ class LpStoreOfferAdminTestCase(TestCase):
         self.assertIn(chip_offer.offer_id, no_ids)
         self.assertEqual(
             yes.lookups(request, self.admin), (("1", "Yes"), ("0", "No"))
+        )
+
+    def test_exclude_negligible_volume_uses_market_type_and_history(self):
+        """Missing/zero 30d Forge volume → negligible; hull history covers BPC."""
+        group = EveGroup.objects.get(id=27)
+        hull = EveType.objects.create(
+            id=HULL_TYPE_ID,
+            name="Typhoon Fleet Issue",
+            published=True,
+            eve_group=group,
+        )
+        bpc = EveType.objects.create(
+            id=BPC_TYPE_ID,
+            name="Typhoon Fleet Issue Blueprint",
+            published=True,
+            eve_group=group,
+        )
+        EveIndustryActivityProduct.objects.create(
+            eve_type=bpc,
+            activity_id=1,
+            product_eve_type=hull,
+            quantity=1,
+        )
+        EveIndustryActivityDuration.objects.create(
+            eve_type=bpc, activity_id=1, time=100
+        )
+        with patch(
+            "industry.tasks.ensure_loyalty_store_offers_for_product_task.delay"
+        ):
+            IndustryProduct.objects.create(
+                eve_type=hull, strategy=Strategy.IMPORTED
+            )
+
+        dead = EveType.objects.create(
+            id=42427,
+            name="Dead LP Cosmetic",
+            published=True,
+            eve_group=group,
+        )
+        bpc_offer = IndustryLpStoreOffer.objects.create(
+            offer_id=2400,
+            corporation_id=TLIB_CORP_ID,
+            type_id=BPC_TYPE_ID,
+            lp_cost=100_000,
+            isk_cost=20_000_000,
+            quantity=1,
+        )
+        liquid = IndustryLpStoreOffer.objects.create(
+            offer_id=2401,
+            corporation_id=TLIB_CORP_ID,
+            type_id=INPUT_TYPE_ID,
+            lp_cost=1_000,
+            isk_cost=0,
+            quantity=1,
+        )
+        dead_offer = IndustryLpStoreOffer.objects.create(
+            offer_id=2402,
+            corporation_id=TLIB_CORP_ID,
+            type_id=dead.id,
+            lp_cost=500,
+            isk_cost=0,
+            quantity=1,
+        )
+        today = timezone.now().date()
+        EveMarketItemHistory.objects.create(
+            region_id=JITA_REGION_ID,
+            item=hull,
+            date=today - timedelta(days=1),
+            average=Decimal("250000000"),
+            highest=Decimal("260000000"),
+            lowest=Decimal("240000000"),
+            order_count=2,
+            volume=3,
+        )
+        EveMarketItemHistory.objects.create(
+            region_id=JITA_REGION_ID,
+            item=self.input_type,
+            date=today - timedelta(days=1),
+            average=Decimal("1500000"),
+            highest=Decimal("1600000"),
+            lowest=Decimal("1400000"),
+            order_count=5,
+            volume=50,
+        )
+
+        request = self.factory.get("/admin/industry/industrylpstoreoffer/")
+        request.user = self.user
+        yes = IndustryLpStoreExcludeNegligibleVolumeFilter(
+            request,
+            {"exclude_negligible_volume": "1"},
+            IndustryLpStoreOffer,
+            self.admin,
+        )
+        yes_ids = set(
+            yes.queryset(
+                request, self.admin.get_queryset(request)
+            ).values_list("offer_id", flat=True)
+        )
+        self.assertIn(bpc_offer.offer_id, yes_ids)
+        self.assertIn(liquid.offer_id, yes_ids)
+        self.assertNotIn(dead_offer.offer_id, yes_ids)
+
+        no = IndustryLpStoreExcludeNegligibleVolumeFilter(
+            request,
+            {"exclude_negligible_volume": "0"},
+            IndustryLpStoreOffer,
+            self.admin,
+        )
+        no_ids = set(
+            no.queryset(request, self.admin.get_queryset(request)).values_list(
+                "offer_id", flat=True
+            )
+        )
+        self.assertIn(dead_offer.offer_id, no_ids)
+        self.assertNotIn(bpc_offer.offer_id, no_ids)
+        self.assertNotIn(liquid.offer_id, no_ids)
+        self.assertEqual(
+            yes.lookups(request, self.admin), (("1", "Yes"), ("0", "No"))
+        )
+        self.assertIn(
+            IndustryLpStoreExcludeNegligibleVolumeFilter,
+            self.admin.list_filter,
         )
 
     @patch("industry.admin.offer_economics_for_queryset")

--- a/backend/industry/tests/test_lp_store_economics.py
+++ b/backend/industry/tests/test_lp_store_economics.py
@@ -23,6 +23,7 @@ from market.models import EveMarketItemHistory, EveMarketItemLocationPrice
 
 from industry.admin import (
     IndustryLpStoreCurrencyListFilter,
+    IndustryLpStoreExcludeChipsFilter,
     IndustryLpStoreExcludeSupplyPackagesFilter,
     IndustryLpStoreExcludeTagsFilter,
     IndustryLpStoreOfferAdmin,
@@ -753,6 +754,95 @@ class LpStoreOfferAdminTestCase(TestCase):
         self.assertNotIn(clean.offer_id, no_ids)
         self.assertIn(with_tag.offer_id, no_ids)
         self.assertIn(tag_offer.offer_id, no_ids)
+        self.assertEqual(
+            yes.lookups(request, self.admin), (("1", "Yes"), ("0", "No"))
+        )
+
+    def test_exclude_chips_hides_required_and_output_chip_offers(self):
+        """Nexus Chip as required item or output → excluded; implants stay."""
+        misc = EveGroup.objects.create(
+            id=315,
+            name="Miscellaneous",
+            published=True,
+            eve_category=EveCategory.objects.get(id=6),
+        )
+        chip = EveType.objects.create(
+            id=17816,
+            name="Minmatar UUB Nexus Chip",
+            published=True,
+            eve_group=misc,
+        )
+        # Social Adaptation Chip must NOT match Nexus Chip detection.
+        implant = EveType.objects.create(
+            id=9956,
+            name="Social Adaptation Chip - Basic",
+            published=True,
+            eve_group=misc,
+        )
+        clean = IndustryLpStoreOffer.objects.create(
+            offer_id=2300,
+            corporation_id=TLIB_CORP_ID,
+            type_id=INPUT_TYPE_ID,
+            lp_cost=1_000,
+            isk_cost=0,
+            quantity=1,
+        )
+        with_chip = IndustryLpStoreOffer.objects.create(
+            offer_id=2301,
+            corporation_id=TLIB_CORP_ID,
+            type_id=INPUT_TYPE_ID,
+            lp_cost=2_000,
+            isk_cost=0,
+            quantity=1,
+        )
+        IndustryLpStoreOfferRequiredItem.objects.create(
+            offer=with_chip,
+            type_id=chip.id,
+            quantity=4,
+        )
+        chip_offer = IndustryLpStoreOffer.objects.create(
+            offer_id=2302,
+            corporation_id=TLIB_CORP_ID,
+            type_id=chip.id,
+            lp_cost=500,
+            isk_cost=0,
+            quantity=1,
+        )
+        implant_offer = IndustryLpStoreOffer.objects.create(
+            offer_id=2303,
+            corporation_id=TLIB_CORP_ID,
+            type_id=implant.id,
+            lp_cost=800,
+            isk_cost=0,
+            quantity=1,
+        )
+        request = self.factory.get("/admin/industry/industrylpstoreoffer/")
+        request.user = self.user
+        yes = IndustryLpStoreExcludeChipsFilter(
+            request, {"exclude_chips": "1"}, IndustryLpStoreOffer, self.admin
+        )
+        yes_ids = set(
+            yes.queryset(
+                request, self.admin.get_queryset(request)
+            ).values_list("offer_id", flat=True)
+        )
+        self.assertIn(clean.offer_id, yes_ids)
+        self.assertIn(implant_offer.offer_id, yes_ids)
+        self.assertNotIn(with_chip.offer_id, yes_ids)
+        self.assertNotIn(chip_offer.offer_id, yes_ids)
+
+        no = IndustryLpStoreExcludeChipsFilter(
+            request, {"exclude_chips": "0"}, IndustryLpStoreOffer, self.admin
+        )
+        no_ids = set(
+            no.queryset(request, self.admin.get_queryset(request)).values_list(
+                "offer_id", flat=True
+            )
+        )
+        self.assertNotIn(clean.offer_id, no_ids)
+        self.assertNotIn(implant_offer.offer_id, no_ids)
+        self.assertIn(with_chip.offer_id, no_ids)
+        self.assertIn(chip_offer.offer_id, no_ids)
         self.assertEqual(
             yes.lookups(request, self.admin), (("1", "Yes"), ("0", "No"))
         )

--- a/backend/market/helpers/pricing.py
+++ b/backend/market/helpers/pricing.py
@@ -11,6 +11,7 @@ aka “ItemPrice”) as the Jita guide — see docs/market-pricing.md and
 """
 
 from datetime import timedelta
+from typing import Dict, Iterable, List, Optional, Sequence
 
 from django.db.models import OuterRef, Subquery, Sum
 from django.utils import timezone
@@ -21,6 +22,7 @@ from market.models.history import EveMarketItemHistory
 
 JITA_REGION_ID = 10000002
 VOLUME_LOOKBACK_DAYS = 90
+VOLUME_WINDOWS: tuple[int, ...] = (1, 7, 30)
 
 
 def _baseline_region_id() -> int:
@@ -76,14 +78,17 @@ def get_prices_by_type_id(type_ids: list[int]) -> dict[int, int]:
     return prices
 
 
-def get_volume_90d_by_type_id(type_ids: list[int]) -> dict[int, int]:
-    """Return summed market history volume over the last 90 days by type ID."""
-    if not type_ids:
+def get_volume_by_type_id(type_ids: list[int], *, days: int) -> dict[int, int]:
+    """
+    Sum EveMarketItemHistory.volume over the last ``days`` calendar days
+    for the price_baseline region (Forge when Jita is baseline).
+    """
+    if not type_ids or days <= 0:
         return {}
 
     unique_ids = list({int(tid) for tid in type_ids})
     region_id = _baseline_region_id()
-    cutoff = timezone.now().date() - timedelta(days=VOLUME_LOOKBACK_DAYS)
+    cutoff = timezone.now().date() - timedelta(days=days)
     rows = (
         EveMarketItemHistory.objects.filter(
             region_id=region_id,
@@ -98,3 +103,53 @@ def get_volume_90d_by_type_id(type_ids: list[int]) -> dict[int, int]:
         for row in rows
         if row["total"] is not None
     }
+
+
+def get_volume_90d_by_type_id(type_ids: list[int]) -> dict[int, int]:
+    """Return summed market history volume over the last 90 days by type ID."""
+    return get_volume_by_type_id(type_ids, days=VOLUME_LOOKBACK_DAYS)
+
+
+def get_volume_windows_by_type_id(
+    type_ids: Iterable[int],
+    windows: Sequence[int] = VOLUME_WINDOWS,
+) -> Dict[int, Dict[int, Optional[int]]]:
+    """
+    Sum daily Forge/baseline history volume for each lookback window.
+
+    One history query covering the widest window; per-type/per-window sums
+    are computed in Python. Missing history → type omitted (callers treat
+    as None / "—").
+    """
+    unique_ids = list({int(tid) for tid in type_ids})
+    clean_windows = sorted({int(w) for w in windows if int(w) > 0})
+    if not unique_ids or not clean_windows:
+        return {}
+
+    region_id = _baseline_region_id()
+    today = timezone.now().date()
+    max_days = clean_windows[-1]
+    cutoff = today - timedelta(days=max_days)
+
+    # {type_id: [(date, volume), ...]}
+    by_type: Dict[int, List[tuple]] = {tid: [] for tid in unique_ids}
+    for item_id, hist_date, volume in EveMarketItemHistory.objects.filter(
+        region_id=region_id,
+        item_id__in=unique_ids,
+        date__gte=cutoff,
+    ).values_list("item_id", "date", "volume"):
+        by_type[int(item_id)].append((hist_date, int(volume or 0)))
+
+    out: Dict[int, Dict[int, Optional[int]]] = {}
+    for type_id, rows in by_type.items():
+        if not rows:
+            continue
+        window_totals: Dict[int, Optional[int]] = {}
+        for days in clean_windows:
+            win_cutoff = today - timedelta(days=days)
+            total = sum(vol for d, vol in rows if d >= win_cutoff)
+            # Include zero when we saw rows in the outer window but none in
+            # this shorter window (distinguish from completely missing).
+            window_totals[days] = int(total)
+        out[type_id] = window_totals
+    return out

--- a/backend/market/tasks.py
+++ b/backend/market/tasks.py
@@ -12,7 +12,7 @@ from eveonline.models import (
     EveCorporationContract,
     EveLocation,
 )
-from industry.helpers.lp_catalog import lp_catalog_type_ids
+from industry.helpers.lp_catalog import lp_market_history_type_ids
 from market.helpers import (
     clear_structure_sell_orders_for_location,
     create_or_update_contract,
@@ -601,7 +601,7 @@ def fetch_market_item_history():
         EveMarketItemOrder.objects.values_list("item_id", flat=True).distinct()
     )
     try:
-        type_ids.update(lp_catalog_type_ids())
+        type_ids.update(lp_market_history_type_ids())
     except Exception:
         logger.exception(
             "Failed to load LP catalog type ids for market history"

--- a/backend/templates/admin/industry/industrylpstoreoffer/change_list.html
+++ b/backend/templates/admin/industry/industrylpstoreoffer/change_list.html
@@ -58,12 +58,13 @@
 
     .lp-store-offer-item {
       display: flex;
-      align-items: flex-start;
+      align-items: center;
       gap: 0.55em;
       line-height: 1.3;
     }
 
-    .lp-store-offer-item__icon {
+    .lp-store-offer-item__icon,
+    .lp-store-offer-item__placeholder {
       flex-shrink: 0;
       width: 32px;
       height: 32px;
@@ -71,20 +72,9 @@
       background: var(--darkened-bg, #222);
     }
 
-    .lp-store-offer-item__text {
-      display: flex;
-      flex-direction: column;
-      gap: 0.15em;
-      min-width: 0;
-    }
-
     .lp-store-offer-item__name {
       font-weight: 600;
-    }
-
-    .lp-store-offer-item__type {
-      color: var(--body-quiet-color, #888);
-      font-size: 0.85em;
+      min-width: 0;
     }
 
     #changelist #result_list td.field-conversion_sell_display,
@@ -92,12 +82,14 @@
     #changelist #result_list td.field-jita_sell_display,
     #changelist #result_list td.field-jita_buy_display,
     #changelist #result_list td.field-other_cost_display,
-    #changelist #result_list td.field-volume_90d_display,
+    #changelist #result_list td.field-volume_1d_display,
+    #changelist #result_list td.field-volume_7d_display,
+    #changelist #result_list td.field-volume_30d_display,
     #changelist #result_list td.field-isk_per_lp_display,
     #changelist #result_list td.field-cost_display,
     #changelist #result_list td.field-profit_vs_sell_display,
-    #changelist #result_list td.field-lp_cost,
-    #changelist #result_list td.field-isk_cost,
+    #changelist #result_list td.field-lp_cost_display,
+    #changelist #result_list td.field-isk_cost_display,
     #changelist #result_list td.field-quantity {
       font-variant-numeric: tabular-nums;
       text-align: right;
@@ -109,12 +101,14 @@
     #changelist #result_list th.column-jita_sell_display,
     #changelist #result_list th.column-jita_buy_display,
     #changelist #result_list th.column-other_cost_display,
-    #changelist #result_list th.column-volume_90d_display,
+    #changelist #result_list th.column-volume_1d_display,
+    #changelist #result_list th.column-volume_7d_display,
+    #changelist #result_list th.column-volume_30d_display,
     #changelist #result_list th.column-isk_per_lp_display,
     #changelist #result_list th.column-cost_display,
     #changelist #result_list th.column-profit_vs_sell_display,
-    #changelist #result_list th.column-lp_cost,
-    #changelist #result_list th.column-isk_cost,
+    #changelist #result_list th.column-lp_cost_display,
+    #changelist #result_list th.column-isk_cost_display,
     #changelist #result_list th.column-quantity {
       text-align: right;
     }

--- a/backend/templates/admin/industry/industrylpstoreoffer/change_list.html
+++ b/backend/templates/admin/industry/industrylpstoreoffer/change_list.html
@@ -5,7 +5,7 @@
   <style>
     /*
      * Wide economics table: keep checkbox + Item visible while scrolling
-     * horizontally, and allow long type names to wrap.
+     * horizontally, and allow long type names to wrap (Fuzzwork-style identity).
      */
     #changelist #result_list {
       border-collapse: separate;
@@ -31,8 +31,8 @@
       left: 2.5em;
       z-index: 1;
       background: var(--body-bg);
-      min-width: 14em;
-      max-width: 22em;
+      min-width: 16em;
+      max-width: 24em;
       box-shadow: 1px 0 0 var(--hairline-color, #ccc);
     }
 
@@ -43,7 +43,7 @@
 
     #changelist #result_list td.field-type_name_display {
       white-space: normal;
-      vertical-align: top;
+      vertical-align: middle;
     }
 
     #changelist #result_list tbody tr:nth-child(even) td.action-checkbox,
@@ -58,9 +58,24 @@
 
     .lp-store-offer-item {
       display: flex;
+      align-items: flex-start;
+      gap: 0.55em;
+      line-height: 1.3;
+    }
+
+    .lp-store-offer-item__icon {
+      flex-shrink: 0;
+      width: 32px;
+      height: 32px;
+      border-radius: 3px;
+      background: var(--darkened-bg, #222);
+    }
+
+    .lp-store-offer-item__text {
+      display: flex;
       flex-direction: column;
       gap: 0.15em;
-      line-height: 1.3;
+      min-width: 0;
     }
 
     .lp-store-offer-item__name {
@@ -70,6 +85,38 @@
     .lp-store-offer-item__type {
       color: var(--body-quiet-color, #888);
       font-size: 0.85em;
+    }
+
+    #changelist #result_list td.field-conversion_sell_display,
+    #changelist #result_list td.field-conversion_buy_display,
+    #changelist #result_list td.field-jita_sell_display,
+    #changelist #result_list td.field-jita_buy_display,
+    #changelist #result_list td.field-other_cost_display,
+    #changelist #result_list td.field-volume_90d_display,
+    #changelist #result_list td.field-isk_per_lp_display,
+    #changelist #result_list td.field-cost_display,
+    #changelist #result_list td.field-profit_vs_sell_display,
+    #changelist #result_list td.field-lp_cost,
+    #changelist #result_list td.field-isk_cost,
+    #changelist #result_list td.field-quantity {
+      font-variant-numeric: tabular-nums;
+      text-align: right;
+      white-space: nowrap;
+    }
+
+    #changelist #result_list th.column-conversion_sell_display,
+    #changelist #result_list th.column-conversion_buy_display,
+    #changelist #result_list th.column-jita_sell_display,
+    #changelist #result_list th.column-jita_buy_display,
+    #changelist #result_list th.column-other_cost_display,
+    #changelist #result_list th.column-volume_90d_display,
+    #changelist #result_list th.column-isk_per_lp_display,
+    #changelist #result_list th.column-cost_display,
+    #changelist #result_list th.column-profit_vs_sell_display,
+    #changelist #result_list th.column-lp_cost,
+    #changelist #result_list th.column-isk_cost,
+    #changelist #result_list th.column-quantity {
+      text-align: right;
     }
   </style>
 {% endblock %}

--- a/docs/market-pricing.md
+++ b/docs/market-pricing.md
@@ -77,7 +77,7 @@ Only need a coarse average / “has any price”?
 
 ## Correct examples in-repo
 
-- **LP store conversion:** `industry.helpers.lp_store_economics` — baseline `EveMarketItemLocationPrice` sell/buy when present, else Forge history via `get_prices_by_type_id`. Required-item “other cost” prices inputs at sell. Alliance buyback ISK/LP acquisition remains separate from conversion isk/lp rates.
+- **LP store conversion:** `industry.helpers.lp_store_economics` — baseline `EveMarketItemLocationPrice` sell/buy when present, else Forge history via `get_prices_by_type_id`. **Other cost** = LP-store required items (sell) **plus**, for blueprints, SDE manufacturing materials × offer quantity (Fuzzwork “Materials to build”). Alliance buyback ISK/LP acquisition remains LP-desk only (required items, not BOM). Fuzzwork itself uses a simulated 5% Jita buy (order-book percentile); we use LocationPrice/history, so thin-market rows can still diverge slightly.
 - **Buyback:** `buyback.helpers.pricing.get_baseline_buy_prices` — history only; docstring states not live order-book rows.
 - **Market admin contrast:** local book from LocationPrice, separate `jita_price` from history/`get_prices_by_type_id`.
 

--- a/frontend/app/.astro/types.d.ts
+++ b/frontend/app/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />


### PR DESCRIPTION
## Summary
- **Root cause of the screenshot:** `#2578` made Item sticky, but economics stash was still cleared in `changelist_view` before `TemplateResponse` rendered — so Item showed raw type IDs and every market column was `—`
- Force-render the changelist while the stash is live; fall back to EveType / currency names if needed
- Fuzzwork-like column order (item+icon, costs, required, Jita, ISK/LP rates, volume); harden missing required-items table

## Test plan
- [ ] Open Admin → Loyalty points → LP store offers
- [ ] Confirm Item shows names + icons (e.g. not just `3895` / `type 3895`)
- [ ] Confirm Currency shows names, not corp IDs
- [ ] Confirm Jita / ISK/LP columns populate when price data exists
- [ ] Scroll horizontally; Item stays pinned
- [ ] `pipenv run python manage.py test industry.tests.test_lp_store_economics --settings=app.settings_test`


Made with [Cursor](https://cursor.com)