### PR TITLE
Post LP buyback ISK-sent notice before archiving threads

### DIFF
--- a/backend/industry/helpers/lp_buyback_discord.py
+++ b/backend/industry/helpers/lp_buyback_discord.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import time
 
 from django.conf import settings
 
@@ -23,6 +24,10 @@ from industry.models import IndustryLoyaltyPointMarketOrder
 
 logger = logging.getLogger(__name__)
 discord = DiscordClient()
+
+# Match help tickets / bot ISK-sent: settle message traffic before archive so
+# Discord does not reopen the thread when a post lands after close.
+THREAD_ARCHIVE_DELAY_SECONDS = 5
 
 
 def order_site_url(order: IndustryLoyaltyPointMarketOrder) -> str:
@@ -365,6 +370,33 @@ def _awaiting_isk_message(order: IndustryLoyaltyPointMarketOrder) -> str:
     )
 
 
+def _completed_message(order: IndustryLoyaltyPointMarketOrder) -> str:
+    """Public completion notice; pings the LP sender (ISK recipient)."""
+    lp = _lp_quantity_for_isk(order)
+    isk = _isk_due(order)
+    mention = _user_mention(lp_sender(order))
+    lines: list[str] = []
+    if mention:
+        lines.extend([mention, ""])
+    lines.extend(
+        [
+            ":white_check_mark: ISK sent — order completed",
+            f"**{isk:,} ISK** for {lp:,} LP @ {order.isk_per_lp} ISK/LP",
+            order_site_url(order),
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _post_completed_then_archive(
+    order: IndustryLoyaltyPointMarketOrder,
+) -> None:
+    """Post completion, wait, then archive (avoids Discord reopen race)."""
+    post_order_status_update(order, message=_completed_message(order))
+    time.sleep(THREAD_ARCHIVE_DELAY_SECONDS)
+    close_order_thread(order)
+
+
 def notify_order_status_changed(
     order: IndustryLoyaltyPointMarketOrder,
 ) -> None:
@@ -381,7 +413,11 @@ def notify_order_status_changed(
             message=_awaiting_isk_message(order),
             components=isk_sent_components(order.pk),
         )
-    elif status in (order.Status.COMPLETED, order.Status.CANCELLED):
-        # Do not post a close/status message — Discord unarchives threads when
+    elif status == order.Status.COMPLETED:
+        # Post first, wait, then archive — never post after close (Discord
+        # unarchives). Caller must invoke after DB commit (see transition_order).
+        _post_completed_then_archive(order)
+    elif status == order.Status.CANCELLED:
+        # Do not post a cancel message — Discord unarchives threads when
         # anything is sent (including after archive), same race as help tickets.
         close_order_thread(order)

--- a/backend/industry/helpers/lp_market_orders.py
+++ b/backend/industry/helpers/lp_market_orders.py
@@ -285,55 +285,58 @@ def release_order_claims(
     return locked
 
 
-@transaction.atomic
 def transition_order(
     order: IndustryLoyaltyPointMarketOrder,
     new_status: str,
     *,
     destination_character_name: str | None = None,
 ) -> IndustryLoyaltyPointMarketOrder:
-    locked = (
-        IndustryLoyaltyPointMarketOrder.objects.select_for_update()
-        .select_related("loyalty_point", "created_by", "claimed_by")
-        .get(pk=order.pk)
-    )
-    if new_status == locked.status:
-        return locked
-
-    allowed = ALLOWED_TRANSITIONS.get(locked.status, frozenset())
-    if new_status not in allowed:
-        raise LpMarketOrderError(
-            f"Cannot transition from {locked.status} to {new_status}."
+    with transaction.atomic():
+        locked = (
+            IndustryLoyaltyPointMarketOrder.objects.select_for_update()
+            .select_related("loyalty_point", "created_by", "claimed_by")
+            .get(pk=order.pk)
         )
+        if new_status == locked.status:
+            return locked
 
-    if new_status == AWAITING_LP:
-        dest = (
-            destination_character_name
-            if destination_character_name is not None
-            else locked.destination_character_name
-        )
-        if not dest or not str(dest).strip():
+        allowed = ALLOWED_TRANSITIONS.get(locked.status, frozenset())
+        if new_status not in allowed:
             raise LpMarketOrderError(
-                "destination_character_name is required when awaiting LP."
+                f"Cannot transition from {locked.status} to {new_status}."
             )
-        locked.destination_character_name = str(dest).strip()
-    elif destination_character_name is not None:
-        locked.destination_character_name = str(
-            destination_character_name
-        ).strip()
 
-    previous = locked.status
-    locked.status = new_status
-    if new_status == COMPLETED:
-        locked.completed_at = timezone.now()
-        if locked.side == IndustryLoyaltyPointMarketOrder.Side.SELL:
-            try:
-                post_sell_order_completion_ledger(locked)
-            except LpLedgerError as exc:
-                raise LpMarketOrderError(str(exc)) from exc
-    locked.save()
+        if new_status == AWAITING_LP:
+            dest = (
+                destination_character_name
+                if destination_character_name is not None
+                else locked.destination_character_name
+            )
+            if not dest or not str(dest).strip():
+                raise LpMarketOrderError(
+                    "destination_character_name is required when awaiting LP."
+                )
+            locked.destination_character_name = str(dest).strip()
+        elif destination_character_name is not None:
+            locked.destination_character_name = str(
+                destination_character_name
+            ).strip()
 
-    if previous != locked.status:
+        previous = locked.status
+        locked.status = new_status
+        if new_status == COMPLETED:
+            locked.completed_at = timezone.now()
+            if locked.side == IndustryLoyaltyPointMarketOrder.Side.SELL:
+                try:
+                    post_sell_order_completion_ledger(locked)
+                except LpLedgerError as exc:
+                    raise LpMarketOrderError(str(exc)) from exc
+        locked.save()
+        status_changed = previous != locked.status
+
+    # Notify after commit so COMPLETED can post + delay + archive without
+    # holding select_for_update (and so Discord work is not rolled back).
+    if status_changed:
         # pylint: disable=import-outside-toplevel
         from industry.helpers import lp_buyback_discord
 

--- a/backend/industry/tests/test_loyalty_buyback.py
+++ b/backend/industry/tests/test_loyalty_buyback.py
@@ -1035,8 +1035,11 @@ class LpBuybackSideAwareMessagingTestCase(AppTestCase):
             f"lp_buyback:lp:{order.pk}",
         )
 
+    @patch("industry.helpers.lp_buyback_discord.time.sleep")
     @patch("industry.helpers.lp_buyback_discord.discord")
-    def test_completed_closes_thread_without_message(self, discord_mock):
+    def test_completed_posts_then_closes_thread(
+        self, discord_mock, sleep_mock
+    ):
         order = IndustryLoyaltyPointMarketOrder.objects.create(
             loyalty_point=self.currency,
             side=IndustryLoyaltyPointMarketOrder.Side.SELL,
@@ -1048,8 +1051,21 @@ class LpBuybackSideAwareMessagingTestCase(AppTestCase):
             discord_thread_id=555,
         )
         notify_order_status_changed(order)
-        discord_mock.create_message.assert_not_called()
+        discord_mock.create_message.assert_called_once()
+        payload = discord_mock.create_message.call_args.kwargs["payload"]
+        self.assertIn("ISK sent — order completed", payload["content"])
+        self.assertIn("**800,000 ISK** for 1,000 LP", payload["content"])
+        self.assertIn("<@1001>", payload["content"])
+        sleep_mock.assert_called_once_with(5)
         discord_mock.close_thread.assert_called_once_with(channel_id=555)
+        self.assertEqual(
+            [
+                call[0]
+                for call in discord_mock.method_calls
+                if call[0] in ("create_message", "close_thread")
+            ],
+            ["create_message", "close_thread"],
+        )
 
     @patch("industry.helpers.lp_buyback_discord.discord")
     def test_cancelled_closes_thread_without_message(self, discord_mock):

--- a/bot/app/lp_buyback/views.py
+++ b/bot/app/lp_buyback/views.py
@@ -41,8 +41,9 @@ async def _handle_ack(
 ) -> None:
     await interaction.response.defer(ephemeral=True)
 
-    # ISK sent completes the order and archives the thread. Confirm + clear
-    # buttons before the API close so nothing hits the thread afterward.
+    # ISK sent: clear buttons + settle interaction traffic, then the API posts
+    # a public "ISK sent" notice, waits, and archives (same delay as help
+    # tickets). Do not edit/followup the thread after the API returns.
     closes_thread = action == "isk_sent"
     if closes_thread:
         await _clear_message_buttons(interaction)


### PR DESCRIPTION
## Summary
- Completing an LP buyback order now posts a public Discord notice (`ISK sent — order completed`, pinging the LP sender) instead of silently closing the thread.
- Archives after a 5s delay (same pattern as help tickets) so Discord does not reopen the thread when traffic lands after close.
- Moves Discord notify to after DB commit so the post/delay/archive path does not hold `select_for_update`.

## Test plan
- [ ] Mark ISK sent via Discord button on an awaiting-ISK order; confirm thread gets completion message, then archives ~5s later and stays archived
- [ ] Mark ISK sent via web UI; confirm same Discord notice + archive behavior
- [ ] Cancel an order; confirm thread still closes without a status post
- [ ] `pipenv run python manage.py test industry.tests.test_loyalty_buyback --settings=app.settings_test`


Made with [Cursor](https://cursor.com)