### PR TITLE
Add Selling Loyalty Points guide

### DIFF
--- a/frontend/app/src/components/blocks/GuideMarkdown.astro
+++ b/frontend/app/src/components/blocks/GuideMarkdown.astro
@@ -1,0 +1,27 @@
+---
+/**
+ * Renders markdown guide HTML with cruiser-guide panel chrome.
+ * Pass HTML from `wrapMarkdownSectionsInPanels(pageProgressFromMarkdown(...).html)`.
+ */
+import './GuideMarkdown.scss'
+
+interface Props {
+    html: string
+    class?: string
+    [propName: string]: any
+}
+
+const {
+    html,
+    class: class_name,
+    ...attributes
+} = Astro.props
+
+delete attributes.class
+---
+
+<div
+    {...attributes}
+    class:list={['guide-md', class_name]}
+    set:html={html}
+/>

--- a/frontend/app/src/components/blocks/GuideMarkdown.scss
+++ b/frontend/app/src/components/blocks/GuideMarkdown.scss
@@ -1,0 +1,155 @@
+/**
+ * Cruiser/frigate-guide panel chrome for markdown guides.
+ * Pair with {@link wrapMarkdownSectionsInPanels}.
+ */
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@500;600;700&family=Source+Sans+3:ital,wght@0,400;0,600;1,400&display=swap');
+
+.guide-md {
+    --guide-md-display-font: 'Orbitron', var(--heading-font);
+    --guide-md-body-font: 'Source Sans 3', var(--body-font);
+    --guide-md-panel-padding-block: var(--component-padding-block);
+    --guide-md-panel-padding-inline: var(--space-l-xl);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-l);
+    width: 100%;
+    min-width: 0;
+    font-family: var(--guide-md-body-font);
+}
+
+.guide-md-preamble {
+    max-width: var(--max-text-width);
+    font-size: var(--step-0);
+    line-height: 1.7;
+}
+
+.guide-md-panel {
+    padding: var(--guide-md-panel-padding-block) var(--guide-md-panel-padding-inline);
+    background: color-mix(in srgb, var(--component-background) 72%, transparent);
+    border: 1px solid color-mix(in srgb, var(--border-color) 70%, transparent);
+    min-width: 0;
+}
+
+@media (max-width: 48rem) {
+    .guide-md-panel {
+        --guide-md-panel-padding-inline: var(--space-s);
+    }
+}
+
+.guide-md-section {
+    scroll-margin-top: calc(var(--header-height, 4rem) + var(--space-l));
+}
+
+.guide-md-section__title {
+    margin: 0 0 var(--space-m);
+    padding-bottom: var(--space-s);
+    border-bottom: 1px solid color-mix(in srgb, var(--border-color) 55%, transparent);
+    font-family: var(--guide-md-display-font);
+    font-size: clamp(var(--step-1), 2.5vw, var(--step-2));
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.guide-md-section :is(h3) {
+    margin: var(--space-l) 0 var(--space-m);
+    font-family: var(--guide-md-display-font);
+    font-size: var(--step-0);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--highlight);
+}
+
+.guide-md-section :is(p) {
+    margin: 0 0 var(--space-m);
+    font-size: var(--step-0);
+    line-height: 1.7;
+    max-width: var(--max-text-width);
+}
+
+.guide-md-section :is(ul, ol) {
+    margin: 0 0 var(--space-m);
+    padding-left: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-s);
+    line-height: 1.65;
+    max-width: var(--max-text-width);
+}
+
+.guide-md-section :is(li) {
+    margin: 0;
+}
+
+.guide-md-section :is(a) {
+    color: var(--highlight);
+    text-decoration: underline;
+    text-decoration-color: color-mix(in srgb, var(--fleet-yellow) 45%, transparent);
+    text-underline-offset: 0.15em;
+
+    &:hover,
+    &:focus-visible {
+        color: var(--fleet-yellow);
+        text-decoration-color: currentColor;
+    }
+}
+
+.guide-md-section :is(pre) {
+    margin: 0 0 var(--space-m);
+    padding: var(--space-s) var(--space-m);
+    overflow-x: auto;
+    background: color-mix(in srgb, var(--component-background) 88%, transparent);
+    border: 1px solid color-mix(in srgb, var(--border-color) 60%, transparent);
+    font-size: var(--step--1);
+    line-height: 1.5;
+}
+
+.guide-md-section :is(code) {
+    font-size: 0.92em;
+}
+
+.guide-md-section :is(pre code) {
+    font-size: inherit;
+}
+
+.guide-md-section :is(table) {
+    width: 100%;
+    margin: 0 0 var(--space-m);
+    border-collapse: collapse;
+    font-size: var(--step--1);
+    line-height: 1.5;
+}
+
+.guide-md-section :is(th, td) {
+    padding: var(--space-2xs) var(--space-s);
+    border: 1px solid color-mix(in srgb, var(--border-color) 65%, transparent);
+    text-align: left;
+    vertical-align: top;
+}
+
+.guide-md-section :is(th) {
+    font-family: var(--guide-md-display-font);
+    font-size: var(--step--2);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    background: color-mix(in srgb, var(--component-background) 88%, transparent);
+}
+
+.guide-md-section :is(blockquote) {
+    margin: 0 0 var(--space-m);
+    padding-left: var(--space-m);
+    border-left: 3px solid color-mix(in srgb, var(--fleet-red) 70%, transparent);
+    color: var(--text-color-secondary, var(--faded));
+}
+
+.guide-md-section :is(hr) {
+    margin: var(--space-l) 0;
+    border: 0;
+    border-top: 1px solid color-mix(in srgb, var(--border-color) 55%, transparent);
+}
+
+.guide-md-section :is(img) {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    border: 1px solid color-mix(in srgb, var(--border-color) 70%, transparent);
+}

--- a/frontend/app/src/data/guides/covers.ts
+++ b/frontend/app/src/data/guides/covers.ts
@@ -29,6 +29,7 @@ const GUIDE_COVERS: Record<string, string> = {
     'pochven-standings': '/images/guides/pochven-map.png',
     'zohar-hunting': '/images/guides/guides/level5s/wrath_of_angels.png',
     'bookmarks': '/images/assets-cover.jpg',
+    'selling-loyalty-points': '/images/loyalty-points-cover.webp',
 }
 
 /** Flat 1200×630 share cards for og:image / Twitter — not used as page heroes. */

--- a/frontend/app/src/data/guides/index.ts
+++ b/frontend/app/src/data/guides/index.ts
@@ -13,6 +13,7 @@ import * as abyss_stormbringer_t6_electrical from '@markdown/guides/abyss-stormb
 import * as abyss_trio_hawk_t5_dark from '@markdown/guides/abyss-trio-hawk-t5-dark.md'
 import * as zohar_hunting from '@markdown/guides/zohar-hunting.md'
 import * as bookmarks from '@markdown/guides/bookmarks.md'
+import * as selling_loyalty_points from '@markdown/guides/selling-loyalty-points.md'
 
 type GuideModule = {
     frontmatter: {
@@ -38,6 +39,7 @@ const guideModules: Record<string, GuideModule> = {
     'abyss-trio-hawk-t5-dark': abyss_trio_hawk_t5_dark,
     'zohar-hunting': zohar_hunting,
     'bookmarks': bookmarks,
+    'selling-loyalty-points': selling_loyalty_points,
 }
 
 export const guideCategories = ["Faction Warfare","PVP","PVE","Utility"] as const
@@ -85,6 +87,19 @@ export const guides: GuideMeta[] = [
             name: "A'Songala",
             id: 2120647389,
             entity: 'character',
+        }],
+    },
+    {
+        slug: "selling-loyalty-points",
+        title: "Selling Loyalty Points",
+        excerpt: "Convert Tribal Liberation Force LP into ISK: LP store offers, pitfalls, and alliance brokers.",
+        category: "Faction Warfare",
+        section: "Mechanics",
+        author: "Minmatar Fleet",
+        authors: [{
+            name: "Minmatar Fleet",
+            id: 99011978,
+            entity: 'alliance',
         }],
     },
     {
@@ -252,7 +267,7 @@ export const guides: GuideMeta[] = [
             id: 99011978,
             entity: 'alliance',
         }],
-    }
+    },
 ]
 
 export function getGuideBySlug(slug: string): (GuideMeta & { module: GuideModule }) | undefined {

--- a/frontend/app/src/data/guides/types.ts
+++ b/frontend/app/src/data/guides/types.ts
@@ -15,4 +15,9 @@ export type GuideMeta = {
     authors: Author[]
     path?: string
     hiddenFromIndex?: boolean
+    /**
+     * Map of section id → Contents group label (cruiser-guide style).
+     * Adjacent sections with the same group share one nav subheader.
+     */
+    contents_groups?: Record<string, string>
 }

--- a/frontend/app/src/helpers/pageProgress/index.ts
+++ b/frontend/app/src/helpers/pageProgress/index.ts
@@ -19,7 +19,8 @@ export {
     normalizeSectionIds,
     slugifySectionId,
 } from '@helpers/pageProgress/sections'
-export { parseMarkdownWithSections } from '@helpers/pageProgress/markdown'
+export { parseMarkdownWithSections, wrapMarkdownSectionsInPanels } from '@helpers/pageProgress/markdown'
+
 export {
     pageProgressFromMarkdown,
     pageProgressFromSections,

--- a/frontend/app/src/helpers/pageProgress/markdown.ts
+++ b/frontend/app/src/helpers/pageProgress/markdown.ts
@@ -35,3 +35,41 @@ export function parseMarkdownWithSections(markdown: string): string {
 
     return marked.parse(markdown, { renderer: progressRenderer }) as string
 }
+
+/**
+ * Wrap each tagged `##` block in a cruiser-guide-style panel section.
+ * Moves `id` / `data-section-id` onto the `<section>` (matches ship guides).
+ */
+export function wrapMarkdownSectionsInPanels(html: string): string {
+    const chunks = html.split(/(?=<h2\b[^>]*\bdata-section-id=)/i)
+    const out: string[] = []
+
+    for (const chunk of chunks) {
+        const match = chunk.match(/^<h2\b([^>]*)>([\s\S]*?)<\/h2>([\s\S]*)$/i)
+        if (!match) {
+            if (chunk.trim()) {
+                out.push(`<div class="guide-md-preamble">${chunk}</div>`)
+            }
+            continue
+        }
+
+        const attrs = match[1] ?? ''
+        const title_html = match[2] ?? ''
+        const body_html = match[3] ?? ''
+        const id_match = attrs.match(/\bdata-section-id="([^"]+)"/i)
+        const id = id_match?.[1] ?? ''
+        if (!id) {
+            out.push(chunk)
+            continue
+        }
+
+        out.push(
+            `<section id="${id}" data-section-id="${id}" class="guide-md-section guide-md-panel">` +
+                `<h2 class="guide-md-section__title">${title_html}</h2>` +
+                body_html +
+            `</section>`,
+        )
+    }
+
+    return out.join('\n')
+}

--- a/frontend/app/src/markdown/guides/selling-loyalty-points.md
+++ b/frontend/app/src/markdown/guides/selling-loyalty-points.md
@@ -1,0 +1,109 @@
+---
+title: 'Selling Loyalty Points'
+excerpt: 'Convert Tribal Liberation Force LP into ISK: LP store offers, pitfalls, and alliance brokers.'
+category: 'Faction Warfare'
+author: 'Minmatar Fleet'
+---
+## Overview
+
+Loyalty points are the reward for performing activities in faction warfare. They are by far the hardest part of faction warfare, mostly because they are extremely misunderstood by new players.
+
+In this guide, we are going to go over two ways to convert your loyalty points to ISK:
+
+1. **Brokers** — selling loyalty points directly to folks that convert them in volume, typically making 10–25% margins.
+2. **DIY** — using the loyalty point store to convert loyalty points into ISK for yourself.
+
+Both styles are valid, so we'll let you make the decision.
+
+The loyalty point store allows you to convert loyalty points into items that you can sell on the market. The formula is easy:
+
+```text
+ISK/LP ≈ (market price × quantity − ISK cost − other cost) / LP cost
+```
+
+The best way to understand this is to look at an online tool. [Fuzzwork’s LP store](https://www.fuzzwork.co.uk/lpstore/buy/10000002/1000182/withblueprints) is the classic external table. We prefer [our tool](/industry/loyalty/offers/) for the same information, because it's much more accessible to new players.
+
+## Recommendation
+
+Although we recommend everyone try to convert their own loyalty points at some point, we recommend the following path for all new players.
+
+1. Use a broker for your first 250M ISK. You will generate this in one day, and it will provide you the capital you need to convert your own loyalty points.
+2. Use high volume, lower value offers to convert your first billion ISK. You can do this in your first week of faction warfare.
+
+Please, don't try to convert loyalty points on day one — it's fairly complex and you need capital to do it. Much like yourself in your 20s: your income stream is your best moneymaker, not your capital.
+
+## Brokers
+
+### Overview
+
+If you want fast ISK without the hassle, sell to a broker. We recommend pilots start with this, because realistically it's faster to just keep running complexes.
+
+There are a few known brokers out there:
+
+| Broker | Where |
+| --- | --- |
+| **Minmatar Fleet** | [Loyalty Points](/industry/loyalty/) desk |
+| **LP Broker Discord** | Public LP broker communities |
+| **Militia Discord(s)** | Ask in your militia for known converters |
+
+Be extremely careful of scams — loyalty point scams are fairly common. Only use trusted sources.
+
+### Example flow
+
+1. Join the [Minmatar Fleet Discord](https://discord.gg/minmatar)
+2. Go to our [loyalty point store page](/industry/loyalty/)
+3. Press **Sell Loyalty Points**
+4. Select the type and amount
+5. Follow the instructions in the thread
+
+**Important:** There is no loyalty point ledger, so you will need to provide screenshots of the steps for the broker so that they can confirm you sent the loyalty points.
+
+## Systems
+
+To convert your loyalty points, you need to travel to a system with a loyalty point store for your faction.
+
+| Faction | Militia | Key highsec systems | Nearby trade hub |
+| --- | --- | --- | --- |
+| **Minmatar** | Tribal Liberation Force | **Hek** (0.8), **Amo** (0.5) | Hek → Jita |
+| **Amarr** | 24th Imperial Crusade | **Mehatoor** (0.7), **Dihra** (0.6), **Gammel** / **Myyhera** / **Sasiekko** (0.5) | Amarr → Jita |
+| **Caldari** | State Protectorate | **Nourvukaiken** (0.8), **Onnamon** (0.6), **Elanoda** / **Usi** / **Oshaima** (0.5) | Jita |
+| **Gallente** | Federal Defense Union | **Villore** (0.9), **Orvolle** (0.7), **Intaki** / **Caslemon** / **Aidart** (0.6) | Dodixie → Jita |
+
+Unless you are in Caldari State, you will likely need to move your goods to a major trade hub (usually Jita) to sell them. **Do not move large volumes of goods yourself.** New Eden is littered with Iteron Mark V wrecks worth a billion ISK where new players wanted to do everything themselves on their first day.
+
+Use a freight service to ship goods, where it makes sense:
+
+- **Red Frog Freight** (usually 1–2% of cargo, meaningless margin to you)
+- **PushX** (similar prices)
+
+If you insist on moving things yourself, we recommend sticking to low volumes (under 25M ISK) of Navy Cap Booster 3200 / Navy Cap Booster 800 and various datacores.
+
+## Stores
+
+Once you get to a store, you'll need to purchase an item so that you can sell it on the market. This is where those online tools come in handy.
+
+1. Go to [our loyalty point store tool](/industry/loyalty/offers/)
+2. Select your currency
+3. Select **Buy** for your first conversions
+
+From here, you'll see a table of offers that you can convert. There's a few things you want to look out for.
+
+1. **Volume.** The most common pitfall people hit is buying something that looks like it converts at a great price, but only a few sell every single week. You'll be stuck selling the same thing for months, and it won't move.
+2. **ISK/LP.** This is the rate that you get by converting this item.
+3. **Other cost.** This is the other tricky part — some items require other items, and ISK, to convert them. If you don't have capital, you can't take advantage of some offers.
+
+We recommend various sized cap boosters, datacores, and small (frigate, destroyer, etc) blueprints for players to start with. You can sell the blueprints on public contract — just undercut people until you get the hang of it.
+
+**Don't chase the ISK dragon too soon.** You're going to make hundreds of billions of ISK in loyalty points over your ISK career; saving a few hundred million at the start is meaningless.
+
+## Pitfalls
+
+- **Paper ISK/LP** — BPCs, rare modules, and low-volume navy hulls look rich and don’t clear.
+- **Ignoring required items** — navy upgrades that need a pile of T1 can erase the edge if you buy T1 retail in the wrong place.
+- **Dumping into a thin book** — one large sell order can push you below buyback rates; watch the spread and recent volume.
+- **Wrong price side** — planning on sell-side ISK/LP, then panic-selling into buy orders.
+- **Freight afterthought** — navy caps especially: product m³ can dominate. Quote PushX/Red Frog before you commit.
+- **Skins, chips, packages, vanity** — exclude them unless you have a specific buyer.
+- **Standing / docking** — alts without TLIB access cannot cash out that character’s LP in that store.
+- **Opportunity cost** — time spent manufacturing, hauling, and babysitting orders is real. Brokers exist so you can stay in fleets.
+- **Stale third-party tables** — always refresh; militia meta and Jita prices move.

--- a/frontend/app/src/pages/guides/[name].astro
+++ b/frontend/app/src/pages/guides/[name].astro
@@ -3,9 +3,12 @@ import { i18n } from '@helpers/i18n'
 const { t, translatePath } = i18n(Astro.url)
 
 import { getGuideBySlug } from '@/data/guides'
-import { getGuideSeoImage } from '@/data/guides/covers'
+import { getGuideCoverImage, getGuideSeoImage } from '@/data/guides/covers'
 import { buildGuideJsonLd, getGuidePageSeo } from '@/data/guides/seo'
-import { pageProgressFromMarkdown } from '@helpers/pageProgress'
+import {
+    pageProgressFromMarkdown,
+    wrapMarkdownSectionsInPanels,
+} from '@helpers/pageProgress'
 import { HTTP_404_Not_Found } from '@helpers/http_responses'
 import { get_site_origin } from '@helpers/seo'
 
@@ -18,6 +21,7 @@ if (!guide) {
 
 const site_origin = get_site_origin(Astro.url.origin)
 const { module } = guide
+const cover_image = getGuideCoverImage(guide)
 const seo = getGuidePageSeo({
     guide,
     siteName: t('index.page_title'),
@@ -33,10 +37,17 @@ const structured_data = buildGuideJsonLd({
     ...seo,
 })
 
-const { html: guide_html, sections, ...progress } = pageProgressFromMarkdown({
+const { html: markdown_html, sections: markdown_sections, ...progress } = pageProgressFromMarkdown({
     page_key: `guides/${guide.slug}`,
     page_title: guide.title,
     markdown: module.rawContent(),
+})
+
+const guide_html = wrapMarkdownSectionsInPanels(markdown_html)
+
+const sections = markdown_sections.map((section) => {
+    const group = guide.contents_groups?.[section.id]
+    return group ? { ...section, group } : section
 })
 
 import Viewport from '@layouts/Viewport.astro'
@@ -47,12 +58,11 @@ import PageTitle from '@components/page/PageTitle.astro'
 import TextBox from '@components/layout/TextBox.astro'
 
 import Flexblock from '@components/compositions/Flexblock.astro'
-import BlockList from '@components/compositions/BlockList.astro'
 
 import Button from '@components/blocks/Button.astro'
 import GuideContentsLayout from '@components/blocks/GuideContentsLayout.astro'
+import GuideMarkdown from '@components/blocks/GuideMarkdown.astro'
 import GuideShell from '@components/blocks/GuideShell.astro'
-import Tag from '@components/blocks/Tag.astro'
 import PageProgress from '@components/blocks/PageProgress.astro'
 import Wrapper from '@components/compositions/Wrapper.astro'
 
@@ -76,30 +86,27 @@ const shell_subtitle = guide.section
     <PageLanding
         wide={true}
         cover={{
-            image: '/images/guides-cover.jpg',
-            image_990: '/images/guides-cover-990.jpg',
+            image: cover_image,
+            image_990: cover_image,
             scrollable: true,
             overlay: true
         }}
     >
-        <Flexblock gap='var(--space-2xl)' data-page-progress-root>
-            <TextBox>
-                <Flexblock gap='var(--space-m)'>
-                    <div class="guide-header-top">
-                        <nav class="guide-breadcrumb" aria-label="Breadcrumb">
+        <Flexblock gap='var(--space-2xl)' class="guide-page" data-page-progress-root>
+            <TextBox max_width="var(--max-content-width)">
+                <Flexblock gap='var(--space-xl)'>
+                    <div class="guide-page__header-top">
+                        <nav class="guide-page__breadcrumb" aria-label="Breadcrumb">
                             <ol>
                                 <li><a href={translatePath('/guides/')}>{t('guides.page_title')}</a></li>
                                 <li aria-current="page">{guide.title}</li>
                             </ol>
                         </nav>
-                        <div class="guide-header-top__progress">
+                        <div class="guide-page__progress">
                             <PageProgress {...progress} />
                         </div>
                     </div>
-                    <Tag text={guide.category} />
                     <PageTitle is_landing={true}>{guide.title}</PageTitle>
-                    <p class="[ guide-excerpt ]">{guide.excerpt}</p>
-                    <small class="[ text-muted ]">{t('by_template').replace('{name}', guide.author)}</small>
                 </Flexblock>
             </TextBox>
 
@@ -110,32 +117,27 @@ const shell_subtitle = guide.section
             >
                 <GuideShell title={guide.title} subtitle={shell_subtitle}>
                     <GuideContentsLayout sections={sections}>
-                        <BlockList gap='var(--space-xl)'>
-                            <div
-                                class="[ prose ]"
-                                set:html={guide_html}
-                                x-data={`{
-                                    init_zoom() {
-                                        mediumZoom('.prose img', {
-                                            background: 'var(--solid-transparency-background)',
-                                            scrollOffset: 0,
-                                            margin: 24,
-                                            metaClick: false,
-                                        })
-                                    }
-                                }`}
-                                x-init="init_zoom()"
-                            />
+                        <GuideMarkdown
+                            html={guide_html}
+                            x-data={`{
+                                init_zoom() {
+                                    mediumZoom('.guide-md img', {
+                                        background: 'var(--solid-transparency-background)',
+                                        scrollOffset: 0,
+                                        margin: 24,
+                                        metaClick: false,
+                                    })
+                                }
+                            }`}
+                            x-init="init_zoom()"
+                        />
 
-                            <hr class="[ border-bottom ]" />
-
-                            <Button
-                                class="[ w-fit! ]"
-                                href={translatePath('/guides/')}
-                            >
-                                {t('guides.back_to_guides')}
-                            </Button>
-                        </BlockList>
+                        <Button
+                            class="[ w-fit! ]"
+                            href={translatePath('/guides/')}
+                        >
+                            {t('guides.back_to_guides')}
+                        </Button>
                     </GuideContentsLayout>
                 </GuideShell>
             </Wrapper>
@@ -144,7 +146,14 @@ const shell_subtitle = guide.section
 </Viewport>
 
 <style lang="scss">
-    .guide-header-top {
+    .guide-page {
+        width: 100%;
+        max-width: 100%;
+        min-width: 0;
+        overflow-x: clip;
+    }
+
+    .guide-page__header-top {
         display: flex;
         flex-wrap: wrap;
         justify-content: space-between;
@@ -153,12 +162,12 @@ const shell_subtitle = guide.section
         width: 100%;
     }
 
-    .guide-header-top__progress {
+    .guide-page__progress {
         flex: 0 0 auto;
         margin-left: auto;
     }
 
-    .guide-breadcrumb {
+    .guide-page__breadcrumb {
         margin: 0;
         min-width: 0;
 
@@ -170,12 +179,13 @@ const shell_subtitle = guide.section
             padding: 0;
             list-style: none;
             font-size: var(--step--1);
-            color: var(--muted-color);
+            color: var(--text-color-secondary, var(--faded));
         }
 
         li:not(:last-child)::after {
             content: '/';
             margin-left: var(--space-2xs);
+            color: var(--text-color-secondary, var(--faded));
         }
 
         a {
@@ -187,15 +197,5 @@ const shell_subtitle = guide.section
                 text-decoration: underline;
             }
         }
-    }
-
-    .guide-excerpt {
-        font-size: var(--step-1);
-        color: var(--muted-color);
-        max-width: 60ch;
-    }
-
-    .prose :global(h2[id]) {
-        scroll-margin-top: calc(var(--header-height, 4rem) + var(--space-l));
     }
 </style>

--- a/frontend/app/testing/helpers/wrapMarkdownSectionsInPanels.test.ts
+++ b/frontend/app/testing/helpers/wrapMarkdownSectionsInPanels.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+    parseMarkdownWithSections,
+    wrapMarkdownSectionsInPanels,
+} from '@helpers/pageProgress/markdown'
+
+describe('wrapMarkdownSectionsInPanels', () => {
+    it('wraps tagged h2 sections into guide-md panels', () => {
+        const html = parseMarkdownWithSections(`## Overview
+
+Hello.
+
+## Systems
+
+World.
+`)
+        const wrapped = wrapMarkdownSectionsInPanels(html)
+
+        expect(wrapped).toContain('class="guide-md-section guide-md-panel"')
+        expect(wrapped).toContain('id="overview" data-section-id="overview"')
+        expect(wrapped).toContain('id="systems" data-section-id="systems"')
+        expect(wrapped).toContain('class="guide-md-section__title">Overview</h2>')
+        expect(wrapped).not.toMatch(/<h2[^>]*data-section-id=/)
+    })
+
+    it('preserves preamble before the first section', () => {
+        const html = '<p>Lead-in</p>\n<h2 id="overview" data-section-id="overview">Overview</h2>\n<p>Body</p>\n'
+        const wrapped = wrapMarkdownSectionsInPanels(html)
+
+        expect(wrapped).toContain('class="guide-md-preamble"')
+        expect(wrapped).toContain('Lead-in')
+        expect(wrapped).toContain('data-section-id="overview"')
+    })
+})


### PR DESCRIPTION
## Summary
- Adds a Faction Warfare Mechanics guide covering LP brokers (FL33T desk flow) and DIY store conversion (systems, stores, pitfalls)
- Gives markdown guides the same panel / Orbitron section chrome as the cruiser guide via `GuideMarkdown` + `wrapMarkdownSectionsInPanels`
- Optional `contents_groups` on guide meta for Contents nav grouping (unused by this guide currently)

## Test plan
- [ ] Open `/guides/selling-loyalty-points/` and confirm Contents order: Overview → Recommendation → Brokers → Systems → Stores → Pitfalls
- [ ] Confirm Discord join link, loyalty desk link, and offers tool links work
- [ ] Spot-check another markdown guide (e.g. bookmarks) still renders with panel chrome
- [ ] `cd frontend/app && npm run test -- --run testing/helpers/wrapMarkdownSectionsInPanels.test.ts`


Made with [Cursor](https://cursor.com)