### PR TITLE
Use Amamake build costs for LP store BPC conversion

### DIFF
--- a/.cursor/rules/market-pricing.mdc
+++ b/.cursor/rules/market-pricing.mdc
@@ -24,7 +24,7 @@ See also: `docs/market-pricing.md`.
 
 - For **Jita guide prices**, call `get_prices_by_type_id` / `get_baseline_buy_prices`. Never query `EveMarketItemLocationPrice` alone as “Jita”.
 - Jita NPC station buy orders are often **empty** in LocationPrice; that broke buyback when LocationPrice was used as the guide (#2548).
-- LP store **conversion** rates use baseline LocationPrice sell/buy when present, else regional history (`get_prices_by_type_id`). Blueprint other cost includes manufacturing BOM × qty (Fuzzwork materials-to-build). Buyback / markup baselines use **regional history**, not live station rows alone.
+- LP store **conversion** rates use baseline LocationPrice sell/buy when present, else regional history (`get_prices_by_type_id`). Blueprint other cost uses Amamake build-planner manufacturing (compressed ore, jobs, taxes, freight) × qty — excluding navy BPC LP/ISK. Buyback / markup baselines use **regional history**, not live station rows alone.
 - `EveLocation.price_baseline` → which location’s **region** drives guide history (exactly one).
 - `EveLocation.prices_active` → sync LocationPrice from ESI (Jita can be prices_active without being a structure market).
 - `EveLocation.market_active` → alliance market sell-order / expectation flows — **not** the same as prices_active.

--- a/backend/industry/helpers/lp_store_economics.py
+++ b/backend/industry/helpers/lp_store_economics.py
@@ -2,10 +2,12 @@
 
 Conversion rates (isk/lp buy & sell) follow Fuzzwork's LP store formula:
   (market_price * qty - isk_cost - other_cost) / lp_cost
-where other_cost is LP-store required items plus, for blueprints, SDE
-manufacturing materials × offer quantity (Fuzzwork "Materials to build" at
-PE5 / ME0). Market prices use baseline LocationPrice buy/sell when present,
-else Forge history via get_prices_by_type_id.
+where other_cost is LP-store required items plus, for blueprints, Amamake
+build-planner manufacturing cost × offer quantity (compressed ore, job
+install, facility/SCC/reprocessing taxes, freight — excluding navy BPC
+LP/ISK, which stay in the formula via lp_cost / isk_cost). Market prices
+use baseline LocationPrice buy/sell when present, else Forge history via
+get_prices_by_type_id.
 
 Acquisition (LP×buyback rate + ISK + LP required items only) stays separate
 from conversion — it is the LP-desk cost, not finished-hull build cost.
@@ -21,7 +23,7 @@ from django.db import ProgrammingError
 from django.db.models import Sum
 from django.utils import timezone
 from eveonline.models import EveLocation
-from eveuniverse.models import EveIndustryActivityMaterial, EveType
+from eveuniverse.models import EveType
 
 from industry.helpers.blueprint_efficiency import is_faction_navy_hull
 from industry.helpers.lp_catalog import ensure_eve_types
@@ -32,7 +34,6 @@ from industry.helpers.product_unit_cost import (
     plan_product_unit_cost,
 )
 from industry.helpers.type_breakdown import (
-    ACTIVITY_MANUFACTURING,
     get_blueprint_or_reaction_type_id,
 )
 from industry.models import (
@@ -309,50 +310,6 @@ def _conversion_isk_per_lp(
     return (market_price * offer_qty - isk_cost - extras) / float(lp_cost)
 
 
-def manufacturing_materials_by_blueprint_type_id(
-    type_ids: Iterable[int],
-) -> Dict[int, List[Tuple[int, int]]]:
-    """
-    SDE manufacturing bill of materials keyed by blueprint type_id.
-
-    Quantities are ME0 / max Production Efficiency (Fuzzwork PE5) base runs.
-    Blueprints with no manufacturing rows are omitted.
-    """
-    unique = list({int(t) for t in type_ids})
-    if not unique:
-        return {}
-    out: Dict[int, List[Tuple[int, int]]] = {}
-    for bpc_id, mat_id, qty in EveIndustryActivityMaterial.objects.filter(
-        eve_type_id__in=unique,
-        activity_id=ACTIVITY_MANUFACTURING,
-    ).values_list("eve_type_id", "material_eve_type_id", "quantity"):
-        out.setdefault(int(bpc_id), []).append((int(mat_id), int(qty)))
-    return out
-
-
-def _priced_material_pack_cost(
-    materials: List[Tuple[int, int]],
-    *,
-    runs: int,
-    location_prices: Dict[int, Tuple[Optional[int], Optional[int]]],
-    history_prices: Dict[int, int],
-) -> Optional[int]:
-    """Sum sell×qty×runs for a BOM; None if any material lacks a price."""
-    if not materials:
-        return 0
-    total = 0
-    for mat_type_id, mat_qty in materials:
-        sell, _ = _resolve_sell_buy(
-            mat_type_id,
-            location_prices=location_prices,
-            history_prices=history_prices,
-        )
-        if sell is None:
-            return None
-        total += sell * mat_qty * runs
-    return total
-
-
 def _lp_store_required_cost(
     required: List[Tuple[int, int]],
     *,
@@ -381,13 +338,61 @@ def _lp_store_required_cost(
     return (total if priced else None), parts
 
 
-def _fuzzwork_other_cost(
+def _combine_other_cost(
     lp_store_other: Optional[int],
-    build_mats_other: Optional[int],
+    build_other: Optional[int],
 ) -> Optional[int]:
-    if lp_store_other is None or build_mats_other is None:
+    if lp_store_other is None or build_other is None:
         return None
-    return int(lp_store_other) + int(build_mats_other)
+    return int(lp_store_other) + int(build_other)
+
+
+def _amamake_manufacturing_costs(
+    product_type_ids: Iterable[int],
+    batch_sizes: Iterable[int],
+) -> Tuple[Dict[int, int], Dict[Tuple[int, int], Optional[int]]]:
+    """
+    Amamake planner costs for navy hulls.
+
+    Returns:
+      build_cost_per_unit: full unit cost at qty=1 (includes navy BPC LP)
+      mfg_cost_per: manufacturing-only unit cost keyed by (product, batch)
+    """
+    products = sorted({int(t) for t in product_type_ids})
+    batches = sorted({max(int(q), 1) for q in batch_sizes})
+    build_cost_per_unit: Dict[int, int] = {}
+    mfg_cost_per: Dict[Tuple[int, int], Optional[int]] = {}
+    if not products:
+        return build_cost_per_unit, mfg_cost_per
+
+    for product_type_id in products:
+        try:
+            unit = plan_product_unit_cost(
+                product_type_id, quantity=1, use_production_lp=True
+            )
+        except ValueError:
+            continue
+        build_cost_per_unit[product_type_id] = unit.cost_per
+        mfg_cost_per[(product_type_id, 1)] = unit.manufacturing_cost_per
+
+    for product_type_id in products:
+        for batch in batches:
+            if batch == 1:
+                continue
+            try:
+                unit = plan_product_unit_cost(
+                    product_type_id,
+                    quantity=batch,
+                    use_production_lp=True,
+                )
+            except ValueError:
+                mfg_cost_per[(product_type_id, batch)] = None
+                continue
+            mfg_cost_per[(product_type_id, batch)] = (
+                unit.manufacturing_cost_per
+            )
+
+    return build_cost_per_unit, mfg_cost_per
 
 
 def offer_economics_for_queryset(
@@ -427,14 +432,11 @@ def offer_economics_for_queryset(
     product_type_ids = {
         bpc_to_product[tid] for tid in offer_type_ids if tid in bpc_to_product
     }
-    req_type_ids = {tid for items in req_by_offer.values() for tid, _ in items}
-    bom_by_bpc = manufacturing_materials_by_blueprint_type_id(offer_type_ids)
-    bom_type_ids = {
-        mat_id for mats in bom_by_bpc.values() for mat_id, _ in mats
+    blueprint_batch_sizes = {
+        max(o.quantity, 1) for o in rows if o.type_id in bpc_to_product
     }
-    market_type_ids = sorted(
-        offer_type_ids | product_type_ids | req_type_ids | bom_type_ids
-    )
+    req_type_ids = {tid for items in req_by_offer.values() for tid, _ in items}
+    market_type_ids = sorted(offer_type_ids | product_type_ids | req_type_ids)
     ensure_eve_types(market_type_ids)
     history_prices = get_prices_by_type_id(market_type_ids)
     avg_7d_prices = get_volume_weighted_average_by_type_id(
@@ -451,15 +453,9 @@ def offer_economics_for_queryset(
         ).values_list("id", "name")
     }
 
-    build_costs: Dict[int, int] = {}
-    for product_type_id in sorted(product_type_ids):
-        try:
-            unit = plan_product_unit_cost(
-                product_type_id, use_production_lp=True
-            )
-        except ValueError:
-            continue
-        build_costs[product_type_id] = unit.cost_per
+    build_costs, mfg_cost_per = _amamake_manufacturing_costs(
+        product_type_ids, blueprint_batch_sizes
+    )
 
     out: Dict[int, LpStoreOfferEconomics] = {}
     for offer in rows:
@@ -477,33 +473,30 @@ def offer_economics_for_queryset(
             type_names=type_names,
         )
 
-        # Fuzzwork: Other Cost = LP required items + materials to build
-        # (manufacturing BOM × offer quantity). Acquisition stays LP-desk only.
         runs = max(offer.quantity, 1)
-        build_mats_other = _priced_material_pack_cost(
-            bom_by_bpc.get(type_id, []),
-            runs=runs,
-            location_prices=location_prices,
-            history_prices=history_prices,
-        )
-        other_cost = _fuzzwork_other_cost(lp_store_other, build_mats_other)
-
-        acquisition = _acquisition_isk_per_unit(
-            offer, isk_per_lp, lp_store_other
-        )
-
         product_type_id = bpc_to_product.get(type_id)
         if product_type_id is not None:
             kind = "blueprint"
             market_type_id = product_type_id
             build_cost = build_costs.get(product_type_id)
+            # Amamake manufacturing (excl. navy BPC LP) × offer quantity.
+            # BPC LP/ISK remain in the conversion formula via lp_cost/isk_cost.
+            mfg_per = mfg_cost_per.get((product_type_id, runs))
+            build_other = None if mfg_per is None else int(mfg_per) * runs
         else:
             kind = "input"
             market_type_id = type_id
             build_cost = None
+            build_other = 0
+
+        other_cost = _combine_other_cost(lp_store_other, build_other)
+
+        acquisition = _acquisition_isk_per_unit(
+            offer, isk_per_lp, lp_store_other
+        )
 
         # Cost/Profit compare LP-store acquisition per unit, not planner
-        # build cost (identical across same-hull BPCs) and not BOM other cost.
+        # build cost (identical across same-hull BPCs) and not Amamake mfg.
         cost_per_unit = acquisition
 
         jita_sell, jita_buy = _resolve_sell_buy(

--- a/backend/industry/helpers/product_unit_cost.py
+++ b/backend/industry/helpers/product_unit_cost.py
@@ -44,6 +44,9 @@ class ProductUnitCost:
     name: str
     kind: str  # "Navy" | "T1"
     cost_per: int
+    # Build cost excluding navy BPC LP/ISK (materials, jobs, taxes, freight).
+    # Same as cost_per for T1 / when no LP offer is priced in.
+    manufacturing_cost_per: int
     jita_sell: int
     profit_per: int
     isk_per_lp: Optional[float]
@@ -213,7 +216,9 @@ def plan_product_unit_cost(
         )
     else:
         batch_total = uncompressed_total_isk(plan, navy_bpc_isk=navy_isk)
+    mfg_batch_total = max(int(batch_total) - int(navy_isk), 0)
     cost_per = int(round(batch_total / batch))
+    manufacturing_cost_per = int(round(mfg_batch_total / batch))
 
     prices = sell_prices or jita_sell_prices_by_type_id([type_id])
     jita_sell = int(prices.get(type_id) or 0)
@@ -224,6 +229,7 @@ def plan_product_unit_cost(
         name=eve_type.name or str(type_id),
         kind=kind,
         cost_per=cost_per,
+        manufacturing_cost_per=manufacturing_cost_per,
         jita_sell=jita_sell,
         profit_per=profit_per,
         isk_per_lp=effective_lp if is_navy else None,

--- a/backend/industry/tests/test_loyalty_offers_api.py
+++ b/backend/industry/tests/test_loyalty_offers_api.py
@@ -127,7 +127,9 @@ class LoyaltyOffersApiTestCase(AppTestCase):
         )
         with patch(
             "industry.helpers.lp_store_economics.plan_product_unit_cost",
-            return_value=type("U", (), {"cost_per": None})(),
+            return_value=type(
+                "U", (), {"cost_per": None, "manufacturing_cost_per": None}
+            )(),
         ):
             rebuild_lp_store_offer_economics()
 

--- a/backend/industry/tests/test_lp_store_economics.py
+++ b/backend/industry/tests/test_lp_store_economics.py
@@ -226,7 +226,10 @@ class LpStoreEconomicsHelperTestCase(TestCase):
         return_value=type(
             "U",
             (),
-            {"cost_per": 180_000_000},
+            {
+                "cost_per": 180_000_000,
+                "manufacturing_cost_per": 50_000_000,
+            },
         )(),
     )
     def test_blueprint_row_uses_hull_market_and_build_cost(self, mock_plan):
@@ -244,20 +247,23 @@ class LpStoreEconomicsHelperTestCase(TestCase):
         self.assertEqual(econ.profit_vs_sell, 150_000_000)
         self.assertEqual(econ.isk_per_lp, 800.0)
         self.assertEqual(econ.acquisition_isk_per_unit, 100_000_000)
-        # Other cost includes SDE manufacturing BOM (1× LP Input Item @ 1.5M).
-        self.assertEqual(econ.other_cost, 1_500_000)
-        # (250M - 20M - 1.5M) / 100k LP = 2285
-        self.assertAlmostEqual(econ.conversion_isk_per_lp_sell, 2285.0)
-        self.assertAlmostEqual(econ.conversion_isk_per_lp_buy, 2285.0)
+        # Other cost = Amamake manufacturing (excl. navy BPC LP).
+        self.assertEqual(econ.other_cost, 50_000_000)
+        # (250M - 20M - 50M) / 100k LP = 1800
+        self.assertAlmostEqual(econ.conversion_isk_per_lp_sell, 1800.0)
+        self.assertAlmostEqual(econ.conversion_isk_per_lp_buy, 1800.0)
         self.assertEqual(econ.jita_avg_7d, 250_000_000)
-        self.assertAlmostEqual(econ.conversion_isk_per_lp_avg_7d, 2285.0)
+        self.assertAlmostEqual(econ.conversion_isk_per_lp_avg_7d, 1800.0)
 
     @patch(
         "industry.helpers.lp_store_economics.plan_product_unit_cost",
         return_value=type(
             "U",
             (),
-            {"cost_per": 180_000_000},
+            {
+                "cost_per": 180_000_000,
+                "manufacturing_cost_per": 50_000_000,
+            },
         )(),
     )
     def test_blueprint_offers_differ_by_acquisition(self, mock_plan):
@@ -290,13 +296,13 @@ class LpStoreEconomicsHelperTestCase(TestCase):
         self.assertEqual(cheap_econ.profit_vs_sell, 218_000_000)
         self.assertEqual(dear_econ.profit_vs_sell, 208_000_000)
         self.assertNotEqual(cheap_econ.cost_per_unit, dear_econ.cost_per_unit)
-        # Conversion subtracts BOM (1.5M); acquisition does not.
-        # cheap: (250M - 0 - 1.5M) / 40k = 6212.5
-        self.assertAlmostEqual(cheap_econ.conversion_isk_per_lp_sell, 6212.5)
-        self.assertEqual(cheap_econ.other_cost, 1_500_000)
+        # Conversion subtracts Amamake mfg (50M); acquisition does not.
+        # cheap: (250M - 0 - 50M) / 40k = 5000
+        self.assertAlmostEqual(cheap_econ.conversion_isk_per_lp_sell, 5000.0)
+        self.assertEqual(cheap_econ.other_cost, 50_000_000)
 
-    def test_blueprint_pack_multiplies_build_materials_in_other_cost(self):
-        """Fuzzwork scales Materials to build by offer quantity."""
+    def test_blueprint_pack_multiplies_amamake_mfg_in_other_cost(self):
+        """Amamake manufacturing cost scales by offer quantity."""
         pack = IndustryLpStoreOffer.objects.create(
             offer_id=1012,
             corporation_id=TLIB_CORP_ID,
@@ -307,14 +313,21 @@ class LpStoreEconomicsHelperTestCase(TestCase):
         )
         with patch(
             "industry.helpers.lp_store_economics.plan_product_unit_cost",
-            return_value=type("U", (), {"cost_per": 180_000_000})(),
+            return_value=type(
+                "U",
+                (),
+                {
+                    "cost_per": 180_000_000,
+                    "manufacturing_cost_per": 50_000_000,
+                },
+            )(),
         ):
             econ = offer_economics_for_queryset([pack])[pack.pk]
-        # 10 runs × 1 input @ 1.5M
-        self.assertEqual(econ.other_cost, 15_000_000)
-        # (250M * 10 - 100M - 15M) / 100k = 23850
-        self.assertAlmostEqual(econ.conversion_isk_per_lp_sell, 23850.0)
-        # Acquisition ignores BOM: (100k*800 + 100M) / 10 = 18M
+        # 10 runs × 50M Amamake mfg / hull
+        self.assertEqual(econ.other_cost, 500_000_000)
+        # (250M * 10 - 100M - 500M) / 100k = 19000
+        self.assertAlmostEqual(econ.conversion_isk_per_lp_sell, 19000.0)
+        # Acquisition ignores build: (100k*800 + 100M) / 10 = 18M
         self.assertEqual(econ.acquisition_isk_per_unit, 18_000_000)
 
     def test_volume_windows_sum_daily_history(self):

--- a/backend/industry/tests/test_lp_store_offer_economics_rebuild.py
+++ b/backend/industry/tests/test_lp_store_offer_economics_rebuild.py
@@ -79,7 +79,9 @@ class LpStoreOfferEconomicsRebuildTestCase(TestCase):
     def test_rebuild_writes_snapshot_rows(self):
         with patch(
             "industry.helpers.lp_store_economics.plan_product_unit_cost",
-            return_value=type("U", (), {"cost_per": None})(),
+            return_value=type(
+                "U", (), {"cost_per": None, "manufacturing_cost_per": None}
+            )(),
         ):
             count = rebuild_lp_store_offer_economics()
         self.assertEqual(count, 1)
@@ -121,7 +123,9 @@ class LpStoreOfferEconomicsRebuildTestCase(TestCase):
         )
         with patch(
             "industry.helpers.lp_store_economics.plan_product_unit_cost",
-            return_value=type("U", (), {"cost_per": None})(),
+            return_value=type(
+                "U", (), {"cost_per": None, "manufacturing_cost_per": None}
+            )(),
         ):
             rebuild_lp_store_offer_economics()
         row = IndustryLpStoreOfferEconomics.objects.get(offer=skin_offer)
@@ -132,7 +136,9 @@ class LpStoreOfferEconomicsRebuildTestCase(TestCase):
     def test_rebuild_replaces_previous_rows(self):
         with patch(
             "industry.helpers.lp_store_economics.plan_product_unit_cost",
-            return_value=type("U", (), {"cost_per": None})(),
+            return_value=type(
+                "U", (), {"cost_per": None, "manufacturing_cost_per": None}
+            )(),
         ):
             rebuild_lp_store_offer_economics()
             IndustryLpStoreOffer.objects.create(

--- a/backend/industry/tests/test_order_profit_breakdown.py
+++ b/backend/industry/tests/test_order_profit_breakdown.py
@@ -90,6 +90,7 @@ class OrderProfitBreakdownTestCase(AppTestCase):
             name=name,
             kind="T1",
             cost_per=1_000_000,
+            manufacturing_cost_per=1_000_000,
             jita_sell=1_500_000,
             profit_per=500_000,
             isk_per_lp=None,

--- a/backend/industry/tests/test_orders_profit_summary.py
+++ b/backend/industry/tests/test_orders_profit_summary.py
@@ -62,6 +62,7 @@ class OrdersProfitSummaryEndpointTestCase(AppTestCase):
             name=name,
             kind="T1",
             cost_per=1_000_000,
+            manufacturing_cost_per=1_000_000,
             jita_sell=1_500_000,
             profit_per=500_000,
             isk_per_lp=None,

--- a/docs/market-pricing.md
+++ b/docs/market-pricing.md
@@ -77,7 +77,7 @@ Only need a coarse average / “has any price”?
 
 ## Correct examples in-repo
 
-- **LP store conversion:** `industry.helpers.lp_store_economics` — baseline `EveMarketItemLocationPrice` sell/buy when present, else Forge history via `get_prices_by_type_id`. **Other cost** = LP-store required items (sell) **plus**, for blueprints, SDE manufacturing materials × offer quantity (Fuzzwork “Materials to build”). Alliance buyback ISK/LP acquisition remains LP-desk only (required items, not BOM). Fuzzwork itself uses a simulated 5% Jita buy (order-book percentile); we use LocationPrice/history, so thin-market rows can still diverge slightly.
+- **LP store conversion:** `industry.helpers.lp_store_economics` — baseline `EveMarketItemLocationPrice` sell/buy when present, else Forge history via `get_prices_by_type_id`. **Other cost** = LP-store required items (sell) **plus**, for blueprints, Amamake build-planner manufacturing cost × offer quantity (compressed ore, job install, facility/SCC/reprocessing taxes, freight — excluding navy BPC LP/ISK, which stay in the conversion formula via `lp_cost` / `isk_cost`). Alliance buyback ISK/LP acquisition remains LP-desk only (required items, not build). Fuzzwork itself uses ME0 mineral BOM + a simulated 5% Jita buy; we diverge for navy BPCs by assuming an Amamake build.
 - **Buyback:** `buyback.helpers.pricing.get_baseline_buy_prices` — history only; docstring states not live order-book rows.
 - **Market admin contrast:** local book from LocationPrice, separate `jita_price` from history/`get_prices_by_type_id`.
 

--- a/frontend/app/src/markdown/guides/selling-loyalty-points.md
+++ b/frontend/app/src/markdown/guides/selling-loyalty-points.md
@@ -110,7 +110,7 @@ We recommend various sized cap boosters, datacores, and small (frigate, destroye
 
 ## Pitfalls
 
-- **Paper ISK/LP** — BPCs, rare modules, and low-volume navy hulls look rich and don’t clear.
+- **Paper ISK/LP** — BPCs, rare modules, and low-volume navy hulls can still look rich and don’t clear. Our BPC rates assume you build the hull in Amamake (planner costs), then sell the hull — not BPC contract flips.
 - **Ignoring required items** — navy upgrades that need a pile of T1 can erase the edge if you buy T1 retail in the wrong place.
 - **Dumping into a thin book** — one large sell order can push you below buyback rates; watch the spread and recent volume.
 - **Wrong price side** — planning on sell-side ISK/LP, then panic-selling into buy orders.


### PR DESCRIPTION
## Summary
- Navy blueprint LP store ISK/LP `other_cost` now uses Amamake build-planner manufacturing (compressed ore, job install, taxes, freight) × offer quantity instead of ME0 Jita mineral BOM.
- Excludes navy BPC LP/ISK from that other cost so the conversion formula does not double-count the LP desk.
- Documents the Amamake assumption in market-pricing docs and the Selling Loyalty Points guide.

## Test plan
- [ ] `pipenv run python manage.py test industry.tests.test_lp_store_economics industry.tests.test_loyalty_offers_api industry.tests.test_lp_store_offer_economics_rebuild --settings=app.settings_test`
- [ ] After economics rebuild, confirm BPC rows on `/industry/loyalty/offers/` show higher other cost / lower ISK/LP vs prior Fuzzwork-style BOM math
- [ ] Confirm non-blueprint offers (caps, drones, modules) are unchanged
- [ ] Spot-check a navy BPC against the Amamake build planner for the same hull


Made with [Cursor](https://cursor.com)