### PR TITLE
Polish LP offers page styling and currency logos

### DIFF
--- a/frontend/app/src/components/blocks/LoyaltyOffersFilters.astro
+++ b/frontend/app/src/components/blocks/LoyaltyOffersFilters.astro
@@ -7,6 +7,7 @@ import {
     DEFAULT_LOYALTY_OFFERS_PARAMS,
     TLIB_CORP_ID,
 } from '@helpers/loyalty_offers_metrics'
+import { get_corporation_logo } from '@helpers/eve_image_server'
 import { query_string } from '@helpers/string'
 
 import Flexblock from '@components/compositions/Flexblock.astro'
@@ -15,6 +16,14 @@ import Input from '@components/blocks/Input.astro'
 import Select from '@components/blocks/Select.astro'
 import Button from '@components/blocks/Button.astro'
 import MagnifierIcon from '@components/icons/buttons/MagnifierIcon.astro'
+import CaretIcon from '@components/icons/CaretIcon.astro'
+
+const FACTION_ORDER: readonly number[] = [
+    1000182, // TLIB
+    1000179, // 24th
+    1000180, // State
+    1000181, // FDU
+]
 
 interface Props {
     currencies: LoyaltyCurrency[]
@@ -55,6 +64,19 @@ const selected_currency = currencies.some((c) => c.corporation_id === currency)
     : (currencies.find((c) => c.corporation_id === TLIB_CORP_ID)?.corporation_id
         ?? currencies[0]?.corporation_id
         ?? TLIB_CORP_ID)
+
+const sorted_currencies = [...currencies].sort((a, b) => {
+    const ai = FACTION_ORDER.indexOf(a.corporation_id)
+    const bi = FACTION_ORDER.indexOf(b.corporation_id)
+    const ao = ai === -1 ? FACTION_ORDER.length : ai
+    const bo = bi === -1 ? FACTION_ORDER.length : bi
+    if (ao !== bo) return ao - bo
+    return a.name.localeCompare(b.name)
+})
+
+const selected_currency_record = sorted_currencies.find(
+    (c) => c.corporation_id === selected_currency,
+) ?? sorted_currencies[0] ?? null
 
 const base_params: Record<string, string> = {
     currency: String(selected_currency),
@@ -133,7 +155,7 @@ const excludes = [
 ]
 
 const hx_include_filters =
-    ".loyalty-offers-filters__persist, .loyalty-offers-filters__search [name='q'], select[name='currency'], select[name='side']"
+    ".loyalty-offers-filters__persist, .loyalty-offers-filters__search [name='q'], select[name='side']"
 ---
 
 <Flexblock class="[ loyalty-offers-filters ]" gap="var(--space-s)">
@@ -143,28 +165,88 @@ const hx_include_filters =
         justification="space-between"
     >
         <FlexInline gap="var(--space-s)" class="[ loyalty-offers-filters__controls ]">
-            <Select
-                name="currency"
-                size="sm"
-                width="16rem"
-                required
-                hx-get={PARTIAL}
-                hx-target={SLOT}
-                hx-swap="innerHTML"
-                hx-indicator=".loader"
-                hx-trigger="change"
-                hx-include={hx_include_filters}
-                class="[ loyalty-offers-filters__select ]"
+            <div
+                class="[ loyalty-offers-filters__currency ]"
+                x-data={`{
+                    open: false,
+                    close() { this.open = false },
+                    toggle() { this.open = this.open ? false : true },
+                }`}
+                @keydown.escape.prevent.stop="close()"
+                @mousedown.outside="open && close()"
+                @htmx:before-request="close()"
             >
-                {currencies.map((c) => (
-                    <option
-                        value={String(c.corporation_id)}
-                        selected={selected_currency === c.corporation_id}
-                    >
-                        {c.name}
-                    </option>
-                ))}
-            </Select>
+                <button
+                    type="button"
+                    class="[ loyalty-offers-filters__currency-trigger ]"
+                    @click.prevent="toggle()"
+                    x-bind:aria-expanded="open"
+                    aria-haspopup="listbox"
+                    aria-controls="loyalty-offers-currency-options"
+                    aria-label={t('industry.loyalty.offers.currency_label')}
+                >
+                    {selected_currency_record && (
+                        <img
+                            class="[ loyalty-offers-filters__currency-logo ]"
+                            src={get_corporation_logo(selected_currency_record.corporation_id, 32)}
+                            width="20"
+                            height="20"
+                            alt=""
+                            loading="lazy"
+                        />
+                    )}
+                    <span class="[ loyalty-offers-filters__currency-name ]">
+                        {selected_currency_record?.name
+                            ?? t('industry.loyalty.offers.currency_label')}
+                    </span>
+                    <CaretIcon class="[ loyalty-offers-filters__currency-caret ]" />
+                </button>
+
+                <ul
+                    id="loyalty-offers-currency-options"
+                    class="[ loyalty-offers-filters__currency-options ]"
+                    role="listbox"
+                    x-show="open"
+                    x-cloak
+                    style="display: none"
+                >
+                    {sorted_currencies.map((c) => (
+                        <li role="presentation">
+                            <button
+                                type="button"
+                                role="option"
+                                class:list={[
+                                    '[ loyalty-offers-filters__currency-option ]',
+                                    {
+                                        'loyalty-offers-filters__currency-option--selected':
+                                            selected_currency === c.corporation_id,
+                                    },
+                                ]}
+                                aria-selected={selected_currency === c.corporation_id
+                                    ? 'true'
+                                    : 'false'}
+                                @click="close()"
+                                hx-get={with_params({
+                                    currency: String(c.corporation_id),
+                                })}
+                                hx-target={SLOT}
+                                hx-swap="innerHTML"
+                                hx-indicator=".loader"
+                            >
+                                <img
+                                    class="[ loyalty-offers-filters__currency-logo ]"
+                                    src={get_corporation_logo(c.corporation_id, 32)}
+                                    width="20"
+                                    height="20"
+                                    alt=""
+                                    loading="lazy"
+                                />
+                                <span>{c.name}</span>
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            </div>
 
             <Select
                 name="side"
@@ -204,7 +286,7 @@ const hx_include_filters =
                     value={q}
                     placeholder={t('industry.loyalty.offers.search_placeholder')}
                     size="sm"
-                    width="18rem"
+                    width="22rem"
                 >
                     <MagnifierIcon slot="icon" />
                 </Input>
@@ -245,6 +327,7 @@ const hx_include_filters =
     </FlexInline>
 
     <div class="[ loyalty-offers-filters__persist ]" hidden>
+        <input type="hidden" name="currency" value={String(selected_currency)} />
         <input type="hidden" name="ordering" value={ordering} />
         {exclude_tags === '1' && <input type="hidden" name="exclude_tags" value="1" />}
         {exclude_supply_packages === '1' && (
@@ -265,6 +348,10 @@ const hx_include_filters =
 </Flexblock>
 
 <style lang="scss">
+    [x-cloak] {
+        display: none !important;
+    }
+
     .loyalty-offers-filters__toolbar {
         flex-wrap: wrap;
         width: 100%;
@@ -276,8 +363,120 @@ const hx_include_filters =
         align-items: center;
     }
 
+    .loyalty-offers-filters__currency {
+        position: relative;
+        flex-shrink: 0;
+        width: 18rem;
+        max-width: 100%;
+    }
+
+    .loyalty-offers-filters__currency-trigger {
+        appearance: none;
+        display: flex;
+        align-items: center;
+        gap: var(--space-2xs);
+        width: 100%;
+        margin: 0;
+        padding-block: var(--space-2xs);
+        padding-inline: var(--space-xs-s) var(--space-m);
+        border: solid 1px var(--border-color);
+        background-color: rgba(85, 85, 85, 0.1);
+        backdrop-filter: blur(var(--input-backdrop-blur));
+        color: var(--form-color);
+        cursor: pointer;
+        text-align: left;
+        transition: border-color var(--fast-transition), background-color var(--fast-transition);
+
+        @media (hover: hover) {
+            &:hover {
+                border-color: var(--border-color-hover);
+            }
+        }
+
+        &:focus-visible {
+            outline: 1px solid var(--highlight);
+            outline-offset: 2px;
+        }
+
+        &[aria-expanded='true'] {
+            background-color: var(--component-background);
+        }
+    }
+
+    .loyalty-offers-filters__currency-name {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-size: var(--step--1);
+    }
+
+    .loyalty-offers-filters__currency-logo {
+        flex-shrink: 0;
+        width: 20px;
+        height: 20px;
+        border-radius: 2px;
+        background-color: var(--background);
+    }
+
+    .loyalty-offers-filters__currency-caret {
+        flex-shrink: 0;
+        color: var(--highlight);
+    }
+
+    .loyalty-offers-filters__currency-options {
+        position: absolute;
+        inset-inline-start: 0;
+        inset-block-start: calc(100% + 2px);
+        z-index: var(--sticky-z-index);
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        width: max(100%, 18rem);
+        border: solid 1px var(--border-color);
+        background-color: var(--component-background);
+    }
+
+    .loyalty-offers-filters__currency-option {
+        appearance: none;
+        display: flex;
+        align-items: center;
+        gap: var(--space-2xs);
+        width: 100%;
+        margin: 0;
+        padding-block: var(--space-2xs);
+        padding-inline: var(--space-xs-s);
+        border: 0;
+        background: transparent;
+        color: var(--form-color);
+        cursor: pointer;
+        font-size: var(--step--1);
+        text-align: left;
+
+        @media (hover: hover) {
+            &:hover {
+                background-color: color-mix(in srgb, var(--fleet-yellow) 12%, transparent);
+                color: var(--highlight);
+            }
+        }
+
+        &--selected {
+            background-color: color-mix(in srgb, var(--fleet-red) 35%, transparent);
+            color: var(--highlight);
+        }
+
+        &:focus-visible {
+            outline: 1px solid var(--highlight);
+            outline-offset: -2px;
+        }
+    }
+
     .loyalty-offers-filters__search {
         display: flex;
+        flex-shrink: 0;
+        width: 22rem;
+        max-width: 100%;
     }
 
     .loyalty-offers-filters__chips {
@@ -286,27 +485,39 @@ const hx_include_filters =
 
     .loyalty-offers-filters__chip {
         appearance: none;
+        margin: 0;
         background: transparent;
-        border: solid 1px var(--border-color);
-        color: var(--foreground);
+        border: solid 1px color-mix(in srgb, var(--fleet-yellow) 40%, transparent);
+        color: var(--fleet-yellow);
         cursor: pointer;
         font-family: var(--button-font);
         font-size: var(--step--2);
-        letter-spacing: 0.02em;
+        font-weight: 600;
+        letter-spacing: 0.06em;
         padding-block: var(--space-3xs);
         padding-inline: var(--space-xs);
         text-transform: uppercase;
-        transition: border-color var(--fast-transition), color var(--fast-transition);
+        transition:
+            border-color var(--fast-transition),
+            background-color var(--fast-transition),
+            color var(--fast-transition);
 
         &--active {
             border-color: var(--fleet-yellow);
-            color: var(--highlight);
+            background: var(--fleet-yellow);
+            color: var(--background);
         }
 
         @media (hover: hover) {
             &:hover {
-                border-color: var(--highlight);
-                color: var(--highlight);
+                border-color: var(--fleet-yellow);
+                background: color-mix(in srgb, var(--fleet-yellow) 12%, transparent);
+                color: var(--fleet-yellow);
+            }
+
+            &--active:hover {
+                background: var(--fleet-yellow);
+                color: var(--background);
             }
         }
 

--- a/frontend/app/src/components/blocks/LoyaltyOffersMetrics.astro
+++ b/frontend/app/src/components/blocks/LoyaltyOffersMetrics.astro
@@ -6,6 +6,7 @@ import type { LoyaltyOffersMetrics } from '@helpers/loyalty_offers_metrics'
 import { format_number, number_name, number_thousand_separator } from '@helpers/numbers'
 
 import Grid from '@components/compositions/Grid.astro'
+import ComponentBlock from '@components/blocks/ComponentBlock.astro'
 
 interface Props {
     metrics: LoyaltyOffersMetrics
@@ -49,15 +50,23 @@ function lp_tippy(value: number): string | undefined {
         row_gap="var(--space-s)"
         column_gap="var(--space-s)"
     >
-        <article class="[ loyalty-offers-metrics__card ]">
+        <ComponentBlock
+            class="[ loyalty-offers-metrics__card ]"
+            padding_block="var(--space-m)"
+            padding_inline="var(--space-m)"
+        >
             <p class="[ loyalty-offers-metrics__label ]">
                 {t('industry.loyalty.offers.metrics.avg_isk_lp')}
             </p>
             <p class="[ loyalty-offers-metrics__value ]">{avg_display}</p>
             <p class="[ loyalty-offers-metrics__meta ]">{avg_meta}</p>
-        </article>
+        </ComponentBlock>
 
-        <article class="[ loyalty-offers-metrics__card ]">
+        <ComponentBlock
+            class="[ loyalty-offers-metrics__card ]"
+            padding_block="var(--space-m)"
+            padding_inline="var(--space-m)"
+        >
             <p class="[ loyalty-offers-metrics__label ]">
                 {t('industry.loyalty.offers.metrics.weekly_lp')}
             </p>
@@ -66,9 +75,13 @@ function lp_tippy(value: number): string | undefined {
                 data-tippy-content={lp_tippy(metrics.weekly_lp_volume)}
             >{lp_display(metrics.weekly_lp_volume)}</p>
             <p class="[ loyalty-offers-metrics__meta ]">{filters_applied}</p>
-        </article>
+        </ComponentBlock>
 
-        <article class="[ loyalty-offers-metrics__card ]">
+        <ComponentBlock
+            class="[ loyalty-offers-metrics__card ]"
+            padding_block="var(--space-m)"
+            padding_inline="var(--space-m)"
+        >
             <p class="[ loyalty-offers-metrics__label ]">
                 {t('industry.loyalty.offers.metrics.monthly_lp')}
             </p>
@@ -77,18 +90,17 @@ function lp_tippy(value: number): string | undefined {
                 data-tippy-content={lp_tippy(metrics.monthly_lp_volume)}
             >{lp_display(metrics.monthly_lp_volume)}</p>
             <p class="[ loyalty-offers-metrics__meta ]">{filters_applied}</p>
-        </article>
+        </ComponentBlock>
     </Grid>
 </section>
 
 <style lang="scss">
-    .loyalty-offers-metrics__card {
+    .loyalty-offers-metrics :global(.loyalty-offers-metrics__card) {
         display: flex;
         flex-direction: column;
         gap: var(--space-3xs);
-        padding: var(--space-m);
-        border: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
-        background: color-mix(in srgb, var(--background) 78%, transparent);
+        height: 100%;
+        box-sizing: border-box;
     }
 
     .loyalty-offers-metrics__label {
@@ -116,7 +128,7 @@ function lp_tippy(value: number): string | undefined {
 
     .loyalty-offers-metrics__meta {
         margin: 0;
-        color: color-mix(in srgb, var(--foreground) 65%, transparent);
+        color: var(--faded);
         font-size: var(--step--1);
     }
 </style>

--- a/frontend/app/src/components/blocks/LoyaltyOffersMetricsSkeleton.astro
+++ b/frontend/app/src/components/blocks/LoyaltyOffersMetricsSkeleton.astro
@@ -1,5 +1,6 @@
 ---
 import Grid from '@components/compositions/Grid.astro'
+import ComponentBlock from '@components/blocks/ComponentBlock.astro'
 ---
 
 <section class="[ loyalty-offers-metrics-skeleton ]" aria-hidden="true">
@@ -10,29 +11,32 @@ import Grid from '@components/compositions/Grid.astro'
         column_gap="var(--space-s)"
     >
         {Array.from({ length: 3 }).map(() => (
-            <div class="[ loyalty-offers-metrics-skeleton__card ]">
+            <ComponentBlock
+                class="[ loyalty-offers-metrics-skeleton__card ]"
+                padding_block="var(--space-m)"
+                padding_inline="var(--space-m)"
+            >
                 <div class="[ skel skel-label ]"></div>
                 <div class="[ skel skel-value ]"></div>
                 <div class="[ skel skel-meta ]"></div>
-            </div>
+            </ComponentBlock>
         ))}
     </Grid>
 </section>
 
 <style lang="scss">
-    .loyalty-offers-metrics-skeleton .skel {
-        border-radius: 2px;
-        background: color-mix(in srgb, var(--background) 85%, var(--foreground));
-        animation: loyalty-offers-metrics-skel 1.2s ease-in-out infinite;
-    }
-
-    .loyalty-offers-metrics-skeleton__card {
+    .loyalty-offers-metrics-skeleton :global(.loyalty-offers-metrics-skeleton__card) {
         display: flex;
         flex-direction: column;
         gap: var(--space-3xs);
-        padding: var(--space-m);
-        border: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
-        background: color-mix(in srgb, var(--background) 78%, transparent);
+        height: 100%;
+        box-sizing: border-box;
+    }
+
+    .loyalty-offers-metrics-skeleton .skel {
+        border-radius: 2px;
+        background: color-mix(in srgb, var(--component-background) 70%, var(--foreground));
+        animation: loyalty-offers-metrics-skel 1.2s ease-in-out infinite;
     }
 
     .skel-label {

--- a/frontend/app/src/components/blocks/LoyaltyOffersSkeleton.astro
+++ b/frontend/app/src/components/blocks/LoyaltyOffersSkeleton.astro
@@ -1,33 +1,37 @@
 ---
 import Flexblock from '@components/compositions/Flexblock.astro'
+import ComponentBlock from '@components/blocks/ComponentBlock.astro'
 import LoyaltyOffersMetricsSkeleton from '@components/blocks/LoyaltyOffersMetricsSkeleton.astro'
 ---
 
-<div class="[ loyalty-offers-skeleton solid-transparency ]" aria-hidden="true">
+<div class="[ loyalty-offers-skeleton ]" aria-hidden="true">
     <Flexblock gap="var(--space-l)">
         <LoyaltyOffersMetricsSkeleton />
-        <div class="[ loyalty-offers-skeleton__toolbar ]"></div>
-        <div class="[ loyalty-offers-skeleton__chips ]"></div>
-        <div class="[ loyalty-offers-skeleton__table ]">
-            <div class="[ loyalty-offers-skeleton__header ]"></div>
-            {Array.from({ length: 8 }).map(() => (
-                <div class="[ loyalty-offers-skeleton__row ]"></div>
-            ))}
-        </div>
+        <ComponentBlock
+            class="[ loyalty-offers-skeleton__body ]"
+            padding_block="var(--space-m)"
+            padding_inline="var(--space-s)"
+        >
+            <Flexblock gap="var(--space-l)">
+                <div class="[ loyalty-offers-skeleton__toolbar ]"></div>
+                <div class="[ loyalty-offers-skeleton__chips ]"></div>
+                <div class="[ loyalty-offers-skeleton__table ]">
+                    <div class="[ loyalty-offers-skeleton__header ]"></div>
+                    {Array.from({ length: 8 }).map(() => (
+                        <div class="[ loyalty-offers-skeleton__row ]"></div>
+                    ))}
+                </div>
+            </Flexblock>
+        </ComponentBlock>
     </Flexblock>
 </div>
 
 <style lang="scss">
-    .loyalty-offers-skeleton {
-        padding-block: var(--space-m);
-        padding-inline: var(--space-s);
-    }
-
     .loyalty-offers-skeleton__toolbar,
     .loyalty-offers-skeleton__chips,
     .loyalty-offers-skeleton__header,
     .loyalty-offers-skeleton__row {
-        background: color-mix(in srgb, var(--background) 85%, var(--foreground));
+        background: color-mix(in srgb, var(--component-background) 70%, var(--foreground));
         border-radius: 2px;
         animation: loyalty-offers-pulse 1.2s ease-in-out infinite;
     }

--- a/frontend/app/src/i18n/ui.ts
+++ b/frontend/app/src/i18n/ui.ts
@@ -645,6 +645,7 @@ export const ui = {
         'industry.loyalty.offers.showing_plural': 'Showing {count} offers',
         'industry.loyalty.offers.showing_singular': 'Showing {count} offer',
         'industry.loyalty.offers.search_placeholder': 'Search item name or id…',
+        'industry.loyalty.offers.currency_label': 'Loyalty store',
         'industry.loyalty.offers.currency_all': 'All currencies',
         'industry.loyalty.offers.side_sell': 'Sell',
         'industry.loyalty.offers.side_buy': 'Buy',

--- a/frontend/app/src/pages/partials/loyalty_offers_component.astro
+++ b/frontend/app/src/pages/partials/loyalty_offers_component.astro
@@ -114,6 +114,7 @@ import UpdateAlpineVariables from '@components/blocks/UpdateAlpineVariables.astr
 import LoyaltyOffersFilters from '@components/blocks/LoyaltyOffersFilters.astro'
 import LoyaltyOffersMetrics from '@components/blocks/LoyaltyOffersMetrics.astro'
 import LoyaltyOffersTable from '@components/blocks/LoyaltyOffersTable.astro'
+import ComponentBlock from '@components/blocks/ComponentBlock.astro'
 import Flexblock from '@components/compositions/Flexblock.astro'
 ---
 
@@ -126,49 +127,50 @@ import Flexblock from '@components/compositions/Flexblock.astro'
         }}
     />
 ) : (
-    <div class="[ loyalty-offers-panel solid-transparency ]">
-        <Flexblock gap="var(--space-l)" class="[ compensate-bottom-bar ]">
-            <UpdateAlpineVariables
-                variables={{
-                    offers_count: offers_list.total,
-                    last_updated_text: last_updated_text,
-                }}
-            />
-            <LoyaltyOffersMetrics metrics={metrics} />
-            <LoyaltyOffersFilters
-                currencies={currencies}
-                currency={currency}
-                exclude_tags={exclude_tags}
-                exclude_supply_packages={exclude_supply_packages}
-                exclude_chips={exclude_chips}
-                exclude_skins={exclude_skins}
-                exclude_blueprints={exclude_blueprints}
-                exclude_useless_offers={exclude_useless_offers}
-                exclude_below_set_lp_price={exclude_below_set_lp_price}
-                side={side}
-                q={q || ''}
-                ordering={ordering}
-            />
-            {offers_list.items.length > 0 ? (
-                <LoyaltyOffersTable
-                    offers={offers_list.items}
-                    filter_state={filter_state}
-                    ordering={ordering}
+    <Flexblock gap="var(--space-l)" class="[ loyalty-offers-panel compensate-bottom-bar ]">
+        <UpdateAlpineVariables
+            variables={{
+                offers_count: offers_list.total,
+                last_updated_text: last_updated_text,
+            }}
+        />
+        <LoyaltyOffersMetrics metrics={metrics} />
+        <ComponentBlock
+            class="[ loyalty-offers-panel__body ]"
+            padding_block="var(--space-m)"
+            padding_inline="var(--space-s)"
+        >
+            <Flexblock gap="var(--space-l)">
+                <LoyaltyOffersFilters
+                    currencies={currencies}
+                    currency={currency}
+                    exclude_tags={exclude_tags}
+                    exclude_supply_packages={exclude_supply_packages}
+                    exclude_chips={exclude_chips}
+                    exclude_skins={exclude_skins}
+                    exclude_blueprints={exclude_blueprints}
+                    exclude_useless_offers={exclude_useless_offers}
+                    exclude_below_set_lp_price={exclude_below_set_lp_price}
                     side={side}
+                    q={q || ''}
+                    ordering={ordering}
                 />
-            ) : (
-                <p class="[ loyalty-offers-empty ]">{t('industry.loyalty.offers.empty')}</p>
-            )}
-        </Flexblock>
-    </div>
+                {offers_list.items.length > 0 ? (
+                    <LoyaltyOffersTable
+                        offers={offers_list.items}
+                        filter_state={filter_state}
+                        ordering={ordering}
+                        side={side}
+                    />
+                ) : (
+                    <p class="[ loyalty-offers-empty ]">{t('industry.loyalty.offers.empty')}</p>
+                )}
+            </Flexblock>
+        </ComponentBlock>
+    </Flexblock>
 )}
 
 <style lang="scss">
-    .loyalty-offers-panel {
-        padding-block: var(--space-m);
-        padding-inline: var(--space-s);
-    }
-
     .loyalty-offers-empty {
         color: var(--foreground);
         font-size: var(--step-0);


### PR DESCRIPTION
## Summary
- Soften LP offers metrics/filters surfaces with `ComponentBlock` / light-transparency instead of harsh pure-black panels
- Replace the currency `<select>` with a logo + name picker (closed state and dropdown), and keep it closing on select/outside/Escape
- Widen the search field so the placeholder no longer clips, and align exclude chips with the existing gold active-chip pattern

## Test plan
- [ ] Open `/industry/loyalty/offers/` and confirm metric cards use soft glass surfaces (not pure black cutouts)
- [ ] Confirm currency picker shows corp logos; open/close works; selecting a corp closes the menu and refreshes offers
- [ ] Confirm search placeholder fully readable (`Search item name or id…`)
- [ ] Confirm exclude chips show gold fill when active; reset filters still works
- [ ] `cd frontend/app && npm run check`


Made with [Cursor](https://cursor.com)