### PR TITLE
Fix PlanCostOptions kwargs collision on include_navy_bpc

### DIFF
--- a/backend/industry/helpers/plan_costing.py
+++ b/backend/industry/helpers/plan_costing.py
@@ -159,21 +159,25 @@ class PlanCostOptions(BaseModel):
     def planner_defaults(cls, **kwargs) -> "PlanCostOptions":
         """Interactive planner / profit / guide: alliance inbound freight."""
         return cls(
-            input_freight=FreightOptions.alliance_default(),
-            output_freight=FreightOptions.off(),
-            sales_tax=SalesTaxOptions.off(),
-            **kwargs,
+            **{
+                "input_freight": FreightOptions.alliance_default(),
+                "output_freight": FreightOptions.off(),
+                "sales_tax": SalesTaxOptions.off(),
+                **kwargs,
+            }
         )
 
     @classmethod
     def lp_conversion_defaults(cls, **kwargs) -> "PlanCostOptions":
         """LP store net: Red Frog value freight; no alliance route."""
         return cls(
-            input_freight=FreightOptions.red_frog_jita_amo(),
-            output_freight=FreightOptions.red_frog_jita_amo(),
-            sales_tax=SalesTaxOptions.accounting_v(),
-            include_navy_bpc=False,
-            **kwargs,
+            **{
+                "input_freight": FreightOptions.red_frog_jita_amo(),
+                "output_freight": FreightOptions.red_frog_jita_amo(),
+                "sales_tax": SalesTaxOptions.accounting_v(),
+                "include_navy_bpc": False,
+                **kwargs,
+            }
         )
 
 

--- a/backend/industry/tests/test_plan_costing.py
+++ b/backend/industry/tests/test_plan_costing.py
@@ -11,6 +11,7 @@ from industry.helpers.plan_costing import (
     FreightMode,
     FreightOptions,
     ItemPlanCost,
+    PlanCostOptions,
     SalesTaxOptions,
     plan_lp_offer_conversion,
 )
@@ -30,6 +31,36 @@ class FreightOptionsTestCase(TestCase):
             FreightOptions.alliance_default().mode,
             FreightMode.alliance_route,
         )
+
+
+class PlanCostOptionsDefaultsTestCase(TestCase):
+    def test_lp_conversion_defaults_allow_include_navy_bpc_override(self):
+        # Callers pass include_navy_bpc / freight overrides; must not collide
+        # with factory hardcoded kwargs (MINMATAR-CELERY-K4).
+        with_bpc = PlanCostOptions.lp_conversion_defaults(
+            include_navy_bpc=True,
+            input_freight=FreightOptions.off(),
+            output_freight=FreightOptions.off(),
+        )
+        without_bpc = PlanCostOptions.lp_conversion_defaults(
+            include_navy_bpc=False,
+            input_freight=FreightOptions.off(),
+        )
+        self.assertTrue(with_bpc.include_navy_bpc)
+        self.assertFalse(without_bpc.include_navy_bpc)
+        self.assertEqual(with_bpc.input_freight.mode, FreightMode.off)
+        self.assertEqual(
+            PlanCostOptions.lp_conversion_defaults().include_navy_bpc,
+            False,
+        )
+
+    def test_planner_defaults_allow_freight_override(self):
+        opts = PlanCostOptions.planner_defaults(
+            input_freight=FreightOptions.off(),
+            include_navy_bpc=True,
+        )
+        self.assertEqual(opts.input_freight.mode, FreightMode.off)
+        self.assertTrue(opts.include_navy_bpc)
 
 
 class PlanLpOfferConversionTestCase(TestCase):


### PR DESCRIPTION
## Summary
- `PlanCostOptions.lp_conversion_defaults()` (and `planner_defaults`) now merge factory defaults with `**kwargs` so overrides like `include_navy_bpc` / freight do not raise `TypeError: got multiple values for keyword argument`
- Fixes Celery failure in `rebuild_lp_store_offer_economics_task` ([MINMATAR-CELERY-K4](https://minmatar-fleet.sentry.io/issues/MINMATAR-CELERY-K4))
- Adds regression tests for override paths

## Test plan
- [x] `pipenv run python manage.py test industry.tests.test_plan_costing --settings=app.settings_test`
- [ ] Confirm LP store offer economics rebuild task succeeds after deploy


Made with [Cursor](https://cursor.com)