### PR TITLE
Add hover affordance to LP offers table

### DIFF
--- a/frontend/app/src/components/blocks/LoyaltyOfferItem.astro
+++ b/frontend/app/src/components/blocks/LoyaltyOfferItem.astro
@@ -245,6 +245,16 @@ const conversion_tippy = loyalty_conversion_tip_lines(breakdown, {
 
         &[data-tippy-content] {
             cursor: help;
+            text-decoration: underline dotted color-mix(in srgb, currentColor 35%, transparent);
+            text-underline-offset: 0.2em;
+            transition: var(--fast-transition);
+
+            @media (hover: hover) {
+                &:hover {
+                    color: var(--fleet-yellow);
+                    text-decoration-color: currentColor;
+                }
+            }
         }
     }
 </style>

--- a/frontend/app/src/components/blocks/LoyaltyOffersTable.astro
+++ b/frontend/app/src/components/blocks/LoyaltyOffersTable.astro
@@ -151,7 +151,10 @@ import LoyaltyOfferItem from '@components/blocks/LoyaltyOfferItem.astro'
         font: inherit;
         letter-spacing: inherit;
         padding: 0;
+        text-decoration: underline dotted color-mix(in srgb, currentColor 35%, transparent);
         text-transform: inherit;
+        text-underline-offset: 0.2em;
+        transition: var(--fast-transition);
 
         &:focus-visible {
             outline: 1px solid var(--highlight);
@@ -161,6 +164,7 @@ import LoyaltyOfferItem from '@components/blocks/LoyaltyOfferItem.astro'
         @media (hover: hover) {
             &:hover {
                 color: var(--fleet-yellow);
+                text-decoration-color: currentColor;
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add dotted underline + yellow hover on sortable LP offers column headers so they read as interactive.
- Same treatment on tippy cells (other cost, ISK/LP, volume) so breakdown/LP tooltips have a clear hover cue.

## Test plan
- [ ] Open `/industry/loyalty/offers` and confirm sort headers show a dotted underline at rest
- [ ] Hover headers: solid underline + fleet yellow; click still sorts via htmx
- [ ] Hover other cost / ISK/LP / 7d–30d vol cells: same underline cue and tippy still opens
- [ ] Quantity column (no tippy) stays undecorated


Made with [Cursor](https://cursor.com)