### PR TITLE
Let tribe leadership apply to groups without an existing membership

### DIFF
--- a/frontend/app/src/components/blocks/ButtonAddTribeCharacter.astro
+++ b/frontend/app/src/components/blocks/ButtonAddTribeCharacter.astro
@@ -9,7 +9,7 @@ interface Props {
     tribe_id:               number;
     group_id:               number;
     pilots:                 SummaryCharacter[];
-    membership_id:          number;
+    membership_id:          number | null;
     hidden?:                boolean;
     id:                     string;
 }
@@ -74,8 +74,8 @@ import StylessButton from '@components/blocks/StylessButton.astro';
                         <StylessButton
                             size='sm'
                             hx-post={`${TRIBE_GROUP_MEMBERSHIPS_PARTIAL_URL}&${query_string({
-                                membership_id: membership_id,
                                 character_id: pilot.character_id,
+                                ...(membership_id && { membership_id })
                             })}`}
                             hx-target={`#members`}
                             hx-indicator=".loader"

--- a/frontend/app/src/components/blocks/GroupLeadership.astro
+++ b/frontend/app/src/components/blocks/GroupLeadership.astro
@@ -2,13 +2,13 @@
 import { i18n } from '@helpers/i18n'
 const { t } = i18n(Astro.url)
 
-import type { TribeCharacterRef, TribeGroup, SummaryCharacter, TribeMembership } from '@dtypes/api.minmatar.org'
+import type { TribeCharacterRef, TribeGroup, SummaryCharacter, TribeMembership, TribeAvailableCharacter } from '@dtypes/api.minmatar.org'
 interface Props {
-    chief:              TribeCharacterRef | null;
-    elders:             TribeCharacterRef[];
-    user_characters:    SummaryCharacter[];
-    tribe_group:        TribeGroup;
-    chief_membership:   TribeMembership | null;
+    chief:                  TribeCharacterRef | null;
+    elders:                 TribeCharacterRef[];
+    user_characters:        SummaryCharacter[];
+    tribe_group:            TribeGroup;
+    chief_membership:       TribeMembership | null;
 }
 
 const {
@@ -19,8 +19,10 @@ const {
     chief_membership,
 } = Astro.props
 
-const membership_character_ids = chief_membership?.characters.map(character => character.character_id)
-const available_characters = user_characters.filter(character => !membership_character_ids?.includes(character.character_id))
+const membership_character_ids = chief_membership ? chief_membership.characters.map(character => character.character_id) : []
+const available_characters = membership_character_ids.length > 0 ?
+    user_characters.filter(character => !membership_character_ids?.includes(character.character_id)) :
+    user_characters
 
 import Flexblock from '@components/compositions/Flexblock.astro';
 import FlexInline from '@components/compositions/FlexInline.astro';
@@ -43,13 +45,13 @@ import ButtonAddTribeCharacter from '@components/blocks/ButtonAddTribeCharacter.
             >
                 <small>{t('group_chief')}</small>
             </PilotBadge>
-            {chief_membership && available_characters.length > 0 &&
+            {available_characters.length > 0 &&
                 <ButtonAddTribeCharacter
                     id='leader-add-character'
                     title={tribe_group.name}
                     tribe_id={tribe_group.tribe_id}
                     group_id={tribe_group.id}
-                    membership_id={chief_membership.id}
+                    membership_id={chief_membership?.id || null}
                     pilots={available_characters}
                 />
             }

--- a/frontend/app/src/pages/partials/tribe_group_memberships_component.astro
+++ b/frontend/app/src/pages/partials/tribe_group_memberships_component.astro
@@ -27,6 +27,7 @@ import type { TribeGroup, TribeMembership, SummaryCharacter } from '@dtypes/api.
 import {
     get_tribe_group,
     get_memberships,
+    apply_to_group,
     approve_membership,
     deny_membership,
     delete_membership,
@@ -48,14 +49,20 @@ if (Astro.request.method === "POST") {
     const status = Astro.url.searchParams.get('status')
 
     try {
-        if (isNaN(membership_id))
-            throw new Error(t('invalid_membership_id'))
+        if (isNaN(membership_id)) {
+            const membership = await apply_to_group(
+                auth_token as string,
+                tribe_id,
+                group_id,
+                [ character_id ]
+            )
 
-        if (status === 'approve')
+            await approve_membership(auth_token as string, tribe_id, group_id, membership.id)
+        } else if (status === 'approve')
             await approve_membership(auth_token as string, tribe_id, group_id, membership_id)
         else if (status === 'deny')
             await deny_membership(auth_token as string, tribe_id, group_id, membership_id)
-        else if (character_id)
+        else if (character_id) {
             await add_character_to_membership(
                 auth_token as string,
                 tribe_id,
@@ -63,7 +70,7 @@ if (Astro.request.method === "POST") {
                 membership_id,
                 character_id
             )
-        else
+        } else
             throw new Error(t('invalid_membership_action'))
     } catch (error) {
         update_membership_error = error.message


### PR DESCRIPTION
Fixes applying a chief's characters to a group when the chief has no membership yet.

- GroupLeadership.astro: show the "add character" button even when chief_membership is null; all of the user's characters are then candidates.
- ButtonAddTribeCharacter.astro: accept a nullable membership_id and omit it from the POST query string when absent.
- tribe_group_memberships_component.astro: when no membership_id is supplied, create the membership via apply_to_group and approve it before adding the character.