### PR TITLE
Polish market tiles and operator links

### DIFF
--- a/frontend/app/src/components/blocks/MarketOperatorsReel.astro
+++ b/frontend/app/src/components/blocks/MarketOperatorsReel.astro
@@ -12,7 +12,7 @@ const {
     market_operators,
 } = Astro.props
 
-const MARKET_TRIBE_GROUP_PATH = '/alliance/tribes/2/10'
+const MARKET_TRIBE_GROUP_PATH = '/alliance/tribes/2/'
 
 import Wrapper from '@components/compositions/Wrapper.astro';
 import FixedFluid from '@components/compositions/FixedFluid.astro';

--- a/frontend/app/src/components/blocks/MarketTiles.astro
+++ b/frontend/app/src/components/blocks/MarketTiles.astro
@@ -43,8 +43,6 @@ import FreightServiceEvEIcon from '@components/icons/FreightServiceEvEIcon.astro
             description={t('services.leading_text')}
             cover='/images/freight-tile-background.webp'
         >
-            <FreightServiceEvEIcon class="[ ml-[-7px] ]" slot="icon" />
-
             <Button size='sm' href={translatePath('/market/freight/calculator/')}>
                 {t('freight_service')}
             </Button>
@@ -63,8 +61,6 @@ import FreightServiceEvEIcon from '@components/icons/FreightServiceEvEIcon.astro
             description={t('staging_supply.ops.tile_description')}
             cover='/images/sellorders-tile-background.webp'
         >
-            <MarketDeliveriesEVEIcon class="[ ml-[-7px] ]" slot="icon" />
-
             <Button size='sm' href={translatePath('/market/ops/')}>
                 {t('staging_supply.ops.tile_browse')}
             </Button>

--- a/frontend/app/src/i18n/ui.ts
+++ b/frontend/app/src/i18n/ui.ts
@@ -398,7 +398,7 @@ export const ui = {
         'staging_supply.ops.page_title': 'Market Operations',
         'staging_supply.ops.leading_text': 'We don\'t hide our trillion-ISK market behind leadership teams. View the contracts and sell orders necessary to keep our alliance afloat so you can participate.',
         'staging_supply.ops.meta_description': 'Market tribe operations monitor for Minmatar Fleet staging supply health.',
-        'staging_supply.ops.tile_title': 'Market',
+        'staging_supply.ops.tile_title': 'Market operations',
         'staging_supply.ops.tile_description': 'We don\'t hide our trillion-ISK market behind leadership teams. View the contracts and sell orders necessary to keep our alliance afloat so you can participate.',
         'staging_supply.ops.tile_browse': 'Browse',
         'page_finder.staging_supply.ops.description': 'Market operations monitor queues.',

--- a/frontend/app/src/pages/alliance/tribes/[tribe_id]/[group_id].astro
+++ b/frontend/app/src/pages/alliance/tribes/[tribe_id]/[group_id].astro
@@ -22,6 +22,10 @@ const group_id = parseInt(Astro?.params?.group_id ?? '')
 if (isNaN(tribe_id) || isNaN(group_id))
     return HTTP_400_Bad_Request()
 
+return Astro.redirect(translatePath(`/alliance/tribes/${tribe_id}/`))
+
+// TODO: Finish the landing page for groups. Is not quite ready yet
+
 import { apply_to_group, leave_group } from '@helpers/api.minmatar.org/tribes'
 import type { Alert } from '@dtypes/layout_components'
 


### PR DESCRIPTION
- MarketOperatorsReel: link market operators to the tribe page instead of a specific group.
- MarketTiles: drop the freight and market operations icons from the staging supply tiles.
- i18n: rename the market ops tile title to "Market operations".
- Tribes group pages: redirect to the tribe page until the group landing page is ready.