### PR TITLE
Fix LP economics test history dates aging out of 7-day window

### DIFF
--- a/backend/industry/tests/test_lp_store_economics.py
+++ b/backend/industry/tests/test_lp_store_economics.py
@@ -1,6 +1,6 @@
 """Tests for LP store offer economics helpers."""
 
-from datetime import date, timedelta
+from datetime import timedelta
 from decimal import Decimal
 from unittest.mock import patch
 
@@ -218,10 +218,12 @@ class LpStoreEconomicsHelperTestCase(TestCase):
             enqueue_history=False,
         )
 
+        # Relative to now so 7d/30d lookbacks stay valid as calendar days pass.
+        history_date = timezone.now().date() - timedelta(days=1)
         EveMarketItemHistory.objects.create(
             region_id=JITA_REGION_ID,
             item=self.hull,
-            date=date(2026, 7, 30),
+            date=history_date,
             average=Decimal("250000000"),
             highest=Decimal("260000000"),
             lowest=Decimal("240000000"),
@@ -231,7 +233,7 @@ class LpStoreEconomicsHelperTestCase(TestCase):
         EveMarketItemHistory.objects.create(
             region_id=JITA_REGION_ID,
             item=self.input_type,
-            date=date(2026, 7, 30),
+            date=history_date,
             average=Decimal("1500000"),
             highest=Decimal("1600000"),
             lowest=Decimal("1400000"),
@@ -241,7 +243,7 @@ class LpStoreEconomicsHelperTestCase(TestCase):
         EveMarketItemHistory.objects.create(
             region_id=JITA_REGION_ID,
             item=self.req_type,
-            date=date(2026, 7, 30),
+            date=history_date,
             average=Decimal("250000"),
             highest=Decimal("260000"),
             lowest=Decimal("240000"),


### PR DESCRIPTION
## Summary
- All open PR `backend-check` jobs were failing on `test_blueprint_row_uses_hull_market_and_build_cost` with `AssertionError: None != 250000000` for `jita_avg_7d`.
- Root cause: setUp hardcoded `EveMarketItemHistory` to `2026-07-30`, which fell outside `get_volume_weighted_average_by_type_id`'s 7-day window once today became 2026-08-07.
- Use a relative history date (`now - 1 day`) so lookback windows stay valid over time.

## Test plan
- [x] `pipenv run python manage.py test industry.tests.test_lp_store_economics.LpStoreEconomicsHelperTestCase.test_blueprint_row_uses_hull_market_and_build_cost industry.tests.test_lp_store_economics.LpStoreEconomicsHelperTestCase.test_offer_type_ids_viable_volume_uses_hull_for_bpc industry.tests.test_lp_store_offer_economics_rebuild --settings=app.settings_test`
- [ ] Confirm PR Check / backend-check is green
- [ ] After merge, re-run or rebase open PRs so they pick up the fix from main


Made with [Cursor](https://cursor.com)