### PR TITLE
Fix deleted market contracts counting as outstanding stock

### DIFF
--- a/backend/market/helpers/contracts.py
+++ b/backend/market/helpers/contracts.py
@@ -118,15 +118,35 @@ def get_fitting_for_contract(contract_summary: str) -> EveFitting | None:
     return None
 
 
+# Terminal ESI statuses that are not a completed sale — do not count as stock.
+_TERMINAL_NON_SALE_STATUSES = frozenset(
+    {
+        "expired",
+        "deleted",
+        "cancelled",
+        "rejected",
+        "failed",
+        "reversed",
+    }
+)
+
+
 def _map_contract_status(esi_status: str) -> str:
-    """Map ESI contract status to EveMarketContract status_choices."""
+    """Map ESI contract status to EveMarketContract status_choices.
+
+    Unknown / unexpected statuses map to expired so they cannot inflate stock.
+    """
     if esi_status in ("outstanding", "in_progress"):
         return "outstanding"
-    if esi_status == "finished":
+    if esi_status in ("finished", "finished_issuer", "finished_contractor"):
         return "finished"
-    if esi_status == "expired":
+    if esi_status in _TERMINAL_NON_SALE_STATUSES:
         return "expired"
-    return "outstanding"
+    if esi_status:
+        logger.warning(
+            "Unknown ESI contract status %r; mapping to expired", esi_status
+        )
+    return "expired"
 
 
 def create_or_update_contract_from_db_contract(
@@ -264,11 +284,11 @@ def update_completed_contracts(cutoff: datetime) -> int:
 
 
 def update_expired_contracts(cutoff: datetime) -> int:
+    """Mark outstanding contracts past expires_at as expired (public and private)."""
     updated = (
         EveMarketContract.objects.filter(status="outstanding")
-        .filter(is_public=True)
         .filter(expires_at__lt=cutoff)
         .update(status="expired")
     )
-    logger.info("Set %d public contracts to expired status", updated)
+    logger.info("Set %d contracts to expired status", updated)
     return updated

--- a/backend/market/migrations/0035_expire_stale_outstanding_contracts.py
+++ b/backend/market/migrations/0035_expire_stale_outstanding_contracts.py
@@ -1,0 +1,28 @@
+# Generated manually for deleted/expired private market contracts stuck as outstanding.
+
+from django.db import migrations
+from django.utils import timezone
+
+
+def expire_stale_outstanding(apps, schema_editor):
+    """Expire outstanding market contracts whose expiry date is already past."""
+    EveMarketContract = apps.get_model("market", "EveMarketContract")
+    EveMarketContract.objects.filter(
+        status="outstanding",
+        expires_at__lt=timezone.now(),
+    ).update(status="expired")
+
+
+def noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("market", "0034_attributed_order"),
+    ]
+
+    operations = [
+        migrations.RunPython(expire_stale_outstanding, noop),
+    ]

--- a/backend/market/tests/test_helpers.py
+++ b/backend/market/tests/test_helpers.py
@@ -1,9 +1,113 @@
+from datetime import timedelta
+from types import SimpleNamespace
+
+from django.utils import timezone
+
 from app.test import TestCase
 
+from eveonline.models import EveLocation
+from fittings.models import EveFitting
+from market.helpers.contracts import (
+    _map_contract_status,
+    create_or_update_contract_from_db_contract,
+)
+from market.models import EveMarketContract
 
-class MarketHelperTestCase(TestCase):
-    """Placeholder for market helper tests (contract sync moved to eveonline)."""
 
-    def test_placeholder(self):
-        """Keep test module loadable."""
-        self.assertTrue(True)
+class MapContractStatusTestCase(TestCase):
+    def test_active_statuses_map_to_outstanding(self):
+        self.assertEqual("outstanding", _map_contract_status("outstanding"))
+        self.assertEqual("outstanding", _map_contract_status("in_progress"))
+
+    def test_finished_statuses_map_to_finished(self):
+        self.assertEqual("finished", _map_contract_status("finished"))
+        self.assertEqual("finished", _map_contract_status("finished_issuer"))
+        self.assertEqual(
+            "finished", _map_contract_status("finished_contractor")
+        )
+
+    def test_terminal_non_sale_statuses_map_to_expired(self):
+        for status in (
+            "expired",
+            "deleted",
+            "cancelled",
+            "rejected",
+            "failed",
+            "reversed",
+        ):
+            self.assertEqual(
+                "expired",
+                _map_contract_status(status),
+                msg=status,
+            )
+
+    def test_unknown_and_empty_map_to_expired(self):
+        self.assertEqual("expired", _map_contract_status("weird_status"))
+        self.assertEqual("expired", _map_contract_status(""))
+
+
+class CreateOrUpdateContractFromDbContractStatusTestCase(TestCase):
+    def setUp(self):
+        self.location = EveLocation.objects.create(
+            location_id=6001,
+            location_name="Test Structure",
+            solar_system_id=1,
+            solar_system_name="Sys",
+            short_name="tst",
+            region_id=1,
+            market_active=True,
+        )
+        self.fitting = EveFitting.objects.create(
+            name="[FL33T] Deacon",
+            eft_format="[Deacon, [FL33T] Deacon]",
+            ship_id=37457,
+        )
+
+    def _db_contract(self, *, contract_id: int, status: str):
+        return SimpleNamespace(
+            contract_id=contract_id,
+            type=EveMarketContract.esi_contract_type,
+            start_location_id=self.location.location_id,
+            title=self.fitting.name,
+            status=status,
+            price=35_000_000,
+            issuer_id=862613217,
+            date_issued=timezone.now() - timedelta(days=90),
+            date_expired=timezone.now() - timedelta(days=60),
+            date_completed=None,
+            assignee_id=None,
+            acceptor_id=None,
+        )
+
+    def test_deleted_source_contract_does_not_count_as_outstanding(self):
+        self.assertTrue(
+            create_or_update_contract_from_db_contract(
+                self._db_contract(contract_id=230437067, status="deleted"),
+                self.location,
+            )
+        )
+        contract = EveMarketContract.objects.get(id=230437067)
+        self.assertEqual("expired", contract.status)
+        self.assertFalse(contract.is_public)
+
+    def test_resync_keeps_deleted_contract_expired(self):
+        EveMarketContract.objects.create(
+            id=230437068,
+            title=self.fitting.name,
+            price=35_000_000,
+            issuer_external_id=862613217,
+            status="outstanding",
+            fitting=self.fitting,
+            location=self.location,
+            is_public=False,
+            expires_at=timezone.now() - timedelta(days=60),
+        )
+        self.assertTrue(
+            create_or_update_contract_from_db_contract(
+                self._db_contract(contract_id=230437068, status="deleted"),
+                self.location,
+            )
+        )
+        self.assertEqual(
+            "expired", EveMarketContract.objects.get(id=230437068).status
+        )

--- a/backend/market/tests/test_tasks.py
+++ b/backend/market/tests/test_tasks.py
@@ -263,6 +263,15 @@ class MarketTaskTestCase(TestCase):
             is_public=True,
             expires_at=cutoff - timedelta(hours=1),
         )
+        EveMarketContract.objects.create(
+            id=10004,
+            title="Private expired before cutoff",
+            price=12.34,
+            issuer_external_id=1,
+            status="outstanding",
+            is_public=False,
+            expires_at=cutoff - timedelta(hours=1),
+        )
 
         completed = update_completed_contracts(cutoff)
 
@@ -273,7 +282,10 @@ class MarketTaskTestCase(TestCase):
 
         expired = update_expired_contracts(cutoff)
 
-        self.assertEqual(1, expired)
+        self.assertEqual(2, expired)
         self.assertEqual(
             "expired", EveMarketContract.objects.get(id=10003).status
+        )
+        self.assertEqual(
+            "expired", EveMarketContract.objects.get(id=10004).status
         )


### PR DESCRIPTION
## Summary
- Map terminal ESI contract statuses (`deleted`, `cancelled`, `rejected`, `failed`, `reversed`, and unknowns) to `expired` instead of `outstanding`, so they no longer inflate market stock/seller counts.
- Expire private contracts past `expires_at` in `update_expired_contracts` (was public-only).
- Add migration `0035` to backfill stuck outstanding rows with past expiry (e.g. p0dgirl’s 10 Deacons).

## Test plan
- [x] `pipenv run python manage.py test market.tests.test_helpers market.tests.test_tasks --settings=app.settings_test`
- [ ] Deploy / run migration; confirm p0dgirl no longer shows 10 outstanding Deacons
- [ ] Spot-check a live outstanding private contract still counts toward stock


Made with [Cursor](https://cursor.com)