### PR TITLE
Tune Little Helps slide animation timing and cyno placement.

### DIFF
--- a/frontend/app/src/components/blocks/EveryLittleHelpSlide.astro
+++ b/frontend/app/src/components/blocks/EveryLittleHelpSlide.astro
@@ -131,8 +131,8 @@ import StylessButton from '@components/blocks/StylessButton.astro';
 
     .cyno-entrance {
         position: absolute;
-        top: -14%;
-        left: 33%;
+        top: 10%;
+        left: 67%;
         width: 60%;
         height: auto;
         z-index: 2;
@@ -254,7 +254,7 @@ import StylessButton from '@components/blocks/StylessButton.astro';
     .swiper-slide-active {
         .marshall {
             animation: marshall cubic-bezier(0.390, 0.575, 0.565, 1.000) both 2.7s;
-            animation-delay: 1.2s;
+            animation-delay: 2.8s;
             animation-iteration-count: 1;
             transform-origin: center;
             animation-fill-mode: forwards;
@@ -270,7 +270,7 @@ import StylessButton from '@components/blocks/StylessButton.astro';
         
         .widow {
             animation: widow cubic-bezier(0.390, 0.575, 0.565, 1.000) both 2.5s;
-            animation-delay: 1.4s;
+            animation-delay: 2.9s;
             animation-iteration-count: 1;
             transform-origin: center;
             animation-fill-mode: forwards;
@@ -278,7 +278,7 @@ import StylessButton from '@components/blocks/StylessButton.astro';
 
         .cyno-entrance {
             animation: cyno_entrance 1s ease-out 0.5s 1 forwards;
-            animation-delay: 3s;
+            animation-delay: 2.6s;
         }
 
         .cyno-rotation {


### PR DESCRIPTION
Adjust the "Every Little Helps." slide entrance animation so the cyno appears sooner while the ships wait longer before flying in.

- Move the cyno entrance to the top-right of the slide.
- Bring the cyno entrance delay forward to 2.6s.
- Delay the Marshall and Widow entrance animations to 2.8s and 2.9s.