### PR TITLE
Tune Little Helps slide animation delays for a tighter entrance seque…

### DIFF
--- a/frontend/app/src/components/blocks/EveryLittleHelpSlide.astro
+++ b/frontend/app/src/components/blocks/EveryLittleHelpSlide.astro
@@ -254,7 +254,7 @@ import StylessButton from '@components/blocks/StylessButton.astro';
     .swiper-slide-active {
         .marshall {
             animation: marshall cubic-bezier(0.390, 0.575, 0.565, 1.000) both 2.7s;
-            animation-delay: 2.8s;
+            animation-delay: 1.5s;
             animation-iteration-count: 1;
             transform-origin: center;
             animation-fill-mode: forwards;
@@ -262,7 +262,7 @@ import StylessButton from '@components/blocks/StylessButton.astro';
         
         .prospect {
             animation: prospect cubic-bezier(0.390, 0.575, 0.565, 1.000) both 2.6s;
-            animation-delay: 1.3s;
+            animation-delay: 0.6s;
             animation-iteration-count: 1;
             transform-origin: center;
             animation-fill-mode: forwards;
@@ -270,7 +270,7 @@ import StylessButton from '@components/blocks/StylessButton.astro';
         
         .widow {
             animation: widow cubic-bezier(0.390, 0.575, 0.565, 1.000) both 2.5s;
-            animation-delay: 2.9s;
+            animation-delay: 1.6s;
             animation-iteration-count: 1;
             transform-origin: center;
             animation-fill-mode: forwards;
@@ -278,7 +278,7 @@ import StylessButton from '@components/blocks/StylessButton.astro';
 
         .cyno-entrance {
             animation: cyno_entrance 1s ease-out 0.5s 1 forwards;
-            animation-delay: 2.6s;
+            animation-delay: 1.3s;
         }
 
         .cyno-rotation {


### PR DESCRIPTION
…nce.

Bring the ship entrance animations forward so the Marshall, Prospect, and Widow fly in sooner while the cyno activates ahead of them.

- Prospect delay to 0.6s.
- Cyno entrance delay to 1.3s.
- Marshall delay to 1.5s.
- Widow delay to 1.6s.