### PR TITLE
Include M-EXC in application transfer corporation finder

### DIFF
--- a/frontend/app/src/components/blocks/CorporationFinder.astro
+++ b/frontend/app/src/components/blocks/CorporationFinder.astro
@@ -8,7 +8,7 @@ import Flexblock from '@components/compositions/Flexblock.astro';
 import FixedFluid from '@components/compositions/FixedFluid.astro';
 import VerticalCenter from './VerticalCenter.astro';
 
-import { get_all_corporations } from '@helpers/api.minmatar.org/corporations';
+import { get_alliance_corporations_with_extraction } from '@helpers/fetching/corporations';
 import { get_corporation_logo } from '@helpers/eve_image_server';
 
 interface CorporationFinderItem {
@@ -23,7 +23,8 @@ interface Props {
 let corporations: CorporationFinderItem[] = []
 
 try {
-    const api_corporations = await get_all_corporations('alliance')
+    // Alliance MFA corps + M-EXC (associate that recruits on the alliance page).
+    const api_corporations = await get_alliance_corporations_with_extraction()
     corporations = api_corporations
         .map((corporation) => ({
             corporation_id: corporation.corporation_id,

--- a/frontend/app/src/helpers/fetching/applications.ts
+++ b/frontend/app/src/helpers/fetching/applications.ts
@@ -9,14 +9,14 @@ import {
     get_corporation_applications_by_id,
 } from '@helpers/api.minmatar.org/applications'
 import { get_user_character, get_users_character } from '@helpers/fetching/characters'
-import { get_all_corporations } from '@helpers/api.minmatar.org/corporations'
+import { get_alliance_corporations_with_extraction } from '@helpers/fetching/corporations'
 import { unique_values } from '@helpers/array'
 
 export async function get_all_applications(access_token:string) {
     let api_corporations:Corporation[]
     let applications:ApplicationOld[]
 
-    api_corporations = await get_all_corporations('alliance')
+    api_corporations = await get_alliance_corporations_with_extraction()
 
     applications = (await Promise.all(api_corporations.map(async (corporation) => {
         let applications:ApplicationOld[] = []
@@ -61,7 +61,7 @@ export async function get_all_corporations_applications(access_token:string, rec
     let api_corporations:Corporation[]
     let applications:CorporationApplications[]
 
-    api_corporations = await get_all_corporations('alliance')
+    api_corporations = await get_alliance_corporations_with_extraction()
 
     applications = (await Promise.all(api_corporations.map(async (corporation) => {
         const application:CorporationApplications = {

--- a/frontend/app/src/helpers/fetching/corporations.ts
+++ b/frontend/app/src/helpers/fetching/corporations.ts
@@ -9,13 +9,17 @@ import type { CorporationObject, CorporationStatusType, CorporationMembers, Char
 import { get_all_corporations, get_corporation_info, get_corporation_by_id } from '@helpers/api.minmatar.org/corporations'
 import { get_corporation_applications, get_corporation_applications_by_id } from '@helpers/api.minmatar.org/applications'
 
-const MINMATAR_EXTRACTION_COMPANY_ID = 98838663
+export const MINMATAR_EXTRACTION_COMPANY_ID = 98838663
 
 // Minmatar Extraction Company is an associate corporation (Minmatar Fleet
 // Associates), so the "alliance" corporations endpoint does not return it.
 // It is recruiting through the alliance corporations page, so it gets
-// fetched separately and appended to the list.
-const append_extraction_corporation = async (api_corporations:Corporation[]) => {
+// fetched separately and appended to the list (corp page, transfer finder,
+// applications list).
+export const append_extraction_corporation = async (api_corporations:Corporation[]) => {
+    if (api_corporations.some((corporation) => corporation.corporation_id === MINMATAR_EXTRACTION_COMPANY_ID))
+        return
+
     try {
         const extraction_info = await get_corporation_info(MINMATAR_EXTRACTION_COMPANY_ID)
 
@@ -41,14 +45,20 @@ const append_extraction_corporation = async (api_corporations:Corporation[]) => 
     }
 }
 
+/** Alliance MFA corps plus M-EXC (associate that recruits via the alliance page). */
+export async function get_alliance_corporations_with_extraction() {
+    const api_corporations = await get_all_corporations('alliance')
+    await append_extraction_corporation(api_corporations)
+    return api_corporations
+}
+
 export async function get_corporations_list_auth(access_token:string, user_id:number, corporation_type:CorporationType) {
     let api_corporations:Corporation[] = []
     let corporations:CorporationObject[] = []
 
-    api_corporations = await get_all_corporations(corporation_type)
-
-    if (corporation_type === 'alliance')
-        await append_extraction_corporation(api_corporations)
+    api_corporations = corporation_type === 'alliance'
+        ? await get_alliance_corporations_with_extraction()
+        : await get_all_corporations(corporation_type)
 
     corporations = await Promise.all(api_corporations.map(async (api_corp) => add_status_to_corporation(access_token, api_corp, user_id) ));
     
@@ -59,10 +69,9 @@ export async function get_corporations_list(corporation_type:CorporationType) {
     let api_corporations:Corporation[] = []
     let corporations:CorporationObject[] = []
 
-    api_corporations = await get_all_corporations(corporation_type)
-
-    if (corporation_type === 'alliance')
-        await append_extraction_corporation(api_corporations)
+    api_corporations = corporation_type === 'alliance'
+        ? await get_alliance_corporations_with_extraction()
+        : await get_all_corporations(corporation_type)
 
     corporations = api_corporations.map( (i):CorporationObject => {
         return {

--- a/frontend/app/testing/components/blocks/CorporationFinder.test.ts
+++ b/frontend/app/testing/components/blocks/CorporationFinder.test.ts
@@ -2,11 +2,11 @@ import { experimental_AstroContainer as AstroContainer } from "astro/container";
 import { expect, test, vi } from "vitest";
 import CorporationFinder from "@components/blocks/CorporationFinder.astro";
 
-import { get_all_corporations } from "@helpers/api.minmatar.org/corporations";
-vi.mock("@helpers/api.minmatar.org/corporations");
+import { get_alliance_corporations_with_extraction } from "@helpers/fetching/corporations";
+vi.mock("@helpers/fetching/corporations");
 
 test("CorporationFinder defaults", async () => {
-  vi.mocked(get_all_corporations).mockResolvedValue([
+  vi.mocked(get_alliance_corporations_with_extraction).mockResolvedValue([
     {
       corporation_id: 98794203,
       corporation_name: "Banshee Squadron",
@@ -41,6 +41,21 @@ test("CorporationFinder defaults", async () => {
       active: true,
       trial: false,
     },
+    {
+      corporation_id: 98838663,
+      corporation_name: "Minmatar Extraction Company",
+      alliance_id: 99012009,
+      alliance_name: "Minmatar Fleet Associates",
+      type: "associate",
+      introduction: "",
+      biography: "",
+      executor_notes: "",
+      timezones: [],
+      requirements: [],
+      members: [],
+      active: true,
+      trial: false,
+    },
   ]);
 
   const container = await AstroContainer.create();
@@ -48,5 +63,6 @@ test("CorporationFinder defaults", async () => {
 
   expect(result).toContain("Banshee Squadron");
   expect(result).toContain("Rattini Tribe");
-  expect(get_all_corporations).toHaveBeenCalledWith("alliance");
+  expect(result).toContain("Minmatar Extraction Company");
+  expect(get_alliance_corporations_with_extraction).toHaveBeenCalled();
 });

--- a/frontend/app/testing/helpers/alliance_corporations_with_extraction.test.ts
+++ b/frontend/app/testing/helpers/alliance_corporations_with_extraction.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+import {
+  append_extraction_corporation,
+  get_alliance_corporations_with_extraction,
+  MINMATAR_EXTRACTION_COMPANY_ID,
+} from "@helpers/fetching/corporations";
+import {
+  get_all_corporations,
+  get_corporation_info,
+} from "@helpers/api.minmatar.org/corporations";
+
+vi.mock("@helpers/api.minmatar.org/corporations");
+vi.mock("@helpers/api.minmatar.org/applications", () => ({
+  get_corporation_applications: vi.fn(),
+  get_corporation_applications_by_id: vi.fn(),
+}));
+vi.mock("@helpers/fetching/characters", () => ({
+  get_user_character: vi.fn(),
+}));
+
+const alliance_corp = {
+  corporation_id: 98726134,
+  corporation_name: "Rattini Tribe",
+  alliance_id: 99011978,
+  alliance_name: "Minmatar Fleet Alliance",
+  type: "alliance" as const,
+  introduction: "",
+  biography: "",
+  executor_notes: "",
+  timezones: [],
+  requirements: [],
+  members: [],
+  active: true,
+  trial: false,
+};
+
+const extraction_corp = {
+  corporation_id: MINMATAR_EXTRACTION_COMPANY_ID,
+  corporation_name: "Minmatar Extraction Company",
+  alliance_id: 99012009,
+  alliance_name: "Minmatar Fleet Associates",
+  type: "associate" as const,
+  introduction: "",
+  biography: "",
+  executor_notes: "",
+  timezones: [],
+  requirements: [],
+  members: [],
+  active: true,
+  trial: false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("get_alliance_corporations_with_extraction appends M-EXC", async () => {
+  vi.mocked(get_all_corporations).mockResolvedValue([{ ...alliance_corp }]);
+  vi.mocked(get_corporation_info).mockResolvedValue({ ...extraction_corp });
+
+  const corporations = await get_alliance_corporations_with_extraction();
+
+  expect(get_all_corporations).toHaveBeenCalledWith("alliance");
+  expect(get_corporation_info).toHaveBeenCalledWith(
+    MINMATAR_EXTRACTION_COMPANY_ID,
+  );
+  expect(corporations.map((c) => c.corporation_id)).toEqual([
+    alliance_corp.corporation_id,
+    MINMATAR_EXTRACTION_COMPANY_ID,
+  ]);
+});
+
+test("append_extraction_corporation skips when M-EXC already present", async () => {
+  const corporations = [{ ...extraction_corp }];
+
+  await append_extraction_corporation(corporations);
+
+  expect(get_corporation_info).not.toHaveBeenCalled();
+  expect(corporations).toHaveLength(1);
+});


### PR DESCRIPTION
## Summary
- Help ticket: recruiters could not transfer applicants to **Minmatar Extraction Company (M-EXC)** because the transfer finder only listed MFA alliance corps.
- M-EXC is an associate corp that already recruits via the alliance corporations page (existing `append_extraction_corporation` helper). Reuse that list for the transfer finder and the applications list so transferred M-EXC apps stay visible.

## Test plan
- [ ] Open a pending application → Transfer to corporation → search `M-EXC` / `Extraction` → Minmatar Extraction Company appears
- [ ] Transfer an application to M-EXC and confirm Discord thread rename + link update
- [ ] Confirm M-EXC apps still show on `/alliance/corporations/applications/`
- [ ] `npm run check` and CorporationFinder / helper tests pass


Made with [Cursor](https://cursor.com)