### PR TITLE
Restore solid buttons on market health cards

### DIFF
--- a/frontend/app/src/components/blocks/MarketHealthContent.astro
+++ b/frontend/app/src/components/blocks/MarketHealthContent.astro
@@ -209,7 +209,7 @@ const sell_viable = sell_listed > 0
                     class="[ market-health__card-footer ]"
                     justification="space-between"
                 >
-                    <Button href={contracts_href} size="sm" color="transparent">
+                    <Button href={contracts_href} size="sm">
                         {t('view_ops_contracts')}
                     </Button>
                     <p class="[ market-health__card-meta market-health__card-meta--isk ]">
@@ -284,7 +284,7 @@ const sell_viable = sell_listed > 0
                     class="[ market-health__card-footer ]"
                     justification="space-between"
                 >
-                    <Button href={sell_orders_href} size="sm" color="transparent">
+                    <Button href={sell_orders_href} size="sm">
                         {t('view_ops_sell_orders')}
                     </Button>
                     <p class="[ market-health__card-meta market-health__card-meta--isk ]">


### PR DESCRIPTION
## Summary
- Restore **View Contracts** and **View Sell Orders** on the ops market health cards to default solid `Button` styling (fleet-red) instead of transparent link-style CTAs.

## Test plan
- [ ] Open `/market/ops/` and confirm both card footers show solid red buttons
- [ ] Click each button and confirm it still navigates to contracts / sell orders


Made with [Cursor](https://cursor.com)