### PR TITLE
Track market needs by presence, not hard quantities

### DIFF
--- a/backend/fixtures/data/08_market_expectations.json
+++ b/backend/fixtures/data/08_market_expectations.json
@@ -5,7 +5,7 @@
     "fields": {
       "fitting": 351,
       "location": 1051465618860,
-      "quantity": 5
+      "quantity": 1
     }
   },
   {
@@ -14,7 +14,7 @@
     "fields": {
       "fitting": 166,
       "location": 1051465618860,
-      "quantity": 10
+      "quantity": 1
     }
   },
   {
@@ -23,7 +23,7 @@
     "fields": {
       "fitting": 162,
       "location": 1051465618860,
-      "quantity": 10
+      "quantity": 1
     }
   },
   {
@@ -32,7 +32,7 @@
     "fields": {
       "fitting": 353,
       "location": 1051465618860,
-      "quantity": 10
+      "quantity": 1
     }
   },
   {
@@ -41,7 +41,7 @@
     "fields": {
       "fitting": 352,
       "location": 1051465618860,
-      "quantity": 10
+      "quantity": 1
     }
   },
   {
@@ -50,7 +50,7 @@
     "fields": {
       "fitting": 354,
       "location": 1051465618860,
-      "quantity": 15
+      "quantity": 1
     }
   },
   {
@@ -59,7 +59,7 @@
     "fields": {
       "fitting": 355,
       "location": 1051465618860,
-      "quantity": 5
+      "quantity": 1
     }
   },
   {
@@ -68,7 +68,7 @@
     "fields": {
       "fitting": 356,
       "location": 1051465618860,
-      "quantity": 5
+      "quantity": 1
     }
   },
   {
@@ -77,7 +77,7 @@
     "fields": {
       "fitting": 357,
       "location": 1051465618860,
-      "quantity": 5
+      "quantity": 1
     }
   },
   {
@@ -86,7 +86,7 @@
     "fields": {
       "fitting": 358,
       "location": 1051465618860,
-      "quantity": 10
+      "quantity": 1
     }
   },
   {
@@ -95,7 +95,7 @@
     "fields": {
       "fitting": 39,
       "location": 1022167642188,
-      "quantity": 10
+      "quantity": 1
     }
   },
   {
@@ -104,7 +104,7 @@
     "fields": {
       "fitting": 41,
       "location": 1022167642188,
-      "quantity": 10
+      "quantity": 1
     }
   },
   {
@@ -113,7 +113,7 @@
     "fields": {
       "fitting": 102,
       "location": 1022167642188,
-      "quantity": 10
+      "quantity": 1
     }
   },
   {
@@ -122,7 +122,7 @@
     "fields": {
       "fitting": 113,
       "location": 1022167642188,
-      "quantity": 5
+      "quantity": 1
     }
   },
   {
@@ -131,7 +131,7 @@
     "fields": {
       "fitting": 104,
       "location": 1022167642188,
-      "quantity": 10
+      "quantity": 1
     }
   },
   {
@@ -140,7 +140,7 @@
     "fields": {
       "fitting": 109,
       "location": 1022167642188,
-      "quantity": 5
+      "quantity": 1
     }
   },
   {
@@ -149,7 +149,7 @@
     "fields": {
       "fitting": 38,
       "location": 1022167642188,
-      "quantity": 5
+      "quantity": 1
     }
   },
   {
@@ -158,7 +158,7 @@
     "fields": {
       "fitting": 37,
       "location": 1022167642188,
-      "quantity": 5
+      "quantity": 1
     }
   },
   {
@@ -167,7 +167,7 @@
     "fields": {
       "fitting": 32,
       "location": 1022167642188,
-      "quantity": 5
+      "quantity": 1
     }
   },
   {
@@ -176,7 +176,7 @@
     "fields": {
       "fitting": 76,
       "location": 1022167642188,
-      "quantity": 10
+      "quantity": 1
     }
   },
   {
@@ -185,7 +185,7 @@
     "fields": {
       "fitting": 65,
       "location": 1022167642188,
-      "quantity": 5
+      "quantity": 1
     }
   },
   {
@@ -194,7 +194,7 @@
     "fields": {
       "fitting": 179,
       "location": 1051465618860,
-      "quantity": 5
+      "quantity": 1
     }
   },
   {
@@ -203,7 +203,7 @@
     "fields": {
       "fitting": 341,
       "location": 1051465618860,
-      "quantity": 30
+      "quantity": 1
     }
   },
   {
@@ -212,7 +212,7 @@
     "fields": {
       "fitting": 324,
       "location": 1051465618860,
-      "quantity": 30
+      "quantity": 1
     }
   },
   {
@@ -221,7 +221,7 @@
     "fields": {
       "fitting": 73,
       "location": 1051465618860,
-      "quantity": 5
+      "quantity": 1
     }
   },
   {
@@ -230,7 +230,7 @@
     "fields": {
       "fitting": 189,
       "location": 1051465618860,
-      "quantity": 10
+      "quantity": 1
     }
   },
   {
@@ -239,7 +239,7 @@
     "fields": {
       "fitting": 188,
       "location": 1051465618860,
-      "quantity": 10
+      "quantity": 1
     }
   },
   {
@@ -248,7 +248,7 @@
     "fields": {
       "fitting": 315,
       "location": 1051465618860,
-      "quantity": 15
+      "quantity": 1
     }
   },
   {
@@ -257,7 +257,7 @@
     "fields": {
       "fitting": 69,
       "location": 1022167642188,
-      "quantity": 30
+      "quantity": 1
     }
   },
   {
@@ -266,7 +266,7 @@
     "fields": {
       "fitting": 125,
       "location": 1022167642188,
-      "quantity": 15
+      "quantity": 1
     }
   },
   {
@@ -275,7 +275,7 @@
     "fields": {
       "fitting": 243,
       "location": 1022167642188,
-      "quantity": 10
+      "quantity": 1
     }
   },
   {
@@ -284,7 +284,7 @@
     "fields": {
       "fitting": 241,
       "location": 1022167642188,
-      "quantity": 10
+      "quantity": 1
     }
   },
   {
@@ -293,7 +293,7 @@
     "fields": {
       "fitting": 59,
       "location": 1022167642188,
-      "quantity": 10
+      "quantity": 1
     }
   },
   {
@@ -302,7 +302,7 @@
     "fields": {
       "fitting": 246,
       "location": 1022167642188,
-      "quantity": 10
+      "quantity": 1
     }
   },
   {
@@ -311,7 +311,7 @@
     "fields": {
       "fitting": 274,
       "location": 1022167642188,
-      "quantity": 25
+      "quantity": 1
     }
   },
   {
@@ -320,7 +320,7 @@
     "fields": {
       "fitting": 177,
       "location": 1022167642188,
-      "quantity": 5
+      "quantity": 1
     }
   },
   {
@@ -329,7 +329,7 @@
     "fields": {
       "fitting": 205,
       "location": 1022167642188,
-      "quantity": 10
+      "quantity": 1
     }
   },
   {
@@ -338,7 +338,7 @@
     "fields": {
       "fitting": 20,
       "location": 1051465618860,
-      "quantity": 20
+      "quantity": 1
     }
   },
   {
@@ -347,7 +347,7 @@
     "fields": {
       "fitting": 166,
       "location": 1051465618860,
-      "quantity": 10
+      "quantity": 1
     }
   },
   {
@@ -356,7 +356,7 @@
     "fields": {
       "fitting": 343,
       "location": 1051465618860,
-      "quantity": 30
+      "quantity": 1
     }
   },
   {
@@ -365,7 +365,7 @@
     "fields": {
       "fitting": 338,
       "location": 1051465618860,
-      "quantity": 30
+      "quantity": 1
     }
   },
   {
@@ -374,7 +374,7 @@
     "fields": {
       "fitting": 203,
       "location": 1051465618860,
-      "quantity": 2
+      "quantity": 1
     }
   },
   {
@@ -383,7 +383,7 @@
     "fields": {
       "fitting": 204,
       "location": 1051465618860,
-      "quantity": 2
+      "quantity": 1
     }
   },
   {
@@ -410,7 +410,7 @@
     "fields": {
       "fitting": 205,
       "location": 1051465618860,
-      "quantity": 10
+      "quantity": 1
     }
   },
   {
@@ -419,7 +419,7 @@
     "fields": {
       "fitting": 205,
       "location": 1022167642188,
-      "quantity": 10
+      "quantity": 1
     }
   },
   {
@@ -428,7 +428,7 @@
     "fields": {
       "fitting": 57,
       "location": 1022167642188,
-      "quantity": 5
+      "quantity": 1
     }
   },
   {
@@ -437,7 +437,7 @@
     "fields": {
       "fitting": 57,
       "location": 1051465618860,
-      "quantity": 5
+      "quantity": 1
     }
   }
 ]

--- a/backend/market/admin.py
+++ b/backend/market/admin.py
@@ -103,7 +103,7 @@ def get_market_item_trends(item_id):
 
 @admin.register(EveMarketContractExpectation)
 class EveMarketContractExpectationAdmin(admin.ModelAdmin):
-    """Contract expectations: fitting + quantity per location; stock levels from outstanding contracts."""
+    """Contract expectations: tracked fittings per location; presence via outstanding contracts."""
 
     list_display = (
         "fitting",
@@ -291,7 +291,7 @@ class EveMarketBuyOrderExpectationAdmin(admin.ModelAdmin):
 
 @admin.register(EveMarketFittingExpectation)
 class EveMarketFittingExpectationAdmin(admin.ModelAdmin):
-    """Fitting expectations: a fitting × quantity per location, decomposed into item-level expectations."""
+    """Fitting expectations: tracked fittings per location, decomposed into item catalog entries."""
 
     list_display = (
         "fitting",
@@ -495,7 +495,7 @@ class EveTypeWithSellOrdersAdmin(admin.ModelAdmin):
 
 @admin.register(EveMarketItemExpectation)
 class EveMarketItemExpectationAdmin(admin.ModelAdmin):
-    """Item seeding: EVE type + target quantity per location, tracked on sell orders."""
+    """Item pins: EVE types forced onto the sell-order catalog at a location."""
 
     list_display = (
         "item",

--- a/backend/market/admin_location_views.py
+++ b/backend/market/admin_location_views.py
@@ -142,7 +142,7 @@ def market_location_fitting_expectations_view(request, location_id):
             url_name="admin:market_location_fitting_expectations",
             change_perm=CHANGE_FITTING_EXPECTATIONS,
             save_fn=save_fitting_expectation_quantities,
-            success_message="Quantities saved.",
+            success_message="Tracking saved.",
             allowed_ids=_allowed_fitting_ids(page_context),
         )
 
@@ -171,7 +171,7 @@ def market_location_contract_expectations_view(request, location_id):
             url_name="admin:market_location_contract_expectations",
             change_perm=CHANGE_CONTRACT_EXPECTATIONS,
             save_fn=save_contract_expectation_quantities,
-            success_message="Quantities saved.",
+            success_message="Tracking saved.",
             allowed_ids=_allowed_fitting_ids(page_context),
         )
 
@@ -200,7 +200,7 @@ def market_location_sell_orders_view(request, location_id):
             url_name="admin:market_location_sell_orders",
             change_perm=CHANGE_ITEM_EXPECTATIONS,
             save_fn=save_sell_order_desired_quantities,
-            success_message="Target stock saved.",
+            success_message="Tracking saved.",
             allowed_ids=_allowed_type_ids(page_context),
         )
 

--- a/backend/market/endpoints/get_contracts.py
+++ b/backend/market/endpoints/get_contracts.py
@@ -202,7 +202,7 @@ def fetch_eve_market_contracts(request, location_id: int):
             fitting = expectation.fitting
             expectation_id = expectation.id
             title = fitting.name
-            desired_quantity = expectation.quantity
+            desired_quantity = expectation.desired_quantity
         else:
             sample = (
                 contracts_at_location.filter(fitting_id=fitting_id)

--- a/backend/market/endpoints/get_expectations_by_location.py
+++ b/backend/market/endpoints/get_expectations_by_location.py
@@ -44,7 +44,7 @@ def get_expectations_by_location(
                     fitting_id=e.fitting.id,
                     fitting_name=e.fitting.name,
                     expectation_id=e.id,
-                    quantity=e.quantity,
+                    quantity=e.desired_quantity,
                 )
                 for e in data["expectations"]
             ],

--- a/backend/market/helpers/contract_health.py
+++ b/backend/market/helpers/contract_health.py
@@ -183,11 +183,12 @@ def build_contract_health(  # noqa: C901
         key = (expectation.location_id, expectation.fitting_id)
         current = outstanding.get(key, 0)
         viable = viable_outstanding.get(key, 0)
-        if expectation.quantity > 0:
-            ratio = min(1.0, current / expectation.quantity)
+        desired = expectation.desired_quantity
+        if desired > 0:
+            ratio = min(1.0, current / desired)
             contract_fill_ratios_by_loc[expectation.location_id].append(ratio)
             contract_targets_by_loc[expectation.location_id] += 1
-            if current >= expectation.quantity:
+            if current >= desired:
                 contract_fulfilled_by_loc[expectation.location_id] += 1
             # Viability = price quality of what is listed, not empty shelves.
             if current > 0:
@@ -200,7 +201,7 @@ def build_contract_health(  # noqa: C901
                     contract_viable_fulfilled_by_loc[
                         expectation.location_id
                     ] += 1
-        level = fitting_readiness(current, expectation.quantity)
+        level = fitting_readiness(current, desired)
         if level in ("ready", "unknown"):
             continue
         weekly_units = weekly_units_by_loc_fit.get(key, 0)
@@ -214,8 +215,8 @@ def build_contract_health(  # noqa: C901
                 "ship_id": expectation.fitting.ship_id,
                 "current_quantity": current,
                 "viable_quantity": viable,
-                "expected_quantity": expectation.quantity,
-                "shortfall": shortfall(current, expectation.quantity),
+                "expected_quantity": desired,
+                "shortfall": shortfall(current, desired),
                 "readiness": level,
                 "expectation_id": expectation.id,
                 "units_1d": units_1d_by_loc_fit.get(key, 0),

--- a/backend/market/helpers/expectations_admin.py
+++ b/backend/market/helpers/expectations_admin.py
@@ -91,51 +91,119 @@ def filter_contract_expectation_rows(
     return filtered
 
 
-def _save_fitting_quantity_expectations(
+def _checkbox_tracked_ids(
+    post_data,
+    *,
+    prefix: str,
+    allowed_ids: set[int] | None,
+) -> set[int]:
+    tracked_ids: set[int] = set()
+    for key, raw_value in post_data.items():
+        if not key.startswith(prefix):
+            continue
+        if raw_value in (None, "", "0", "false", "False", "off"):
+            continue
+        object_id = int(key.removeprefix(prefix))
+        if allowed_ids is not None and object_id not in allowed_ids:
+            continue
+        tracked_ids.add(object_id)
+    return tracked_ids
+
+
+def _apply_fitting_track_set(
+    location,
+    model_class,
+    *,
+    ids_to_consider: set[int],
+    tracked_ids: set[int],
+) -> int:
+    updated = 0
+    for fitting_id in ids_to_consider:
+        if fitting_id in tracked_ids:
+            model_class.objects.update_or_create(
+                location=location,
+                fitting_id=fitting_id,
+                defaults={"quantity": 1},
+            )
+            updated += 1
+            continue
+        deleted, _ = model_class.objects.filter(
+            location=location,
+            fitting_id=fitting_id,
+        ).delete()
+        if deleted:
+            updated += 1
+    return updated
+
+
+def _save_fitting_track_legacy(
     location,
     post_data,
     model_class,
     *,
-    prefix: str = "quantity_",
-    allowed_ids: set[int] | None = None,
+    allowed_ids: set[int] | None,
 ) -> int:
     updated = 0
     for key, raw_value in post_data.items():
-        if not key.startswith(prefix):
+        if not key.startswith("quantity_"):
             continue
-        fitting_id = int(key.removeprefix(prefix))
+        fitting_id = int(key.removeprefix("quantity_"))
         if allowed_ids is not None and fitting_id not in allowed_ids:
             continue
-        if raw_value in (None, ""):
-            deleted, _ = model_class.objects.filter(
+        should_track = raw_value not in (None, "") and int(raw_value) > 0
+        if should_track:
+            model_class.objects.update_or_create(
                 location=location,
                 fitting_id=fitting_id,
-            ).delete()
-            if deleted:
-                updated += 1
+                defaults={"quantity": 1},
+            )
+            updated += 1
             continue
-        quantity = int(raw_value)
-        if quantity <= 0:
-            deleted, _ = model_class.objects.filter(
-                location=location,
-                fitting_id=fitting_id,
-            ).delete()
-            if deleted:
-                updated += 1
-            continue
-        model_class.objects.update_or_create(
+        deleted, _ = model_class.objects.filter(
             location=location,
             fitting_id=fitting_id,
-            defaults={"quantity": quantity},
-        )
-        updated += 1
+        ).delete()
+        if deleted:
+            updated += 1
     return updated
+
+
+def _save_fitting_track_expectations(
+    location,
+    post_data,
+    model_class,
+    *,
+    allowed_ids: set[int] | None = None,
+) -> int:
+    """
+    Track on/off for fittings via ``tracked_<fitting_id>`` checkboxes.
+
+    When ``presence_tracking`` is set, every id in ``allowed_ids`` is
+    created (qty=1) or deleted. Also accepts legacy ``quantity_<id>``
+    (positive → track, ≤0 → untrack).
+    """
+    if post_data.get("presence_tracking"):
+        tracked_ids = _checkbox_tracked_ids(
+            post_data, prefix="tracked_", allowed_ids=allowed_ids
+        )
+        ids_to_consider = (
+            allowed_ids if allowed_ids is not None else tracked_ids
+        )
+        return _apply_fitting_track_set(
+            location,
+            model_class,
+            ids_to_consider=ids_to_consider,
+            tracked_ids=tracked_ids,
+        )
+    return _save_fitting_track_legacy(
+        location, post_data, model_class, allowed_ids=allowed_ids
+    )
 
 
 def save_fitting_expectation_quantities(
     location, post_data, allowed_ids: set[int] | None = None
 ) -> int:
-    return _save_fitting_quantity_expectations(
+    return _save_fitting_track_expectations(
         location,
         post_data,
         EveMarketFittingExpectation,
@@ -146,7 +214,7 @@ def save_fitting_expectation_quantities(
 def save_contract_expectation_quantities(
     location, post_data, allowed_ids: set[int] | None = None
 ) -> int:
-    return _save_fitting_quantity_expectations(
+    return _save_fitting_track_expectations(
         location,
         post_data,
         EveMarketContractExpectation,
@@ -343,21 +411,20 @@ def build_location_fitting_expectations_context(
         "help_text": (
             f"Showing {len(filtered_rows)} of {len(all_rows)} non-doctrine ship fits."
         ),
-        "save_button_label": "Save quantities",
+        "save_button_label": "Save tracking",
         "page_title": "Non-doctrine fittings for sale",
         "page_intro": (
-            "Set how many of each non-doctrine ship fit you want stocked at this location."
+            "Choose which non-doctrine ship fits should be present on the market "
+            "at this location. Depth and restock are driven by sales volume."
         ),
         "page_help_bullets": [
             (
-                "How many to stock",
-                "Complete ship fits you want listed on the market.",
+                "Track",
+                "When checked, this fit's hull and modules are on the sell-order catalog.",
             ),
             (
                 "Shared modules",
-                "If several fits use the same module, the market status page uses "
-                "the highest quantity needed — not the sum — so one listing can "
-                "cover multiple fits.",
+                "If several fits use the same module, one listing covers all of them.",
             ),
             (
                 "Items in fit",
@@ -424,12 +491,12 @@ def build_location_contract_expectations_context(
         "help_text": (
             f"Showing {len(filtered_rows)} of {len(all_rows)} fleet ship fits."
         ),
-        "save_button_label": "Save quantities",
+        "save_button_label": "Save tracking",
         "page_title": "Doctrine fittings for sale",
         "page_intro": (
-            "Configure how many of each doctrine ship should be offered — this page "
-            "is per ship fit, not individual contract listings. "
-            "Suggested stock on the market status page is calculated from these quantities."
+            "Choose which doctrine ships should have at least one outstanding "
+            "contract at this location. Suggested sell-order items (ammo, refits) "
+            "come from one fit's contents; restock depth uses sales volume."
         ),
         "mismatched_contracts_url": reverse(
             "admin:market_location_contracts",

--- a/backend/market/helpers/expectations_changelist.py
+++ b/backend/market/helpers/expectations_changelist.py
@@ -174,12 +174,12 @@ def _format_doctrine_display(
     return f"{count} doctrines", "\n".join(doctrine_names), doctrine_names
 
 
-def _quantity_input(fitting_id: int, quantity: int | None) -> str:
-    value = "" if quantity is None else quantity
+def _track_checkbox(fitting_id: int, quantity: int | None) -> str:
+    checked = " checked" if quantity not in (None, 0) else ""
     return format_html(
-        '<input type="number" name="quantity_{}" value="{}" min="0" step="1" class="vIntegerField">',
+        '<input type="checkbox" name="tracked_{}" value="on"{}>',
         fitting_id,
-        value,
+        checked,
     )
 
 
@@ -200,9 +200,9 @@ class LocationFittingExpectationsModelAdmin(admin.ModelAdmin):
     def display_fitting_name(self, obj: FittingExpectationListItem):
         return obj.fitting_name
 
-    @admin.display(description=_("How many to stock"), ordering="quantity")
+    @admin.display(description=_("Track"), ordering="quantity")
     def display_quantity(self, obj: FittingExpectationListItem):
-        return _quantity_input(obj.fitting_id, obj.quantity)
+        return _track_checkbox(obj.fitting_id, obj.quantity)
 
     @admin.display(description=_("Items in fit"), ordering="item_count")
     def display_item_count(self, obj: FittingExpectationListItem):
@@ -252,9 +252,9 @@ class LocationContractExpectationsModelAdmin(admin.ModelAdmin):
     def display_current(self, obj: ContractExpectationListItem):
         return obj.current
 
-    @admin.display(description=_("How many to offer"), ordering="quantity")
+    @admin.display(description=_("Track"), ordering="quantity")
     def display_quantity(self, obj: ContractExpectationListItem):
-        return _quantity_input(obj.fitting_id, obj.quantity)
+        return _track_checkbox(obj.fitting_id, obj.quantity)
 
     @admin.display(description=_("Completed sales"), ordering="sold")
     def display_sold(self, obj: ContractExpectationListItem):

--- a/backend/market/helpers/health_common.py
+++ b/backend/market/helpers/health_common.py
@@ -118,6 +118,13 @@ def sell_gap_flags(
     avg_markup_pct: float | None,
     days_of_stock_value: float | None,
 ) -> list[str]:
+    """
+    Stock flags for ops gaps.
+
+    Presence targets are 1; depth uses days_of_stock (understocked < 7d).
+    ``expected`` is retained for call-site compat but unused for bands.
+    """
+    _ = expected
     flags: list[str] = []
     if current == 0:
         flags.append(FLAG_OUT_OF_STOCK)
@@ -128,8 +135,6 @@ def sell_gap_flags(
         flags.append(FLAG_UNDERSTOCKED)
     else:
         flags.append(FLAG_IN_STOCK)
-        if current > expected:
-            flags.append(FLAG_OVERSTOCKED)
     if avg_markup_pct is not None:
         if avg_markup_pct < MARKUP_UNDERPRICED_MAX:
             flags.append(FLAG_UNDERPRICED)

--- a/backend/market/helpers/sell_order_health.py
+++ b/backend/market/helpers/sell_order_health.py
@@ -18,7 +18,6 @@ from django.utils import timezone
 from eveuniverse.models import EveType
 
 from market.helpers.health_common import (
-    CRITICAL_RATIO,
     VOLUME_DAYS_1,
     VOLUME_DAYS_3,
     VOLUME_DAYS_7,
@@ -173,8 +172,10 @@ def build_sell_order_health(  # noqa: C901
                 sell_listed_by_loc[loc_pk] += 1
                 if viable >= current:
                     sell_viable_fulfilled_by_loc[loc_pk] += 1
-            coverage_gap = current < desired * CRITICAL_RATIO
-            viability_gap = viable < desired * CRITICAL_RATIO
+            # Presence: coverage gap = empty shelf; viability = listed but
+            # nothing within-reason priced.
+            coverage_gap = current == 0
+            viability_gap = current > 0 and viable == 0
             avg_markup_pct = None
             if current > 0:
                 baseline = baseline_by_type.get(eve_type.id)

--- a/backend/market/helpers/sell_orders.py
+++ b/backend/market/helpers/sell_orders.py
@@ -37,11 +37,6 @@ SOURCE_REFIT = "refit"
 SOURCE_CONSUMABLE = "consumable"
 SOURCE_NON_DOCTRINE_SHIP = "non-doctrine ship"
 
-# Stock bands use desired_qty as target.
-STOCK_VERY_UNDERSTOCKED_MAX_RATIO = 0.25
-STOCK_UNDERSTOCKED_MAX_RATIO = 0.50
-STOCK_OVERSTOCKED_MAX_RATIO = 2.0
-
 MARKUP_VERY_UNDERPRICED_MAX = -20
 MARKUP_UNDERPRICED_MAX = -5
 MARKUP_NORMAL_MAX = 5
@@ -138,6 +133,7 @@ def _fitting_ship_name(eft_format: str) -> str | None:
 
 
 def _stock_level(row: dict) -> str | None:
+    """Presence stock band for admin filters: listed vs nothing listed."""
     current = row.get("reasonable_qty")
     if current is None:
         current = row.get("current_qty") or 0
@@ -146,16 +142,7 @@ def _stock_level(row: dict) -> str | None:
         return None
     if current == 0:
         return "no_stock"
-    ratio = current / target
-    if ratio < STOCK_VERY_UNDERSTOCKED_MAX_RATIO:
-        return "very_understocked"
-    if ratio < STOCK_UNDERSTOCKED_MAX_RATIO:
-        return "understocked"
-    if ratio > STOCK_OVERSTOCKED_MAX_RATIO:
-        return "very_overstocked"
-    if ratio > 1:
-        return "overstocked"
-    return None
+    return "in_stock"
 
 
 def _markup_level(row: dict) -> str | None:
@@ -220,7 +207,7 @@ def _new_row(item_name: str) -> dict:
 
 
 def get_sell_order_recommendations(location) -> list[dict]:
-    """Consumables and refit modules scaled by contract expectation quantity."""
+    """One-fit consumable/refit advisory amounts for tracked contract fittings."""
     recommendations = []
     seen = set()
 
@@ -238,7 +225,6 @@ def get_sell_order_recommendations(location) -> list[dict]:
 
     for cexp in contract_expectations:
         fitting = cexp.fitting
-        contract_qty = cexp.quantity
         for item_name, qty in _get_consumable_items(fitting).items():
             key = ("consumable", item_name, fitting.pk)
             if key in seen:
@@ -247,7 +233,7 @@ def get_sell_order_recommendations(location) -> list[dict]:
             recommendations.append(
                 {
                     "item_name": item_name,
-                    "quantity": qty * contract_qty,
+                    "quantity": qty,
                     "fitting_name": fitting.name,
                     "source": fitting.name,
                     "kind": "consumable",
@@ -262,7 +248,7 @@ def get_sell_order_recommendations(location) -> list[dict]:
                 recommendations.append(
                     {
                         "item_name": item_name,
-                        "quantity": qty * contract_qty,
+                        "quantity": qty,
                         "fitting_name": fitting.name,
                         "source": f"{fitting.name} refit: {refit.name}",
                         "kind": "refit",
@@ -282,22 +268,60 @@ def _sell_orders_queryset(location):
     )
 
 
-def save_sell_order_desired_quantities(
-    location, post_data, allowed_ids: set[int] | None = None
-) -> int:
-    """Persist desired quantities as pinned item expectations. Returns rows saved."""
-    updated = 0
-    prefix = "desired_"
+def _checkbox_tracked_type_ids(
+    post_data, *, allowed_ids: set[int] | None
+) -> set[int]:
+    tracked_ids: set[int] = set()
     for key, raw_value in post_data.items():
-        if not key.startswith(prefix):
+        if not key.startswith("tracked_"):
             continue
-        type_id = int(key.removeprefix(prefix))
+        if raw_value in (None, "", "0", "false", "False", "off"):
+            continue
+        type_id = int(key.removeprefix("tracked_"))
+        if allowed_ids is not None and type_id not in allowed_ids:
+            continue
+        tracked_ids.add(type_id)
+    return tracked_ids
+
+
+def _apply_item_pin_track_set(
+    location,
+    *,
+    ids_to_consider: set[int],
+    tracked_ids: set[int],
+) -> int:
+    updated = 0
+    for type_id in ids_to_consider:
+        if type_id in tracked_ids:
+            EveMarketItemExpectation.objects.update_or_create(
+                location=location,
+                item_id=type_id,
+                defaults={"quantity": 1},
+            )
+            updated += 1
+            continue
+        deleted, _ = EveMarketItemExpectation.objects.filter(
+            location=location,
+            item_id=type_id,
+        ).delete()
+        if deleted:
+            updated += 1
+    return updated
+
+
+def _save_sell_order_pins_legacy(
+    location, post_data, allowed_ids: set[int] | None
+) -> int:
+    updated = 0
+    for key, raw_value in post_data.items():
+        if not key.startswith("desired_"):
+            continue
+        type_id = int(key.removeprefix("desired_"))
         if allowed_ids is not None and type_id not in allowed_ids:
             continue
         if raw_value in (None, ""):
             continue
-        quantity = int(raw_value)
-        if quantity <= 0:
+        if int(raw_value) <= 0:
             deleted, _ = EveMarketItemExpectation.objects.filter(
                 location=location,
                 item_id=type_id,
@@ -308,10 +332,36 @@ def save_sell_order_desired_quantities(
         EveMarketItemExpectation.objects.update_or_create(
             location=location,
             item_id=type_id,
-            defaults={"quantity": quantity},
+            defaults={"quantity": 1},
         )
         updated += 1
     return updated
+
+
+def save_sell_order_desired_quantities(
+    location, post_data, allowed_ids: set[int] | None = None
+) -> int:
+    """
+    Persist pin track on/off as item expectations (presence qty=1).
+
+    Prefers ``tracked_<type_id>`` checkboxes among ``allowed_ids``. Also
+    accepts legacy ``desired_<type_id>`` (positive → pin, ≤0 → unpin).
+    """
+    has_tracked = bool(post_data.get("presence_tracking")) or any(
+        key.startswith("tracked_") for key in post_data
+    )
+    if not has_tracked:
+        return _save_sell_order_pins_legacy(location, post_data, allowed_ids)
+
+    tracked_ids = _checkbox_tracked_type_ids(
+        post_data, allowed_ids=allowed_ids
+    )
+    ids_to_consider = allowed_ids if allowed_ids is not None else tracked_ids
+    return _apply_item_pin_track_set(
+        location,
+        ids_to_consider=ids_to_consider,
+        tracked_ids=tracked_ids,
+    )
 
 
 def build_unified_sell_order_rows(  # noqa: C901
@@ -327,24 +377,23 @@ def build_unified_sell_order_rows(  # noqa: C901
             rows_by_name[item_name] = _new_row(item_name)
         return rows_by_name[item_name]
 
-    pinned: dict[str, int] = {}
+    pinned_names: set[str] = set()
     pinned_expectations = {}
     for exp in EveMarketItemExpectation.objects.filter(
         location=location
     ).select_related("item"):
-        pinned[exp.item.name] = exp.quantity
+        pinned_names.add(exp.item.name)
         pinned_expectations[exp.item_id] = exp.pk
-    pinned_names = set(pinned.keys())
 
     for fexp in EveMarketFittingExpectation.objects.filter(
         location=location
     ).select_related("fitting"):
         ship_name = _fitting_ship_name(fexp.fitting.eft_format)
-        for item_name, qty in fexp.get_item_quantities().items():
+        for item_name in fexp.get_item_names():
             if item_name in pinned_names:
                 continue
             row = row_for(item_name)
-            row["desired_qty"] = max(row["desired_qty"], qty)
+            row["desired_qty"] = 1
             row["references"].add(fexp.fitting.name)
             if item_name == ship_name:
                 row["sources"].add(SOURCE_NON_DOCTRINE_SHIP)
@@ -354,18 +403,17 @@ def build_unified_sell_order_rows(  # noqa: C901
     for cexp in EveMarketContractExpectation.objects.filter(
         location=location
     ).select_related("fitting"):
-        for item_name, qty in _get_consumable_items(cexp.fitting).items():
+        for item_name in _get_consumable_items(cexp.fitting):
             if item_name in pinned_names:
                 continue
-            total = qty * cexp.quantity
             row = row_for(item_name)
-            row["desired_qty"] = max(row["desired_qty"], total)
+            row["desired_qty"] = 1
             row["references"].add(cexp.fitting.name)
             row["sources"].add("contract consumable")
 
-    for item_name, qty in pinned.items():
+    for item_name in pinned_names:
         row = row_for(item_name)
-        row["desired_qty"] = qty
+        row["desired_qty"] = 1
         row["sources"].add("pinned")
 
     for rec in get_sell_order_recommendations(location):

--- a/backend/market/helpers/sell_orders_changelist.py
+++ b/backend/market/helpers/sell_orders_changelist.py
@@ -87,10 +87,7 @@ class SellOrderStockListFilter(admin.SimpleListFilter):
     def lookups(self, request, model_admin):
         return (
             ("no_stock", _("Nothing listed")),
-            ("very_understocked", _("Far below target")),
-            ("understocked", _("Below target")),
-            ("overstocked", _("Above target")),
-            ("very_overstocked", _("Far above target")),
+            ("in_stock", _("Listed")),
         )
 
     def queryset(self, request, queryset):
@@ -153,7 +150,7 @@ class LocationSellOrdersModelAdmin(admin.ModelAdmin):
             '<span class="item-name-text">{}</span>'
             "</span>",
             PINNED_ITEM_ICON,
-            _("You set the target stock for this item manually."),
+            _("You pinned this item so it stays on the tracking catalog."),
             obj.item_name,
         )
 
@@ -171,17 +168,20 @@ class LocationSellOrdersModelAdmin(admin.ModelAdmin):
             naturaltime(obj.last_synced_at),
         )
 
-    @admin.display(description=_("Target stock"))
+    @admin.display(description=_("Pin track"))
     def display_desired_qty(self, obj: SellOrderListItem):
-        if obj.is_editable:
-            return format_html(
-                '<input type="number" name="desired_{}" value="{}" min="0" step="1" class="vIntegerField">',
-                obj.type_id,
-                obj.desired_qty,
-            )
-        return obj.desired_qty
+        if not obj.is_editable or not obj.type_id:
+            return _("Yes") if obj.desired_qty else "—"
+        checked = " checked" if obj.is_pinned else ""
+        return format_html(
+            '<input type="checkbox" name="tracked_{}" value="on"{}'
+            ' title="{}">',
+            obj.type_id,
+            checked,
+            _("Pin this item on the tracking catalog (presence)."),
+        )
 
-    @admin.display(description=_("Suggested stock"))
+    @admin.display(description=_("Suggested (1 fit)"))
     def display_recommended_qty(self, obj: SellOrderListItem):
         if not obj.recommended_qty:
             return obj.recommended_qty
@@ -192,8 +192,8 @@ class LocationSellOrdersModelAdmin(admin.ModelAdmin):
             "</span>",
             obj.recommended_qty,
             _(
-                "Ammo, charges, and refit modules for doctrine fittings for sale, "
-                "multiplied by how many of each ship you configured."
+                "Ammo, charges, and refit modules for one doctrine fit "
+                "(advisory only; depth uses sales volume)."
             ),
         )
 

--- a/backend/market/migrations/0040_normalize_expectation_quantities_to_presence.py
+++ b/backend/market/migrations/0040_normalize_expectation_quantities_to_presence.py
@@ -1,0 +1,24 @@
+from django.db import migrations
+
+
+def normalize_expectation_quantities(apps, schema_editor):
+    for model_name in (
+        "EveMarketItemExpectation",
+        "EveMarketFittingExpectation",
+        "EveMarketContractExpectation",
+    ):
+        model = apps.get_model("market", model_name)
+        model.objects.exclude(quantity=1).update(quantity=1)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("market", "0039_health_snapshot_listed_targets"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            normalize_expectation_quantities,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/backend/market/models/contract.py
+++ b/backend/market/models/contract.py
@@ -7,6 +7,12 @@ from market.helpers.contract_stock import outstanding_stock_q
 
 
 class EveMarketContractExpectation(models.Model):
+    """
+    Catalog entry: track that a doctrine fitting should have at least one
+    outstanding matched contract at a location. ``quantity`` is schema-compat
+    only (normalized to 1); fulfillment is presence.
+    """
+
     fitting = models.ForeignKey(EveFitting, on_delete=models.CASCADE)
     location = models.ForeignKey(EveLocation, on_delete=models.RESTRICT)
     quantity = models.IntegerField(default=1)
@@ -24,7 +30,8 @@ class EveMarketContractExpectation(models.Model):
 
     @property
     def desired_quantity(self):
-        return self.quantity
+        """Presence target: tracked rows always desire at least one contract."""
+        return 1
 
     @property
     def is_fulfilled(self):
@@ -32,11 +39,8 @@ class EveMarketContractExpectation(models.Model):
 
     @property
     def is_understocked(self):
-        understocked_percentage = 0.5
-        return (
-            self.current_quantity
-            < self.desired_quantity * understocked_percentage
-        )
+        """Legacy prop: no outstanding contracts. Depth uses sell-order volume."""
+        return self.current_quantity < 1
 
 
 class EveMarketContract(models.Model):

--- a/backend/market/models/item.py
+++ b/backend/market/models/item.py
@@ -43,8 +43,9 @@ class EveTypeWithSellOrders(EveType):
 
 class EveMarketItemExpectation(models.Model):
     """
-    Seed definition: track a target quantity of an EVE type (e.g. 1000 missiles)
-    at a location, measured by current sell orders.
+    Catalog entry: track that an EVE type should be present on sell orders
+    at a location. ``quantity`` is kept for schema compat and normalized to 1;
+    fulfillment is presence (any listed stock).
     """
 
     item = models.ForeignKey(EveType, on_delete=models.CASCADE)
@@ -66,7 +67,8 @@ class EveMarketItemExpectation(models.Model):
 
     @property
     def desired_quantity(self):
-        return self.quantity
+        """Presence target: tracked rows always desire at least one unit."""
+        return 1
 
     @property
     def is_fulfilled(self):
@@ -74,11 +76,8 @@ class EveMarketItemExpectation(models.Model):
 
     @property
     def is_understocked(self):
-        understocked_percentage = 0.5
-        return (
-            self.current_quantity
-            < self.desired_quantity * understocked_percentage
-        )
+        """Legacy prop: empty shelf. Depth understock uses days_of_stock."""
+        return self.current_quantity < 1
 
 
 class EveMarketBuyOrderExpectation(models.Model):
@@ -227,9 +226,9 @@ def parse_eft_items(eft_format):
 
 class EveMarketFittingExpectation(models.Model):
     """
-    Track a target number of a fitting at a location.  The fitting is
-    decomposed into its ship + modules so each component appears as an
-    item-level expectation on the market.
+    Catalog entry: track that a fitting's components should be present on
+    the market at a location. Decomposed into ship + modules as item names.
+    ``quantity`` is schema-compat only (normalized to 1).
     """
 
     fitting = models.ForeignKey(EveFitting, on_delete=models.CASCADE)
@@ -240,15 +239,18 @@ class EveMarketFittingExpectation(models.Model):
         unique_together = [["fitting", "location"]]
 
     def __str__(self):
-        return f"{self.fitting.name} x{self.quantity} - {self.location.location_name}"
+        return f"{self.fitting.name} - {self.location.location_name}"
+
+    def get_item_names(self):
+        """Item names from one fit (presence catalog; no BOM multipliers)."""
+        return set(parse_eft_items(self.fitting.eft_format).keys())
 
     def get_item_quantities(self):
         """
-        Decompose the fitting and multiply by the expectation quantity.
-        Returns {item_name: total_quantity_needed}.
+        Presence map for fitting components: each item name → 1.
+        Callers that need BOM line qtys should use parse_eft_items.
         """
-        per_fit = parse_eft_items(self.fitting.eft_format)
-        return {name: qty * self.quantity for name, qty in per_fit.items()}
+        return {name: 1 for name in self.get_item_names()}
 
 
 _STRUCTURAL_CATEGORIES = frozenset({"Ship", "Module", "Subsystem"})
@@ -283,91 +285,86 @@ def _get_consumable_items(fitting):
 
 def get_effective_item_expectations(location):
     """
-    Combine fitting-derived expectations and contract consumables, with manual
-    item expectations (pinned) overriding fitting-derived quantities for those
-    items. Pinned items are excluded from fitting piggyback.
-    """
-    pinned = {}
-    for exp in EveMarketItemExpectation.objects.filter(
-        location=location
-    ).select_related("item"):
-        pinned[exp.item.name] = exp.quantity
+    Catalog of item names that should be present on sell orders at a location.
 
-    pinned_names = set(pinned.keys())
-    effective = defaultdict(int)
+    Sources: fitting expectations, contract consumables, and pinned item
+    expectations. Pinned names are excluded from fitting/contract piggyback.
+    Values are always presence targets (1).
+    """
+    pinned_names = set(
+        EveMarketItemExpectation.objects.filter(location=location)
+        .select_related("item")
+        .values_list("item__name", flat=True)
+    )
+    effective: dict[str, int] = {}
 
     for fexp in EveMarketFittingExpectation.objects.filter(
         location=location
     ).select_related("fitting"):
-        for name, qty in fexp.get_item_quantities().items():
+        for name in fexp.get_item_names():
             if name in pinned_names:
                 continue
-            effective[name] = max(effective[name], qty)
+            effective[name] = 1
 
     for cexp in EveMarketContractExpectation.objects.filter(
         location=location
     ).select_related("fitting"):
-        consumables = _get_consumable_items(cexp.fitting)
-        for name, qty in consumables.items():
+        for name in _get_consumable_items(cexp.fitting):
             if name in pinned_names:
                 continue
-            total = qty * cexp.quantity
-            effective[name] = max(effective[name], total)
+            effective[name] = 1
 
-    for name, qty in pinned.items():
-        effective[name] = qty
+    for name in pinned_names:
+        effective[name] = 1
 
-    return dict(effective)
+    return effective
 
 
 def get_effective_item_expectations_bulk(locations):
     """
     Like get_effective_item_expectations but for many locations at once.
-    Returns {location.pk: {item_name: quantity}}.
+    Returns {location.pk: {item_name: 1}}.
     """
     location_list = list(locations)
     if not location_list:
         return {}
 
     location_pks = [location.pk for location in location_list]
-    effective_by_location = {
-        location_pk: defaultdict(int) for location_pk in location_pks
+    effective_by_location: dict[int, dict[str, int]] = {
+        location_pk: {} for location_pk in location_pks
     }
-    pinned_by_location = {location_pk: {} for location_pk in location_pks}
+    pinned_by_location: dict[int, set[str]] = {
+        location_pk: set() for location_pk in location_pks
+    }
 
     for exp in EveMarketItemExpectation.objects.filter(
         location_id__in=location_pks
     ).select_related("item"):
-        pinned_by_location[exp.location_id][exp.item.name] = exp.quantity
+        pinned_by_location[exp.location_id].add(exp.item.name)
 
     for fexp in EveMarketFittingExpectation.objects.filter(
         location_id__in=location_pks
     ).select_related("fitting"):
         location_effective = effective_by_location[fexp.location_id]
         pinned_names = pinned_by_location[fexp.location_id]
-        for name, qty in fexp.get_item_quantities().items():
+        for name in fexp.get_item_names():
             if name in pinned_names:
                 continue
-            location_effective[name] = max(location_effective[name], qty)
+            location_effective[name] = 1
 
     for cexp in EveMarketContractExpectation.objects.filter(
         location_id__in=location_pks
     ).select_related("fitting"):
         location_effective = effective_by_location[cexp.location_id]
         pinned_names = pinned_by_location[cexp.location_id]
-        consumables = _get_consumable_items(cexp.fitting)
-        for name, qty in consumables.items():
+        for name in _get_consumable_items(cexp.fitting):
             if name in pinned_names:
                 continue
-            total = qty * cexp.quantity
-            location_effective[name] = max(location_effective[name], total)
+            location_effective[name] = 1
 
     for location_pk, pinned in pinned_by_location.items():
         location_effective = effective_by_location[location_pk]
-        for name, qty in pinned.items():
-            location_effective[name] = qty
+        for name in pinned:
+            location_effective[name] = 1
 
-    return {
-        location_pk: dict(effective)
-        for location_pk, effective in effective_by_location.items()
-    }
+    return effective_by_location

--- a/backend/market/templates/admin/market/location_expectations_changelist.html
+++ b/backend/market/templates/admin/market/location_expectations_changelist.html
@@ -72,6 +72,7 @@
 
       <form method="post" id="changelist-form" action="{{ form_action }}">
         {% csrf_token %}
+        <input type="hidden" name="presence_tracking" value="1">
         {% result_list cl %}
         {% pagination cl %}
 

--- a/backend/market/templates/admin/market/location_hub.html
+++ b/backend/market/templates/admin/market/location_hub.html
@@ -85,7 +85,7 @@
         {% endblocktranslate %}
       </p>
       <a href="{% url 'admin:market_location_fitting_expectations' location.pk %}" class="button">
-        {% translate "Configure quantities" %}
+        {% translate "Configure tracking" %}
       </a>
     </div>
 
@@ -98,7 +98,7 @@
         {% endblocktranslate %}
       </p>
       <a href="{% url 'admin:market_location_contract_expectations' location.pk %}" class="button">
-        {% translate "Configure quantities" %}
+        {% translate "Configure tracking" %}
       </a>
     </div>
 

--- a/backend/market/templates/admin/market/location_sell_orders.html
+++ b/backend/market/templates/admin/market/location_sell_orders.html
@@ -135,7 +135,7 @@
   </p>
 
   {% include "admin/market/_learn_more_start.html" %}
-    <p>{% translate "Items to keep stocked at this structure, based on your configuration." %}</p>
+    <p>{% translate "Items that should be present on the market at this structure. Restock depth uses sales volume (about 7 days of cover)." %}</p>
     <ul class="market-help-list">
       <li>
         <strong>{% translate "Listed now" %}</strong> —
@@ -146,16 +146,16 @@
         {% translate "how long ago that import ran for this item (hover for exact time)." %}
       </li>
       <li>
-        <strong>{% translate "Target stock" %}</strong> —
-        {% translate "how many you want listed; edit here and save, or set via the configure pages above. A pin on the item name means you set it manually on this page." %}
+        <strong>{% translate "Pin track" %}</strong> —
+        {% translate "manually keep this item on the catalog even if no fit requires it. Fits and doctrines are configured on the pages above." %}
       </li>
       <li>
-        <strong>{% translate "Suggested stock" %}</strong> —
-        {% translate "ammo, charges, and refit modules for doctrine fittings for sale, based on how many doctrine ships you configured. Hover the number for details." %}
+        <strong>{% translate "Suggested (1 fit)" %}</strong> —
+        {% translate "ammo, charges, and refit modules for one doctrine fit (advisory only)." %}
       </li>
       <li>
         <strong>{% translate "Needed for" %}</strong> —
-        {% translate "which ship fits drive this item's target or suggestion. Hover to see names." %}
+        {% translate "which ship fits put this item on the catalog. Hover to see names." %}
       </li>
     </ul>
   {% include "admin/market/_learn_more_end.html" %}
@@ -181,13 +181,14 @@
 
       <form method="post" id="changelist-form" action="{{ form_action }}">
         {% csrf_token %}
+        <input type="hidden" name="presence_tracking" value="1">
         {% result_list cl %}
         {% pagination cl %}
 
         {% if cl.result_count %}
         <div class="submit-row">
           <p class="help">{% translate "Only the rows on this page are saved when you click Save." %}</p>
-          <input type="submit" value="{% translate 'Save target stock' %}" class="default">
+          <input type="submit" value="{% translate 'Save tracking' %}" class="default">
         </div>
         {% endif %}
       </form>

--- a/backend/market/tests/test_fitting_expectations.py
+++ b/backend/market/tests/test_fitting_expectations.py
@@ -146,17 +146,17 @@ class EveMarketFittingExpectationTestCase(TestCase):
             ship_id=587,
         )
 
-    def test_get_item_quantities_multiplies_by_expectation(self):
+    def test_get_item_quantities_is_presence(self):
         exp = EveMarketFittingExpectation.objects.create(
             fitting=self.fitting,
             location=self.location,
             quantity=10,
         )
         items = exp.get_item_quantities()
-        self.assertEqual(items["Rifter"], 10)
-        self.assertEqual(items["Damage Control II"], 10)
-        self.assertEqual(items["150mm Light Prototype Automatic Cannon"], 30)
-        self.assertEqual(items["Fusion S"], 20000)
+        self.assertEqual(items["Rifter"], 1)
+        self.assertEqual(items["Damage Control II"], 1)
+        self.assertEqual(items["150mm Light Prototype Automatic Cannon"], 1)
+        self.assertEqual(items["Fusion S"], 1)
 
     def test_str(self):
         exp = EveMarketFittingExpectation.objects.create(
@@ -165,7 +165,8 @@ class EveMarketFittingExpectationTestCase(TestCase):
             quantity=5,
         )
         self.assertIn("AC Rifter", str(exp))
-        self.assertIn("x5", str(exp))
+        self.assertIn("Staging Keepstar", str(exp))
+        self.assertNotIn("x5", str(exp))
 
 
 class GetEffectiveItemExpectationsTestCase(TestCase):
@@ -203,19 +204,19 @@ class GetEffectiveItemExpectationsTestCase(TestCase):
             item=self.dc2_type, location=self.location, quantity=10
         )
         result = get_effective_item_expectations(self.location)
-        self.assertEqual(result["Damage Control II"], 10)
+        self.assertEqual(result["Damage Control II"], 1)
 
     def test_fitting_only(self):
         EveMarketFittingExpectation.objects.create(
             fitting=self.fitting_a, location=self.location, quantity=15
         )
         result = get_effective_item_expectations(self.location)
-        self.assertEqual(result["Damage Control II"], 15)
-        self.assertEqual(result["Rifter"], 15)
+        self.assertEqual(result["Damage Control II"], 1)
+        self.assertEqual(result["Rifter"], 1)
 
     def test_pinned_overrides_fitting_max(self):
         """
-        Pinned item expectation overrides fitting-derived quantity for that item.
+        Pinned item expectation still wins for that item (presence target 1).
         """
         EveMarketItemExpectation.objects.create(
             item=self.dc2_type, location=self.location, quantity=10
@@ -227,7 +228,7 @@ class GetEffectiveItemExpectationsTestCase(TestCase):
             fitting=self.fitting_b, location=self.location, quantity=15
         )
         result = get_effective_item_expectations(self.location)
-        self.assertEqual(result["Damage Control II"], 10)
+        self.assertEqual(result["Damage Control II"], 1)
 
     def test_individual_larger_than_fittings(self):
         EveMarketItemExpectation.objects.create(
@@ -237,10 +238,10 @@ class GetEffectiveItemExpectationsTestCase(TestCase):
             fitting=self.fitting_a, location=self.location, quantity=10
         )
         result = get_effective_item_expectations(self.location)
-        self.assertEqual(result["Damage Control II"], 50)
+        self.assertEqual(result["Damage Control II"], 1)
 
     def test_fitting_with_multiple_of_same_module(self):
-        """A fitting with 3× guns: 10 fittings → 30 guns expected."""
+        """A fitting with 3× guns still contributes presence 1 per item name."""
         fitting_c = EveFitting.objects.create(
             name="Fit C",
             eft_format=(
@@ -256,8 +257,8 @@ class GetEffectiveItemExpectationsTestCase(TestCase):
             fitting=fitting_c, location=self.location, quantity=10
         )
         result = get_effective_item_expectations(self.location)
-        self.assertEqual(result["150mm Light Prototype Automatic Cannon"], 30)
-        self.assertEqual(result["Damage Control II"], 10)
+        self.assertEqual(result["150mm Light Prototype Automatic Cannon"], 1)
+        self.assertEqual(result["Damage Control II"], 1)
 
     def test_empty_location(self):
         result = get_effective_item_expectations(self.location)
@@ -363,8 +364,8 @@ class ContractExpectationConsumablesTestCase(TestCase):
             quantity=5,
         )
         result = get_effective_item_expectations(self.location)
-        self.assertEqual(result["Fusion S"], 10000)
-        self.assertEqual(result["Republic Fleet EMP S"], 3600)
+        self.assertEqual(result["Fusion S"], 1)
+        self.assertEqual(result["Republic Fleet EMP S"], 1)
 
     def test_contract_does_not_add_ship_or_modules(self):
         EveMarketContractExpectation.objects.create(
@@ -378,7 +379,7 @@ class ContractExpectationConsumablesTestCase(TestCase):
         self.assertNotIn("150mm Light Prototype Automatic Cannon", result)
 
     def test_max_across_contract_and_item_expectations(self):
-        """Contract gives 10 000 Fusion S; item expectation gives 15 000 → max wins."""
+        """Pinned and contract consumables both resolve to presence 1."""
         fusion_type = EveType.objects.get(name="Fusion S")
         EveMarketItemExpectation.objects.create(
             item=fusion_type, location=self.location, quantity=15000
@@ -389,7 +390,7 @@ class ContractExpectationConsumablesTestCase(TestCase):
             quantity=5,
         )
         result = get_effective_item_expectations(self.location)
-        self.assertEqual(result["Fusion S"], 15000)
+        self.assertEqual(result["Fusion S"], 1)
 
     def test_contract_consumable_larger_than_item_expectation(self):
         """Pinned item expectation overrides contract consumable contribution."""
@@ -403,10 +404,10 @@ class ContractExpectationConsumablesTestCase(TestCase):
             quantity=5,
         )
         result = get_effective_item_expectations(self.location)
-        self.assertEqual(result["Fusion S"], 5000)
+        self.assertEqual(result["Fusion S"], 1)
 
     def test_multiple_contract_expectations_max(self):
-        """Two contract expectations for different fittings; max per item wins."""
+        """Two contract expectations still contribute presence 1 per item."""
         fitting_b = EveFitting.objects.create(
             name="Big Ammo Rifter",
             eft_format="[Rifter, Big Ammo Rifter]\n\nDamage Control II\n\nFusion S x5000\n",
@@ -423,5 +424,4 @@ class ContractExpectationConsumablesTestCase(TestCase):
             quantity=3,
         )
         result = get_effective_item_expectations(self.location)
-        # fitting: 2000*5=10000, fitting_b: 5000*3=15000
-        self.assertEqual(result["Fusion S"], 15000)
+        self.assertEqual(result["Fusion S"], 1)

--- a/backend/market/tests/test_market_vision.py
+++ b/backend/market/tests/test_market_vision.py
@@ -187,8 +187,8 @@ class PinningExpectationsTestCase(TestCase):
             quantity=500,
         )
         effective = get_effective_item_expectations(self.location)
-        self.assertEqual(effective["Fusion S"], 500)
-        self.assertNotEqual(effective["Fusion S"], 20000)
+        self.assertEqual(effective["Fusion S"], 1)
+        self.assertIn("Rifter", effective)
 
     def test_pinned_item_excluded_from_fitting_sum(self):
         EveMarketItemExpectation.objects.create(
@@ -197,7 +197,7 @@ class PinningExpectationsTestCase(TestCase):
             quantity=3,
         )
         effective = get_effective_item_expectations(self.location)
-        self.assertEqual(effective["Rifter"], 3)
+        self.assertEqual(effective["Rifter"], 1)
 
 
 class BuyOrderSyncTestCase(TestCase):
@@ -632,7 +632,7 @@ class SellOrderRowsTestCase(TestCase):
         self.assertEqual(rows["Fusion S"]["current_qty"], 12)
         acolyte = rows["Acolyte I"]
         self.assertEqual(acolyte["current_qty"], 0)
-        self.assertEqual(acolyte["desired_qty"], 50)
+        self.assertEqual(acolyte["desired_qty"], 1)
         self.assertEqual(acolyte["recommended_qty"], 50)
         self.assertIn("[FL33T] Augoror", acolyte["references"])
         self.assertIn("consumable", acolyte["sources"])
@@ -646,10 +646,10 @@ class SellOrderRowsTestCase(TestCase):
             row["item_name"]: row
             for row in build_unified_sell_order_rows(self.location)
         }
-        self.assertEqual(rows["Acolyte I"]["desired_qty"], 75)
+        self.assertEqual(rows["Acolyte I"]["desired_qty"], 1)
         self.assertTrue(rows["Acolyte I"]["is_pinned"])
 
-    def test_recommended_qty_scales_with_contract_expectation_quantity(self):
+    def test_recommended_qty_uses_one_fit_not_contract_quantity(self):
         EveMarketContractExpectation.objects.create(
             location=self.location,
             fitting=self.fitting,
@@ -659,7 +659,8 @@ class SellOrderRowsTestCase(TestCase):
             row["item_name"]: row
             for row in build_unified_sell_order_rows(self.location)
         }
-        self.assertEqual(rows["Acolyte I"]["recommended_qty"], 150)
+        self.assertEqual(rows["Acolyte I"]["recommended_qty"], 50)
+        self.assertEqual(rows["Acolyte I"]["desired_qty"], 1)
 
     def test_filter_search_and_stock_filters(self):
         rows = [
@@ -675,7 +676,7 @@ class SellOrderRowsTestCase(TestCase):
             {
                 "item_name": "Fusion S",
                 "current_qty": 0,
-                "desired_qty": 100,
+                "desired_qty": 1,
                 "recommended_qty": 0,
                 "references": "",
                 "sources": "pinned",
@@ -684,7 +685,7 @@ class SellOrderRowsTestCase(TestCase):
             {
                 "item_name": "Augoror",
                 "current_qty": 10,
-                "desired_qty": 100,
+                "desired_qty": 1,
                 "recommended_qty": 0,
                 "references": "[FL33T] Augoror",
                 "sources": "non-doctrine ship",
@@ -693,7 +694,7 @@ class SellOrderRowsTestCase(TestCase):
             {
                 "item_name": "Damage Control II",
                 "current_qty": 150,
-                "desired_qty": 100,
+                "desired_qty": 1,
                 "recommended_qty": 0,
                 "references": "[FL33T] Augoror",
                 "sources": "fitting",
@@ -701,17 +702,18 @@ class SellOrderRowsTestCase(TestCase):
             },
             {
                 "item_name": "Multispectrum Coating II",
-                "current_qty": 30,
-                "desired_qty": 100,
+                "current_qty": 0,
+                "reasonable_qty": 0,
+                "desired_qty": 1,
                 "recommended_qty": 0,
                 "references": "[FL33T] Augoror",
                 "sources": "fitting",
                 "markup_pct": 2,
             },
             {
-                "item_name": "Overstocked Hull",
+                "item_name": "Listed Hull",
                 "current_qty": 250,
-                "desired_qty": 100,
+                "desired_qty": 1,
                 "recommended_qty": 0,
                 "references": "[FL33T] Augoror",
                 "sources": "non-doctrine ship",
@@ -727,53 +729,43 @@ class SellOrderRowsTestCase(TestCase):
         no_stock = filter_sell_order_rows(rows, stock_filter="no_stock")
         self.assertEqual(
             [row["item_name"] for row in no_stock],
-            ["Fusion S"],
+            ["Fusion S", "Multispectrum Coating II"],
         )
 
-        very_understocked = filter_sell_order_rows(
-            rows, stock_filter="very_understocked"
+        in_stock = filter_sell_order_rows(rows, stock_filter="in_stock")
+        self.assertEqual(
+            [row["item_name"] for row in in_stock],
+            ["Augoror", "Damage Control II", "Listed Hull"],
+        )
+
+    def test_stock_level_is_presence_only(self):
+        self.assertEqual(
+            _stock_level(
+                {
+                    "current_qty": 0,
+                    "desired_qty": 1,
+                }
+            ),
+            "no_stock",
         )
         self.assertEqual(
-            [row["item_name"] for row in very_understocked],
-            ["Augoror"],
+            _stock_level(
+                {
+                    "current_qty": 150,
+                    "reasonable_qty": 10,
+                    "desired_qty": 1,
+                }
+            ),
+            "in_stock",
         )
-
-        understocked = filter_sell_order_rows(
-            rows, stock_filter="understocked"
+        self.assertIsNone(
+            _stock_level(
+                {
+                    "current_qty": 0,
+                    "desired_qty": 0,
+                }
+            )
         )
-        self.assertEqual(
-            [row["item_name"] for row in understocked],
-            ["Multispectrum Coating II"],
-        )
-
-        overstocked = filter_sell_order_rows(rows, stock_filter="overstocked")
-        self.assertEqual(
-            [row["item_name"] for row in overstocked],
-            ["Damage Control II"],
-        )
-
-        very_overstocked = filter_sell_order_rows(
-            rows, stock_filter="very_overstocked"
-        )
-        self.assertEqual(
-            [row["item_name"] for row in very_overstocked],
-            ["Overstocked Hull"],
-        )
-
-    def test_stock_level_uses_reasonable_qty_when_present(self):
-        row = {
-            "current_qty": 150,
-            "reasonable_qty": 10,
-            "desired_qty": 100,
-        }
-        self.assertEqual(_stock_level(row), "very_understocked")
-
-        overstocked_row = {
-            "current_qty": 250,
-            "reasonable_qty": 150,
-            "desired_qty": 100,
-        }
-        self.assertEqual(_stock_level(overstocked_row), "overstocked")
 
     def test_reasonable_listing_thresholds(self):
         self.assertTrue(
@@ -1154,7 +1146,7 @@ class SellOrderRowsTestCase(TestCase):
             {
                 "item_name": "Acolyte I",
                 "current_qty": 0,
-                "desired_qty": 75,
+                "desired_qty": 1,
                 "recommended_qty": 50,
                 "is_pinned": True,
             }
@@ -1168,7 +1160,10 @@ class SellOrderRowsTestCase(TestCase):
         self.assertIn("pinned-hover", pinned_html)
         self.assertIn("pinned-icon", pinned_html)
         self.assertIn("Acolyte I", pinned_html)
-        self.assertIn("You set the target stock", pinned_html)
+        self.assertIn(
+            "You pinned this item so it stays on the tracking catalog",
+            pinned_html,
+        )
 
 
 class ExpectationsAdminViewsTestCase(TestCase):
@@ -1265,13 +1260,13 @@ class ExpectationsAdminViewsTestCase(TestCase):
             EveMarketFittingExpectation.objects.get(
                 location=self.location, fitting=non_doctrine
             ).quantity,
-            6,
+            1,
         )
         self.assertEqual(
             EveMarketContractExpectation.objects.get(
                 location=self.location, fitting=self.fitting
             ).quantity,
-            9,
+            1,
         )
 
     def test_fitting_expectations_render_on_single_page(self):
@@ -1326,7 +1321,10 @@ class ExpectationsAdminViewsTestCase(TestCase):
             )
             post_request = self.factory.post(
                 f"{url}?p=2",
-                {f"quantity_{page2_fitting_id}": "8"},
+                {
+                    "presence_tracking": "1",
+                    f"tracked_{page2_fitting_id}": "on",
+                },
             )
             post_request.user = user
             post_request.session = {}
@@ -1342,7 +1340,7 @@ class ExpectationsAdminViewsTestCase(TestCase):
             EveMarketFittingExpectation.objects.get(
                 location=self.location, fitting_id=page2_fitting_id
             ).quantity,
-            8,
+            1,
         )
 
     def test_contract_expectations_include_all_doctrine_fittings(self):

--- a/backend/market/tests/test_router.py
+++ b/backend/market/tests/test_router.py
@@ -78,12 +78,12 @@ class MarketRouterTestCase(TestCase):
         self.assertEqual(1, len(data))
         self.assertEqual("[NVY-5] Atron", data[0]["title"])
         self.assertEqual(1, data[0]["current_quantity"])
-        self.assertEqual(10, data[0]["desired_quantity"])
+        self.assertEqual(1, data[0]["desired_quantity"])
         self.assertEqual(1, data[0]["ship_id"])
         self.assertEqual(
             expectation.location.location_id, data[0]["location_id"]
         )
-        self.assertEqual("thin", data[0]["readiness"])
+        self.assertEqual("ready", data[0]["readiness"])
         self.assertEqual(1, len(data[0]["sellers"]))
         self.assertEqual(1, data[0]["sellers"][0]["character_id"])
         self.assertEqual(1, data[0]["sellers"][0]["quantity"])
@@ -284,11 +284,11 @@ class MarketRouterTestCase(TestCase):
             description="At target",
             eft_format="[Atron, [NVY-5] Ready Fit]",
         )
-        thin_fit = EveFitting.objects.create(
-            name="[NVY-5] Thin Fit",
+        empty_fit = EveFitting.objects.create(
+            name="[NVY-5] Empty Fit",
             ship_id=587,
-            description="Under target",
-            eft_format="[Rifter, [NVY-5] Thin Fit]",
+            description="No stock",
+            eft_format="[Rifter, [NVY-5] Empty Fit]",
         )
         EveMarketContractExpectation.objects.create(
             fitting=ready_fit,
@@ -296,7 +296,7 @@ class MarketRouterTestCase(TestCase):
             quantity=2,
         )
         EveMarketContractExpectation.objects.create(
-            fitting=thin_fit,
+            fitting=empty_fit,
             location=loc,
             quantity=5,
         )
@@ -309,14 +309,6 @@ class MarketRouterTestCase(TestCase):
                 price=1.0,
                 issuer_external_id=1,
             )
-        EveMarketContract.objects.create(
-            id=7100,
-            location=loc,
-            fitting=thin_fit,
-            status="outstanding",
-            price=1.0,
-            issuer_external_id=1,
-        )
 
         response = self.client.get(
             f"{BASE_URL}/contracts?location_id={loc.location_id}",
@@ -332,19 +324,21 @@ class MarketRouterTestCase(TestCase):
         by_title = {row["title"]: row for row in data}
         self.assertEqual("ready", by_title["[NVY-5] Ready Fit"]["readiness"])
         self.assertEqual(2, by_title["[NVY-5] Ready Fit"]["current_quantity"])
-        self.assertEqual("thin", by_title["[NVY-5] Thin Fit"]["readiness"])
-        self.assertEqual(1, by_title["[NVY-5] Thin Fit"]["current_quantity"])
+        self.assertEqual(1, by_title["[NVY-5] Ready Fit"]["desired_quantity"])
+        self.assertEqual("empty", by_title["[NVY-5] Empty Fit"]["readiness"])
+        self.assertEqual(0, by_title["[NVY-5] Empty Fit"]["current_quantity"])
+        self.assertEqual(1, by_title["[NVY-5] Empty Fit"]["desired_quantity"])
         self.assertEqual(608, by_title["[NVY-5] Ready Fit"]["ship_id"])
         self.assertEqual(1, len(by_title["[NVY-5] Ready Fit"]["sellers"]))
         self.assertEqual(
             2, by_title["[NVY-5] Ready Fit"]["sellers"][0]["quantity"]
         )
-        # Higher fill first (100% -> 0%), then no-expectation
+        # Ready before empty when sorting by fill.
         readiness_order = [row["readiness"] for row in data]
-        self.assertIn("thin", readiness_order)
+        self.assertIn("empty", readiness_order)
         self.assertIn("ready", readiness_order)
         self.assertLess(
-            readiness_order.index("ready"), readiness_order.index("thin")
+            readiness_order.index("ready"), readiness_order.index("empty")
         )
 
     def test_get_contracts_unknown_location_returns_empty(self):

--- a/backend/market/tests/test_staging_supply.py
+++ b/backend/market/tests/test_staging_supply.py
@@ -113,14 +113,15 @@ class MarketHealthApiTestCase(TestCase):
     def test_build_contract_and_sell_health_queues(self):
         contracts = _contract_at(self.loc.location_id)
         sells = _sell_at(self.loc.location_id)
-        self.assertGreaterEqual(len(contracts["rows"]), 1)
+        # Outstanding contract satisfies presence desired=1 → ready, omitted.
+        self.assertEqual(contracts["rows"], [])
         self.assertNotIn("mismatched_contracts", contracts)
         self.assertIsNotNone(contracts["summary"]["health_pct"])
         self.assertIn("viability_pct", contracts["summary"])
         self.assertIn("viable_fulfilled", contracts["summary"])
         self.assertIn("health_pct", sells["summary"])
         self.assertEqual(contracts["summary"]["targets"], 1)
-        self.assertEqual(contracts["summary"]["fulfilled"], 0)
+        self.assertEqual(contracts["summary"]["fulfilled"], 1)
         self.assertGreaterEqual(contracts["summary"]["isk"], 0)
         self.assertGreaterEqual(sells["summary"]["isk"], 0)
 
@@ -390,12 +391,16 @@ class MarketHealthApiTestCase(TestCase):
 
         contracts = _contract_at(self.loc.location_id)
         _sell_at(self.loc.location_id)
+        # Atron has an outstanding contract → presence-ready → omitted.
         ship_ids = [row["ship_id"] for row in contracts["rows"]]
-        self.assertEqual(ship_ids, [608, 24692])
+        self.assertEqual(ship_ids, [24692])
 
     def test_understocked_contracts_include_finished_volume_windows(self):
         now = timezone.now()
-        # Outstanding already created in setUp (id=1) → understocked vs qty 4.
+        # Remove outstanding stock so this fit is understocked (presence).
+        EveMarketContract.objects.filter(
+            id=1, location=self.loc, fitting=self.fit
+        ).delete()
         EveMarketContract.objects.create(
             id=101,
             status="finished",
@@ -468,8 +473,8 @@ class MarketHealthApiTestCase(TestCase):
         self.assertEqual(row["weekly_units"], 3)
         self.assertEqual(row["units_30d"], 4)
         self.assertEqual(row["units_90d"], 5)
-        # 1 outstanding ÷ (3/7 per day) ≈ 2.3 days of stock
-        self.assertEqual(row["days_of_stock"], 2.3)
+        # No outstanding ÷ (3/7 per day) → 0 days of stock
+        self.assertEqual(row["days_of_stock"], 0.0)
         self.assertGreaterEqual(contracts["summary"]["history_days"], 60)
 
     def test_sell_gaps_include_useful_ship_icons(self):
@@ -618,7 +623,7 @@ class MarketHealthApiTestCase(TestCase):
         )
         for row in sells["rows"]:
             self.assertTrue(row["coverage_gap"])
-            self.assertTrue(row["viability_gap"])
+            self.assertFalse(row["viability_gap"])
             self.assertEqual(row["item_type"], "consumable")
             self.assertEqual(row["units_1d"], 0)
             self.assertEqual(row["units_3d"], 0)
@@ -652,18 +657,11 @@ class MarketHealthApiTestCase(TestCase):
             location=self.loc,
             quantity=100,
         )
-        # Coverage OK (100 listed) but only 11 at a viable price.
+        # Listed, but nothing at a viable price → viability gap only.
         EveMarketItemOrder.objects.create(
             location=self.loc,
             item=item,
-            quantity=11,
-            price=2_200_000,
-            is_buy_order=False,
-        )
-        EveMarketItemOrder.objects.create(
-            location=self.loc,
-            item=item,
-            quantity=89,
+            quantity=100,
             price=3_000_000,
             is_buy_order=False,
         )
@@ -681,12 +679,12 @@ class MarketHealthApiTestCase(TestCase):
             if row["item_name"] == "Viability Only Ammo"
         )
         self.assertEqual(gap["current_quantity"], 100)
-        self.assertEqual(gap["viable_quantity"], 11)
+        self.assertEqual(gap["viable_quantity"], 0)
         self.assertFalse(gap["coverage_gap"])
         self.assertTrue(gap["viability_gap"])
         self.assertEqual(gap["item_type"], "consumable")
 
-    def test_both_gaps_when_stock_is_thin(self):
+    def test_no_gaps_when_any_fair_stock_is_listed(self):
         charge_cat, _ = EveCategory.objects.get_or_create(
             id=8, defaults={"name": "Charge", "published": True}
         )
@@ -731,8 +729,9 @@ class MarketHealthApiTestCase(TestCase):
             for row in sells["rows"]
             if row["item_name"] == "Thin Stock Ammo"
         )
-        self.assertTrue(gap["coverage_gap"])
-        self.assertTrue(gap["viability_gap"])
+        # Presence desired=1; any fair listing covers both gap kinds.
+        self.assertFalse(gap["coverage_gap"])
+        self.assertFalse(gap["viability_gap"])
         self.assertEqual(gap["item_type"], "consumable")
 
     def test_gap_row_includes_volume_windows_and_markup(self):
@@ -915,6 +914,11 @@ class MarketHealthApiTestCase(TestCase):
             sell_gap_flags(120, 50, 12.0, 3.0),
             ["understocked", "overpriced"],
         )
+        # Presence targets do not emit overstocked from qty vs expected.
+        self.assertEqual(
+            sell_gap_flags(120, 1, None, None),
+            ["in_stock"],
+        )
 
     def test_seven_day_vwap_avoids_one_day_dip_false_overpriced(self):
         """Listing fair vs 7d VWAP is not overpriced even if latest-day dipped."""
@@ -977,7 +981,7 @@ class MarketHealthApiTestCase(TestCase):
         )
         self.assertEqual(sells["summary"]["viability_pct"], 100.0)
 
-    def test_overstocked_overpriced_flags_on_viability_gap(self):
+    def test_overpriced_flags_on_viability_gap(self):
         charge_cat, _ = EveCategory.objects.get_or_create(
             id=8, defaults={"name": "Charge", "published": True}
         )
@@ -1027,7 +1031,7 @@ class MarketHealthApiTestCase(TestCase):
         self.assertEqual(gap["avg_markup_pct"], 50.0)
         self.assertEqual(
             gap["flags"],
-            ["in_stock", "overstocked", "overpriced"],
+            ["in_stock", "overpriced"],
         )
 
     def test_understocked_contracts_returns_all_rows(self):
@@ -1045,7 +1049,8 @@ class MarketHealthApiTestCase(TestCase):
             )
 
         contracts = _contract_at(self.loc.location_id)
-        self.assertEqual(len(contracts["rows"]), 56)
+        # setUp atron has outstanding stock → ready → omitted; 55 empty only.
+        self.assertEqual(len(contracts["rows"]), 55)
 
     def test_overpriced_stock_counts_as_coverage_not_viability(self):
         charge_cat, _ = EveCategory.objects.get_or_create(
@@ -1101,9 +1106,11 @@ class MarketHealthApiTestCase(TestCase):
         )
         self.assertEqual(gap["current_quantity"], 100)
         self.assertEqual(gap["viable_quantity"], 11)
-        self.assertEqual(gap["shortfall"], 89)
+        # Presence desired=1; shortfall uses viable vs desired.
+        self.assertEqual(gap["shortfall"], 0)
         self.assertFalse(gap["coverage_gap"])
-        self.assertTrue(gap["viability_gap"])
+        # Some viable stock remains → not a viability gap.
+        self.assertFalse(gap["viability_gap"])
         self.assertEqual(gap["item_type"], "consumable")
         self.assertEqual(sells["summary"]["targets"], 1)
         self.assertEqual(sells["summary"]["fulfilled"], 1)
@@ -1116,7 +1123,7 @@ class MarketHealthApiTestCase(TestCase):
                 for r in sells["rows"]
                 if r["coverage_gap"] or r["viability_gap"]
             ),
-            1,
+            0,
         )
         self.assertEqual(gap["flags"], ["in_stock", "overpriced"])
         self.assertIsNone(gap["days_of_stock"])

--- a/backend/tech/seed_data.py
+++ b/backend/tech/seed_data.py
@@ -232,7 +232,7 @@ def seed_market_expectations():
         _, created = EveMarketContractExpectation.objects.get_or_create(
             fitting=doctrine_fitting.fitting,
             location=location,
-            defaults={"quantity": 5},
+            defaults={"quantity": 1},
         )
         if created:
             expectations_created += 1

--- a/dev.sh
+++ b/dev.sh
@@ -5,6 +5,43 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$ROOT"
 
+stop_local_apps() {
+  # Tear down leftover stacks from prior make dev / ./dev.sh runs.
+  local my_pid=$$
+  local pid
+  for pid in $(pgrep -f '(^|/)(\./)?dev\.sh$|bash \./dev\.sh' 2>/dev/null || true); do
+    if [[ "$pid" -ne "$my_pid" ]]; then
+      kill "$pid" 2>/dev/null || true
+    fi
+  done
+
+  pkill -f 'manage.py runserver' 2>/dev/null || true
+  pkill -f 'celery -A app ' 2>/dev/null || true
+  pkill -f 'expo start --tunnel' 2>/dev/null || true
+  # Astro/Vite from this repo's frontend (avoid killing unrelated node apps).
+  pkill -f "${ROOT}/frontend/app/node_modules/.bin/astro" 2>/dev/null || true
+  pkill -f 'astro dev --host' 2>/dev/null || true
+  pkill -f 'astro dev$' 2>/dev/null || true
+
+  # Free ports commonly held by stale listeners.
+  if command -v fuser >/dev/null 2>&1; then
+    fuser -k 8000/tcp 4321/tcp 8081/tcp 2>/dev/null || true
+  fi
+
+  sleep 0.3
+
+  # Hard-kill anything that ignored SIGTERM.
+  for pid in $(pgrep -f '(^|/)(\./)?dev\.sh$|bash \./dev\.sh' 2>/dev/null || true); do
+    if [[ "$pid" -ne "$my_pid" ]]; then
+      kill -9 "$pid" 2>/dev/null || true
+    fi
+  done
+  pkill -9 -f 'manage.py runserver' 2>/dev/null || true
+  pkill -9 -f 'celery -A app ' 2>/dev/null || true
+  pkill -9 -f 'expo start --tunnel' 2>/dev/null || true
+  pkill -9 -f "${ROOT}/frontend/app/node_modules/.bin/astro" 2>/dev/null || true
+}
+
 run() {
   local name=$1
   shift
@@ -25,12 +62,18 @@ cleanup() {
   for pid in "${PIDS[@]}"; do
     kill "$pid" 2>/dev/null || true
   done
+  stop_local_apps
   wait 2>/dev/null || true
 }
 
 trap cleanup EXIT INT TERM
 
+echo "Stopping leftover local app processes..."
+stop_local_apps
+
 echo "Starting MariaDB + Redis..."
+# Recreate Redis so a broken/unpublished 6379 binding cannot block Celery.
+docker compose up -d --force-recreate redis
 docker compose up -d
 
 echo "Starting app services (Ctrl+C to stop all)..."

--- a/frontend/app/src/components/blocks/MarketContractsTable.astro
+++ b/frontend/app/src/components/blocks/MarketContractsTable.astro
@@ -28,7 +28,8 @@ const {
 function fill_pct(current: number, expected: number): number | null {
     if (expected <= 0)
         return null
-    return Math.min(100, (current / expected) * 100)
+    // Presence: 100% when any outstanding contract exists.
+    return current > 0 ? 100 : 0
 }
 
 const filter_rows: OpsContractsFilterRow[] = contracts.map(contract => ({
@@ -66,9 +67,7 @@ const has_no_doctrine = contracts.some(c => (c.doctrines ?? []).length === 0)
 
 const criteria_options = [
     { id: 'unstocked', label: t('ops_contracts_filter_unstocked') },
-    { id: 'low_stock', label: t('ops_contracts_filter_low_stock') },
     { id: 'in_stock', label: t('ops_contracts_filter_in_stock') },
-    { id: 'overstocked', label: t('ops_contracts_filter_overstocked') },
 ] as const
 
 const order_by_options = [

--- a/frontend/app/src/components/blocks/OpsUnderstockedGrid.astro
+++ b/frontend/app/src/components/blocks/OpsUnderstockedGrid.astro
@@ -28,37 +28,34 @@ const {
     hide_location = false,
 } = Astro.props
 
-function fill_pct(current: number, expected: number): number {
-    if (expected <= 0)
-        return 100
-    return Math.min(100, Math.round((current / expected) * 100))
-}
-
 function short_fitting_name(name: string): string {
     return name.replace(/^\[FL33T\]\s*/i, '').replace(/^\[.*?\]\s*/, '')
 }
 
-function tone_for(readiness: string, pct: number): string {
-    if (readiness === 'empty' || pct <= 20)
+function tone_for(readiness: string, present: boolean): string {
+    if (readiness === 'empty' || !present)
         return 'bad'
-    if (pct < 100)
-        return 'warn'
     return 'good'
 }
 
 const ops_href = ops_redirect_path(translatePath, 'monitor')
 
 const tiles = rows.map(row => {
-    const pct = fill_pct(row.current_quantity, row.expected_quantity)
+    const present = row.current_quantity > 0
+    const pct = present ? 100 : 0
     return {
         ...row,
         pct,
-        tone: tone_for(row.readiness, pct),
+        present,
+        tone: tone_for(row.readiness, present),
         label: short_fitting_name(row.fitting_name),
         ops_href,
+        qty_label: present
+            ? String(row.current_quantity)
+            : 'Missing',
         title: [
             row.fitting_name,
-            `${row.current_quantity}/${row.expected_quantity}`,
+            present ? `${row.current_quantity} listed` : 'Missing',
         ].join(' · '),
     }
 })
@@ -97,11 +94,11 @@ import ItemPicture from '@components/blocks/ItemPicture.astro'
                             icon_quality={128}
                         />
                     </div>
-                    <span class="[ ops-stock-tile__pct ]">{tile.pct}%</span>
+                    <span class="[ ops-stock-tile__pct ]">{tile.present ? 'OK' : '0'}</span>
                 </div>
                 <Flexblock gap="var(--space-3xs)" class="[ ops-stock-tile__meta ]">
                     <strong class="[ ops-stock-tile__name ]">{tile.label}</strong>
-                    <span class="[ ops-stock-tile__qty ]">{tile.current_quantity}/{tile.expected_quantity}</span>
+                    <span class="[ ops-stock-tile__qty ]">{tile.qty_label}</span>
                     {!hide_location &&
                         <small class="[ ops-stock-tile__loc ]">{tile.short_name || tile.location_name}</small>
                     }

--- a/frontend/app/src/helpers/ops_contracts_filter.ts
+++ b/frontend/app/src/helpers/ops_contracts_filter.ts
@@ -17,7 +17,6 @@ export const OPS_CONTRACTS_NO_DOCTRINE = 'none'
 
 export const OPS_CONTRACTS_DEFAULT_CRITERIA: readonly OpsContractsCriteriaId[] = [
     'unstocked',
-    'low_stock',
 ]
 
 export const OPS_CONTRACTS_DEFAULT_ORDER_BY: OpsContractsOrderById = 'stock_fill'
@@ -69,8 +68,9 @@ function is_sort_direction(value: string): value is OpsContractsSortDirection {
 }
 
 /**
- * Map outstanding qty vs expectation to a Criteria chip id.
- * Returns null when there is no positive target quantity.
+ * Map outstanding contracts vs tracking to a Criteria chip id.
+ * Presence-only: tracked fittings are unstocked or in stock.
+ * Returns null when the fitting is not tracked.
  */
 export function ops_contracts_stock_status(
     current_quantity: number,
@@ -80,10 +80,6 @@ export function ops_contracts_stock_status(
         return null
     if (current_quantity <= 0)
         return 'unstocked'
-    if (current_quantity < desired_quantity)
-        return 'low_stock'
-    if (current_quantity > desired_quantity)
-        return 'overstocked'
     return 'in_stock'
 }
 

--- a/frontend/app/testing/helpers/ops_contracts_filter.test.ts
+++ b/frontend/app/testing/helpers/ops_contracts_filter.test.ts
@@ -61,11 +61,10 @@ const no_target = {
 }
 
 describe('ops_contracts_stock_status', () => {
-    it('maps qty vs target into criteria buckets', () => {
-        expect(ops_contracts_stock_status(0, 10)).toBe('unstocked')
-        expect(ops_contracts_stock_status(4, 10)).toBe('low_stock')
-        expect(ops_contracts_stock_status(10, 10)).toBe('in_stock')
-        expect(ops_contracts_stock_status(12, 10)).toBe('overstocked')
+    it('maps presence vs tracking into criteria buckets', () => {
+        expect(ops_contracts_stock_status(0, 1)).toBe('unstocked')
+        expect(ops_contracts_stock_status(1, 1)).toBe('in_stock')
+        expect(ops_contracts_stock_status(12, 1)).toBe('in_stock')
         expect(ops_contracts_stock_status(5, 0)).toBeNull()
     })
 })
@@ -77,14 +76,14 @@ describe('ops_contracts_row_visible', () => {
         expect(ops_contracts_row_visible(no_target, [], [], '')).toBe(true)
     })
 
-    it('defaults to unstocked + low stock', () => {
-        expect(OPS_CONTRACTS_DEFAULT_CRITERIA).toEqual(['unstocked', 'low_stock'])
+    it('defaults to unstocked only', () => {
+        expect(OPS_CONTRACTS_DEFAULT_CRITERIA).toEqual(['unstocked'])
         expect(
             ops_contracts_row_visible(unstocked, OPS_CONTRACTS_DEFAULT_CRITERIA, [], ''),
         ).toBe(true)
         expect(
             ops_contracts_row_visible(low_stock, OPS_CONTRACTS_DEFAULT_CRITERIA, [], ''),
-        ).toBe(true)
+        ).toBe(false)
         expect(
             ops_contracts_row_visible(in_stock, OPS_CONTRACTS_DEFAULT_CRITERIA, [], ''),
         ).toBe(false)


### PR DESCRIPTION
## Summary
- Treat fitting/contract/item expectations as a presence catalog (tracked = needed), not handmade stock/contract counts
- Coverage is any listed sell order or outstanding matched contract; understocked depth stays at less than 7 days of stock from inferred sales
- Admin configure UIs switch to track on/off; normalize existing expectation quantities to 1
- `make dev` clears leftover local app processes and recreates Redis before starting

## Test plan
- [ ] Run `pipenv run python manage.py migrate` (includes `0040_normalize_expectation_quantities_to_presence`)
- [ ] Admin → market location → doctrine / non-doctrine configure: track checkboxes save; no quantity inputs
- [ ] Market Ops contracts: unstocked vs in stock; fittings with any outstanding contract show ready
- [ ] Market Ops sell orders: out of stock / understocked (<7d) / in stock flags still work
- [ ] Market health page loads without 500 after migrate
- [ ] `pipenv run python manage.py test market --settings=app.settings_test`
- [ ] Frontend: `npm run test -- --run testing/helpers/ops_contracts_filter.test.ts`


Made with [Cursor](https://cursor.com)