### PR TITLE
Fix remaining Alpine/Sentry ClientRouter errors

### DIFF
--- a/frontend/app/src/components/blocks/NotificationPreferences.astro
+++ b/frontend/app/src/components/blocks/NotificationPreferences.astro
@@ -21,74 +21,13 @@ const channel_labels: Record<string, string> = {
 
 const api_base = `${import.meta.env.API_URL}/api/notifications`
 const save_error = t('notification_preferences_save_error')
+const features_json = JSON.stringify(features ?? [])
 ---
 
 <Flexblock
     gap="var(--space-l)"
     class="[ w-full ]"
-    x-data={`{
-        features: ${JSON.stringify(features)},
-        saving: false,
-        error: '',
-        async setChannel(typeKey, channel, enabled) {
-            this.saving = true
-            this.error = ''
-            try {
-                const response = await fetch('${api_base}/preferences', {
-                    method: 'PUT',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'Authorization': 'Bearer ${auth_token}',
-                    },
-                    body: JSON.stringify({
-                        preferences: [{
-                            notification_type: typeKey,
-                            channel: channel,
-                            enabled: enabled,
-                        }],
-                    }),
-                })
-                if (response.ok) {
-                    this.features = await response.json()
-                } else {
-                    this.error = '${save_error}'
-                }
-            } catch (e) {
-                this.error = '${save_error}'
-            } finally {
-                this.saving = false
-            }
-        },
-        async setTopic(typeKey, subscribed) {
-            this.saving = true
-            this.error = ''
-            try {
-                const url = '${api_base}/topics/' + encodeURIComponent(typeKey)
-                const response = await fetch(url, {
-                    method: subscribed ? 'POST' : 'DELETE',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'Authorization': 'Bearer ${auth_token}',
-                    },
-                })
-                if (response.ok || response.status === 204) {
-                    const prefRes = await fetch('${api_base}/preferences', {
-                        headers: {
-                            'Authorization': 'Bearer ${auth_token}',
-                        },
-                    })
-                    if (prefRes.ok) this.features = await prefRes.json()
-                    else this.error = '${save_error}'
-                } else {
-                    this.error = '${save_error}'
-                }
-            } catch (e) {
-                this.error = '${save_error}'
-            } finally {
-                this.saving = false
-            }
-        },
-    }`}
+    x-data={`notification_preferences(${features_json}, ${JSON.stringify(api_base)}, ${JSON.stringify(auth_token)}, ${JSON.stringify(save_error)})`}
 >
     <h2>{t('notification_preferences')}</h2>
     <p>{t('notification_preferences_description')}</p>

--- a/frontend/app/src/components/partials/AlpineCdn.astro
+++ b/frontend/app/src/components/partials/AlpineCdn.astro
@@ -1,0 +1,34 @@
+---
+/**
+ * Load Alpine CDN plugins + core exactly once per browser session.
+ *
+ * ClientRouter re-runs head scripts via replaceWith on soft nav. Re-executing
+ * alpinejs@cdn calls Alpine.start() again → alpine:init → persist tries to
+ * redefine $persist (MINMATAR-FRONTEND-EA) and other plugins double-bind.
+ */
+---
+
+<script is:inline>
+	(function () {
+		if (window.__minmatar_alpine_cdn_loaded)
+			return
+		window.__minmatar_alpine_cdn_loaded = true
+
+		const urls = [
+			'https://cdn.jsdelivr.net/npm/@alpinejs/mask@3.16.0/dist/cdn.min.js',
+			'https://cdn.jsdelivr.net/npm/@alpinejs/collapse@3.16.0/dist/cdn.min.js',
+			'https://cdn.jsdelivr.net/npm/@alpinejs/anchor@3.16.0/dist/cdn.min.js',
+			'https://cdn.jsdelivr.net/npm/@alpinejs/intersect@3.16.0/dist/cdn.min.js',
+			'https://cdn.jsdelivr.net/npm/@alpinejs/persist@3.16.0/dist/cdn.min.js',
+			'https://cdn.jsdelivr.net/npm/@alpinejs/focus@3.16.0/dist/cdn.min.js',
+			'https://cdn.jsdelivr.net/npm/alpinejs@3.16.0/dist/cdn.min.js',
+		]
+
+		urls.forEach(function (src) {
+			const script = document.createElement('script')
+			script.src = src
+			script.defer = true
+			document.head.appendChild(script)
+		})
+	})()
+</script>

--- a/frontend/app/src/components/partials/FooterScripts.astro
+++ b/frontend/app/src/components/partials/FooterScripts.astro
@@ -3,6 +3,7 @@ import { is_disabled_ccpwgl } from '@helpers/env';
 import LearningAlpine from '@components/partials/LearningAlpine.astro';
 import OpsContractsAlpine from '@components/partials/OpsContractsAlpine.astro';
 import SellOrderGapsAlpine from '@components/partials/SellOrderGapsAlpine.astro';
+import NotificationPreferencesAlpine from '@components/partials/NotificationPreferencesAlpine.astro';
 
 const DISABLED_CCPWGL = is_disabled_ccpwgl()
 ---
@@ -10,6 +11,7 @@ const DISABLED_CCPWGL = is_disabled_ccpwgl()
 <LearningAlpine />
 <OpsContractsAlpine />
 <SellOrderGapsAlpine />
+<NotificationPreferencesAlpine />
 
 <script is:inline src="/js/clipboard.js"></script>
 <script is:inline src="/js/numbers.js"></script>
@@ -95,8 +97,15 @@ const DISABLED_CCPWGL = is_disabled_ccpwgl()
             document.querySelectorAll('.loader').forEach(e => e.classList.remove('active'))
             const content = document.getElementById('content')
                 || document.querySelector('.viewport-layout-inner')
-            if (content)
+            if (content) {
                 htmx.process(content)
+                if (typeof Alpine !== 'undefined')
+                    Alpine.initTree(content)
+            }
+
+            const fittings_finder = document.querySelector('.fittings-finder')
+            if (fittings_finder && typeof Alpine !== 'undefined')
+                Alpine.initTree(fittings_finder)
 
             if (window.ccpwgl_context)
                 window.ccpwgl_context = null

--- a/frontend/app/src/components/partials/GuestsFooterScripts.astro
+++ b/frontend/app/src/components/partials/GuestsFooterScripts.astro
@@ -34,8 +34,11 @@
             tippy('[data-tippy-content]', window.tippy_options)
             const content = document.getElementById('content')
                 || document.querySelector('.viewport-layout-inner')
-            if (content)
+            if (content) {
                 htmx.process(content)
+                if (typeof Alpine !== 'undefined')
+                    Alpine.initTree(content)
+            }
         })
     }
 </script>

--- a/frontend/app/src/components/partials/GuestsHeadScripts.astro
+++ b/frontend/app/src/components/partials/GuestsHeadScripts.astro
@@ -1,5 +1,6 @@
 ---
 import TippyBootstrap from '@components/partials/TippyBootstrap.astro'
+import AlpineCdn from '@components/partials/AlpineCdn.astro'
 ---
 
 <script>
@@ -14,10 +15,6 @@ import TippyBootstrap from '@components/partials/TippyBootstrap.astro'
 <script defer src="https://cdn.jsdelivr.net/npm/tippy.js@6.3.7/dist/tippy.umd.min.js"></script>
 <TippyBootstrap />
 
-<script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/mask@3.16.0/dist/cdn.min.js"></script>
-<script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/anchor@3.16.0/dist/cdn.min.js"></script>
-<script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/intersect@3.16.0/dist/cdn.min.js"></script>
-<script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/focus@3.16.0/dist/cdn.min.js"></script>
-<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.16.0/dist/cdn.min.js"></script>
+<AlpineCdn />
 
 <script defer src="https://unpkg.com/htmx.org@1.9.10"></script>

--- a/frontend/app/src/components/partials/HeadScripts.astro
+++ b/frontend/app/src/components/partials/HeadScripts.astro
@@ -1,5 +1,6 @@
 ---
 import TippyBootstrap from '@components/partials/TippyBootstrap.astro'
+import AlpineCdn from '@components/partials/AlpineCdn.astro'
 ---
 
 <script is:inline src="/js/countdown.js"></script>
@@ -35,13 +36,7 @@ import TippyBootstrap from '@components/partials/TippyBootstrap.astro'
 <script defer src="https://cdn.jsdelivr.net/npm/tippy.js@6.3.7/dist/tippy.umd.min.js"></script>
 <TippyBootstrap />
 
-<script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/mask@3.16.0/dist/cdn.min.js"></script>
-<script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/collapse@3.16.0/dist/cdn.min.js"></script>
-<script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/anchor@3.16.0/dist/cdn.min.js"></script>
-<script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/intersect@3.16.0/dist/cdn.min.js"></script>
-<script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/persist@3.16.0/dist/cdn.min.js"></script>
-<script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/focus@3.16.0/dist/cdn.min.js"></script>
-<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.16.0/dist/cdn.min.js"></script>
+<AlpineCdn />
 
 <script defer src="https://unpkg.com/htmx.org@1.9.10"></script>
 

--- a/frontend/app/src/components/partials/NotificationPreferencesAlpine.astro
+++ b/frontend/app/src/components/partials/NotificationPreferencesAlpine.astro
@@ -1,0 +1,79 @@
+---
+/**
+ * Notification preferences Alpine factory — must live in FooterScripts.
+ *
+ * ClientRouter can init child x-show/x-for (error, features) before a large
+ * inline x-data object on the component is healthy. Define the factory once
+ * here (LearningAlpine pattern); the component only passes JSON args.
+ */
+---
+
+<script is:inline>
+	if (!window.notification_preferences) {
+		window.notification_preferences = function (features, api_base, auth_token, save_error) {
+			return {
+				features: Array.isArray(features) ? features : [],
+				saving: false,
+				error: '',
+				async setChannel(type_key, channel, enabled) {
+					this.saving = true
+					this.error = ''
+					try {
+						const response = await fetch(api_base + '/preferences', {
+							method: 'PUT',
+							headers: {
+								'Content-Type': 'application/json',
+								'Authorization': 'Bearer ' + auth_token,
+							},
+							body: JSON.stringify({
+								preferences: [{
+									notification_type: type_key,
+									channel: channel,
+									enabled: enabled,
+								}],
+							}),
+						})
+						if (response.ok) {
+							this.features = await response.json()
+						} else {
+							this.error = save_error
+						}
+					} catch (e) {
+						this.error = save_error
+					} finally {
+						this.saving = false
+					}
+				},
+				async setTopic(type_key, subscribed) {
+					this.saving = true
+					this.error = ''
+					try {
+						const url = api_base + '/topics/' + encodeURIComponent(type_key)
+						const response = await fetch(url, {
+							method: subscribed ? 'POST' : 'DELETE',
+							headers: {
+								'Content-Type': 'application/json',
+								'Authorization': 'Bearer ' + auth_token,
+							},
+						})
+						if (response.ok || response.status === 204) {
+							const pref_res = await fetch(api_base + '/preferences', {
+								headers: {
+									'Authorization': 'Bearer ' + auth_token,
+								},
+							})
+							if (pref_res.ok) this.features = await pref_res.json()
+							else this.error = save_error
+						} else {
+							this.error = save_error
+						}
+					} catch (e) {
+						this.error = save_error
+					} finally {
+						this.saving = false
+					}
+				},
+			}
+		}
+	}
+</script>

--- a/frontend/app/src/layouts/Post.astro
+++ b/frontend/app/src/layouts/Post.astro
@@ -35,6 +35,7 @@ import PersistentModal from '@components/blocks/PersistentModal.astro';
 import Modal from '@components/blocks/Modal.astro';
 import PersonaFinder from '@components/blocks/PersonasFinder.astro';
 import PageFinder from '@components/blocks/PageFinder.astro';
+import FittingFinder from '@components/blocks/FittingFinder.astro';
 import CorporationFinder from '@components/blocks/CorporationFinder.astro';
 import AllianceFinder from '@components/blocks/AllianceFinder.astro';
 import {
@@ -69,7 +70,6 @@ const {
 components.modal = components.modal ?? true
 
 const CHARACTER_FINDER_PARTIAL_URL = translatePath('/partials/character_finder_component')
-const FITTING_FINDER_PARTIAL_URL = translatePath('/partials/fitting_finder_component')
 
 import '@fontsource-variable/montserrat';
 import '@fontsource/qahiri';
@@ -217,12 +217,7 @@ import PilotBadge from '@components/blocks/PilotBadge.astro'
 			/>
 		}
 
-		<div
-			transition:persist
-			hx-get={FITTING_FINDER_PARTIAL_URL}
-			hx-trigger="load"
-			hx-indicator=".loader"
-		/>
+		<FittingFinder transition:persist />
 
 		<PageFinder transition:persist />
 

--- a/frontend/app/src/layouts/Viewport.astro
+++ b/frontend/app/src/layouts/Viewport.astro
@@ -1,6 +1,6 @@
 ---
 import { i18n } from '@helpers/i18n'
-const { lang, t, translatePath } = i18n(Astro.url)
+const { lang, t } = i18n(Astro.url)
 
 const middleware_error = Astro.cookies.has('middleware_error') ? (Astro.cookies.get('middleware_error')?.value as string) : false
 if (middleware_error) Astro.cookies.delete('middleware_error', { path: '/' })
@@ -42,6 +42,7 @@ import PersistentModal from '@components/blocks/PersistentModal.astro';
 import Modal from '@components/blocks/Modal.astro';
 import PersonaFinder from '@components/blocks/PersonasFinder.astro';
 import PageFinder from '@components/blocks/PageFinder.astro';
+import FittingFinder from '@components/blocks/FittingFinder.astro';
 import CorporationFinder from '@components/blocks/CorporationFinder.astro';
 import AllianceFinder from '@components/blocks/AllianceFinder.astro';
 import {
@@ -91,8 +92,6 @@ const resolved_canonical_url = canonical_url ?? new URL(Astro.url.pathname, site
 const use_large_image_card = meta_image !== default_meta_image
 
 components.modal = components.modal ?? true
- 
-const FITTING_FINDER_PARTIAL_URL = translatePath('/partials/fitting_finder_component')
 
 import '@fontsource-variable/montserrat';
 import '@fontsource/qahiri';
@@ -227,12 +226,7 @@ import RifterIcon from '@components/icons/RifterIcon.astro';
 			<CharacterFinder />
 		}
 
-		<div
-			transition:persist
-			hx-get={FITTING_FINDER_PARTIAL_URL}
-			hx-trigger="load"
-			hx-indicator=".loader"
-		/>
+		<FittingFinder transition:persist />
 
 		<PageFinder transition:persist />
 

--- a/frontend/app/src/pages/industry/orders/planner.astro
+++ b/frontend/app/src/pages/industry/orders/planner.astro
@@ -1292,26 +1292,26 @@ const bucket_labels = JSON.stringify({
                                                 <span
                                                     class="[ planner-tip ]"
                                                     x-ref="cost_total"
-                                                    x-text="formatIsk(cost_breakdown.grand_total_isk) + ' ISK'"
+                                                    x-text="formatIsk(cost_breakdown?.grand_total_isk) + ' ISK'"
                                                 ></span>
                                             </TextGroup>
                                             <TextGroup title={t('industry.orders.planner.per_unit_cost')}>
                                                 <span
                                                     class="[ planner-tip ]"
                                                     x-ref="cost_per_unit"
-                                                    x-text="formatIsk(Math.round(cost_breakdown.per_unit_isk)) + ' ISK'"
+                                                    x-text="formatIsk(Math.round(cost_breakdown?.per_unit_isk ?? 0)) + ' ISK'"
                                                 ></span>
                                             </TextGroup>
                                             <div
                                                 class="[ planner-cost-summary__cell ]"
-                                                x-show="cost_breakdown.freight_volume_m3 > 0"
+                                                x-show="cost_breakdown?.freight_volume_m3 > 0"
                                                 x-cloak
                                             >
                                                 <TextGroup title={t('industry.orders.planner.freight')}>
                                                     <span
                                                         class="[ planner-tip ]"
                                                         data-tippy-content={t('industry.orders.planner.freight_tip')}
-                                                        x-text="cost_breakdown.freight_route_id
+                                                        x-text="cost_breakdown?.freight_route_id
                                                             ? (formatIsk(cost_breakdown.freight_isk) + ' ISK · '
                                                                 + Number(cost_breakdown.freight_volume_m3).toLocaleString(undefined, { maximumFractionDigits: 2 })
                                                                 + ' m³')
@@ -1321,14 +1321,14 @@ const bucket_labels = JSON.stringify({
                                             </div>
                                             <div
                                                 class="[ planner-cost-summary__cell ]"
-                                                x-show="cost_breakdown.navy_bpc_isk > 0"
+                                                x-show="cost_breakdown?.navy_bpc_isk > 0"
                                                 x-cloak
                                             >
                                                 <TextGroup title={t('industry.orders.planner.navy_bpc_cost')}>
                                                     <span
                                                         class="[ planner-tip ]"
                                                         data-tippy-content={t('industry.orders.planner.navy_bpc_cost_tip')}
-                                                        x-text="formatIsk(cost_breakdown.navy_bpc_isk) + ' ISK'"
+                                                        x-text="formatIsk(cost_breakdown?.navy_bpc_isk) + ' ISK'"
                                                     ></span>
                                                 </TextGroup>
                                             </div>

--- a/frontend/app/src/pages/ships/fittings/normal/[fitting_id].astro
+++ b/frontend/app/src/pages/ships/fittings/normal/[fitting_id].astro
@@ -187,13 +187,15 @@ const fittings_list_url = seo_input.fittingsListUrl
 const ships_url = seo_input.shipsUrl
 ---
 
-<script define:vars={{ render_view }}>
-import { navigate } from "astro:transitions/client";
-
+<script is:inline define:vars={{ render_view }}>
     const render_enabled = JSON.parse(localStorage.getItem('_x_render_enabled') ?? 'true')
 
-    if (window.innerWidth > 1820 && render_enabled === true)
-        navigate(render_view)
+    if (window.innerWidth > 1820 && render_enabled === true) {
+        if (typeof window.navigate === 'function')
+            window.navigate(render_view)
+        else
+            window.location.assign(render_view)
+    }
 </script>
 
 <Viewport

--- a/frontend/app/src/pages/ships/fittings/render/[fitting_id].astro
+++ b/frontend/app/src/pages/ships/fittings/render/[fitting_id].astro
@@ -141,13 +141,15 @@ import ItemBadge from '@components/blocks/ItemBadge.astro'
 import FlexInlineSiblings from '@components/compositions/FlexInlineSiblings.astro'
 ---
 
-<script define:vars={{ normal_view }}>
-import { navigate } from "astro:transitions/client";
-
+<script is:inline define:vars={{ normal_view }}>
     const render_enabled = JSON.parse(localStorage.getItem('_x_render_enabled') ?? 'true')
 
-    if (window.innerWidth < 1820 || render_enabled === false)
-        navigate(normal_view)
+    if (window.innerWidth < 1820 || render_enabled === false) {
+        if (typeof window.navigate === 'function')
+            window.navigate(normal_view)
+        else
+            window.location.assign(normal_view)
+    }
 </script>
 
 <Viewport


### PR DESCRIPTION
## Summary
- Persist-mount `FittingFinder` like `PageFinder` so `fittings_finder_open` stays in scope after soft nav (`E7`)
- Move `NotificationPreferences` into a FooterScripts factory (LearningAlpine pattern) to stop `/account/` `error` / `features` / `Unexpected identifier 't'` (`EB`/`ED`/`EC`)
- Load Alpine CDN plugins+core once per session to stop `$persist` redefine on soft nav (`EA`)
- Replace fitting render/normal `import { navigate }` page scripts with `window.navigate` inline to fix View Transition `import outside module` (`CV`)
- Null-safe planner `cost_breakdown` bindings (`D8`/`DA`/`DB`)

Post-2AM verify showed tippy fixed but this Alpine cluster still firing (~83 events/8h).

## Test plan
- [ ] Soft-nav onto `/account/` with notification prefs — no console ReferenceErrors for `error`/`features`
- [ ] Soft-nav onto `/industry/products/` and open fittings finder — no `fittings_finder_open is not defined`
- [ ] Soft-nav between pages that use `$persist` — no `Cannot redefine property: $persist`
- [ ] Visit `/ships/fittings/render/:id` and soft-nav away/back — no import-outside-module
- [ ] After deploy: Sentry `EB`/`E7`/`ED`/`EC`/`EA`/`CV` quiet for ~1h
- [ ] `npm run check` (passed locally)


Made with [Cursor](https://cursor.com)