### PR TITLE
Fix Alpine ClientRouter Sentry residuals and Discord edit noise

### DIFF
--- a/backend/feed/helpers/amarr_fleet_pings.py
+++ b/backend/feed/helpers/amarr_fleet_pings.py
@@ -15,8 +15,18 @@ from feed.constants import (
 )
 from feed.models import FeedAmarrFleetAlert, FeedAmarrFleetPing, FeedEvent
 from ratelimit import RateLimitException
+from requests.exceptions import HTTPError
 
 logger = logging.getLogger(__name__)
+
+_DISCORD_EDIT_SOFT_FAIL_STATUSES = frozenset({400, 404, 500, 502, 503, 504})
+
+
+def _is_discord_edit_soft_fail(exc: BaseException) -> bool:
+    if not isinstance(exc, HTTPError) or exc.response is None:
+        return False
+    return exc.response.status_code in _DISCORD_EDIT_SOFT_FAIL_STATUSES
+
 
 AMARR_FLEET_ALERT_TITLE = "Amarr fleet spotted"
 # Matches mobile fleetYellow (#f1d9a0) used for Amarr feed accents.
@@ -490,6 +500,21 @@ def maybe_notify_amarr_fleet(
             "Amarr fleet ping rate-limited for cluster %s: %s",
             snapshot["cluster_key"],
             exc,
+        )
+        return False
+    except HTTPError as exc:
+        # Transient Discord 5xx or stale message 4xx on PATCH (CELERY-JM / KD).
+        if _is_discord_edit_soft_fail(exc):
+            logger.warning(
+                "Amarr fleet ping Discord HTTP %s for cluster %s: %s",
+                getattr(exc.response, "status_code", "?"),
+                snapshot["cluster_key"],
+                exc,
+            )
+            return False
+        logger.exception(
+            "Failed to send/update Amarr fleet ping for cluster %s",
+            snapshot["cluster_key"],
         )
         return False
     except Exception:

--- a/backend/feed/helpers/capital_pings.py
+++ b/backend/feed/helpers/capital_pings.py
@@ -839,8 +839,8 @@ def _upsert_capital_alert_for_notify(
     system_name: str,
     distance_ly: float,
     capitals: list[dict[str, Any]],
-    kill: dict[str, Any] | None,
-    composition: list[tuple[str, int]],
+    kill: dict[str, Any],
+    composition: dict[str, Any],
     discord_client: DiscordClient,
 ) -> FeedCapitalAlert | None:
     """Create or update a capital alert; soft-fail expected Discord HTTP errors."""

--- a/backend/feed/helpers/capital_pings.py
+++ b/backend/feed/helpers/capital_pings.py
@@ -35,6 +35,7 @@ from feed.helpers.ingest import parse_r2z2_payload
 from feed.helpers.killmail_classify import attacker_pilot_count, is_npc_kill
 from feed.helpers.system_distance import light_years_between_systems
 from feed.models import FeedCapitalAlert, FeedCapitalPing
+from requests.exceptions import HTTPError
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +44,13 @@ CAPITAL_ALERT_COLOR = 0x18ED09
 ZKILL_CHARACTER_URL = "https://zkillboard.com/character/{character_id}/"
 # Concord NPC corp — skip when attributing capital attackers.
 _CONCORD_CORPORATION_ID = 1000125
+_DISCORD_EDIT_SOFT_FAIL_STATUSES = frozenset({400, 404, 500, 502, 503, 504})
+
+
+def _is_discord_edit_soft_fail(exc: BaseException) -> bool:
+    if not isinstance(exc, HTTPError) or exc.response is None:
+        return False
+    return exc.response.status_code in _DISCORD_EDIT_SOFT_FAIL_STATUSES
 
 
 def _capital_ping_channel_ids() -> list[int]:
@@ -823,6 +831,57 @@ def _record_capital_ping(
     )
 
 
+def _upsert_capital_alert_for_notify(
+    *,
+    killmail_id: int,
+    existing: FeedCapitalAlert | None,
+    solar_system_id: int,
+    system_name: str,
+    distance_ly: float,
+    capitals: list[dict[str, Any]],
+    kill: dict[str, Any] | None,
+    composition: list[tuple[str, int]],
+    discord_client: DiscordClient,
+) -> FeedCapitalAlert | None:
+    """Create or update a capital alert; soft-fail expected Discord HTTP errors."""
+    try:
+        if existing is None:
+            return _create_capital_alert(
+                solar_system_id=solar_system_id,
+                system_name=system_name,
+                distance_ly=distance_ly,
+                capitals=capitals,
+                kill=kill,
+                composition=composition,
+                discord_client=discord_client,
+            )
+        return _update_capital_alert(
+            existing,
+            solar_system_id=solar_system_id,
+            system_name=system_name,
+            distance_ly=distance_ly,
+            capitals=capitals,
+            kill=kill,
+            composition=composition,
+            discord_client=discord_client,
+        )
+    except Exception as exc:
+        # Stale Discord message IDs (400/404) or transient 5xx on PATCH
+        # (CELERY-KD / JM). Do not logger.exception — Sentry noise.
+        if _is_discord_edit_soft_fail(exc):
+            logger.warning(
+                "Capital ping Discord HTTP %s for killmail %s: %s",
+                getattr(exc.response, "status_code", "?"),
+                killmail_id,
+                exc,
+            )
+            return None
+        logger.exception(
+            "Failed to send/update capital ping for killmail %s", killmail_id
+        )
+        return None
+
+
 def maybe_notify_capital_kill(
     payload: dict[str, Any],
     *,
@@ -872,34 +931,18 @@ def maybe_notify_capital_kill(
     )
     created = existing is None
 
-    try:
-        if existing is None:
-            alert = _create_capital_alert(
-                solar_system_id=int(solar_system_id),
-                system_name=system_name,
-                distance_ly=distance_ly,
-                capitals=capitals,
-                kill=kill,
-                composition=composition,
-                discord_client=client,
-            )
-            if alert is None:
-                return False
-        else:
-            alert = _update_capital_alert(
-                existing,
-                solar_system_id=int(solar_system_id),
-                system_name=system_name,
-                distance_ly=distance_ly,
-                capitals=capitals,
-                kill=kill,
-                composition=composition,
-                discord_client=client,
-            )
-    except Exception:
-        logger.exception(
-            "Failed to send/update capital ping for killmail %s", killmail_id
-        )
+    alert = _upsert_capital_alert_for_notify(
+        killmail_id=int(killmail_id),
+        existing=existing,
+        solar_system_id=int(solar_system_id),
+        system_name=system_name,
+        distance_ly=distance_ly,
+        capitals=capitals,
+        kill=kill,
+        composition=composition,
+        discord_client=client,
+    )
+    if alert is None:
         return False
 
     _record_capital_ping(

--- a/backend/feed/tests/test_amarr_fleet_pings.py
+++ b/backend/feed/tests/test_amarr_fleet_pings.py
@@ -16,6 +16,7 @@ from feed.models import FeedAmarrFleetAlert, FeedAmarrFleetPing, FeedEvent
 from feed.rollups.types import RollupResult
 from feed.rollups.writer import write_rollup_results
 from ratelimit import RateLimitException
+from requests.exceptions import HTTPError
 
 
 def make_amarr_fleet_ping_channel(
@@ -329,6 +330,24 @@ class AmarrFleetPingTestCase(TestCase):
         mock_client_cls.return_value = mock_client
         mock_client.create_message.side_effect = RateLimitException(
             "Discord API rate limited", 1.0
+        )
+        event = _amarr_event()
+
+        with patch("feed.helpers.amarr_fleet_pings.logger") as mock_logger:
+            self.assertFalse(maybe_notify_amarr_fleet(event))
+            mock_logger.warning.assert_called()
+            mock_logger.exception.assert_not_called()
+
+    @patch("feed.helpers.amarr_fleet_pings.DiscordClient")
+    def test_discord_http_5xx_logs_warning_not_exception(
+        self, mock_client_cls
+    ):
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        response = MagicMock()
+        response.status_code = 503
+        mock_client.create_message.side_effect = HTTPError(
+            "503 Server Error", response=response
         )
         event = _amarr_event()
 

--- a/backend/feed/tests/test_capital_pings.py
+++ b/backend/feed/tests/test_capital_pings.py
@@ -40,6 +40,7 @@ from feed.models import (
     FeedCharacterAffiliation,
 )
 from feed.tests.helpers import make_killmail_payload
+from requests.exceptions import HTTPError
 
 
 def make_test_solar_system(
@@ -603,6 +604,31 @@ class CapitalPingTestCase(TestCase):
             "[Pilot 90000005](https://zkillboard.com/character/90000005/)",
             description,
         )
+
+    @patch("feed.helpers.capital_pings.DiscordClient")
+    def test_discord_http_400_logs_warning_not_exception(
+        self, mock_client_cls
+    ):
+        mock_client = MagicMock()
+        response = MagicMock()
+        response.status_code = 400
+        mock_client.create_message.side_effect = HTTPError(
+            "400 Bad Request", response=response
+        )
+        mock_client_cls.return_value = mock_client
+
+        payload = make_killmail_payload(
+            136500060,
+            solar_system_id=AMAMAKE_SOLAR_SYSTEM_ID,
+            ship_type_id=17726,
+            attacker_ship_type_id=73790,
+            attacker_count=6,
+            faction_id=FACTION_AMARR,
+        )
+        with patch("feed.helpers.capital_pings.logger") as mock_logger:
+            self.assertFalse(maybe_notify_capital_kill(payload))
+            mock_logger.warning.assert_called()
+            mock_logger.exception.assert_not_called()
 
     @patch("feed.helpers.capital_pings.DiscordClient")
     def test_maybe_notify_skips_minmatar_republic_capitals(

--- a/frontend/app/src/components/blocks/FittingLink.astro
+++ b/frontend/app/src/components/blocks/FittingLink.astro
@@ -41,7 +41,16 @@ import Button from '@components/blocks/Button.astro';
     narrow={is_button ? narrow : undefined}
     x-bind:href={DISABLED_CCPWGL ? 'link' : undefined}
     x-data={DISABLED_CCPWGL ? `{
-        render_enabled: $persist(true),
+        // Read Alpine Persist's key without $persist — soft nav can init
+        // before the persist plugin registers (MINMATAR-FRONTEND-EN / EP).
+        render_enabled: (() => {
+            try {
+                const raw = localStorage.getItem('_x_render_enabled')
+                return raw === null ? true : JSON.parse(raw)
+            } catch (e) {
+                return true
+            }
+        })(),
         link: '${render_view}',
         init() {
             if (window.innerWidth > 1820 && this.render_enabled === true)

--- a/frontend/app/src/components/partials/AlpineCdn.astro
+++ b/frontend/app/src/components/partials/AlpineCdn.astro
@@ -5,6 +5,10 @@
  * ClientRouter re-runs head scripts via replaceWith on soft nav. Re-executing
  * alpinejs@cdn calls Alpine.start() again → alpine:init → persist tries to
  * redefine $persist (MINMATAR-FRONTEND-EA) and other plugins double-bind.
+ *
+ * Scripts must load in order (plugins before alpinejs). Dynamically inserted
+ * `defer` scripts can run out of order like async, which leaves $persist
+ * undefined (MINMATAR-FRONTEND-EP / FR). Chain on onload instead.
  */
 ---
 
@@ -24,11 +28,20 @@
 			'https://cdn.jsdelivr.net/npm/alpinejs@3.16.0/dist/cdn.min.js',
 		]
 
-		urls.forEach(function (src) {
+		function load_next(index) {
+			if (index >= urls.length)
+				return
 			const script = document.createElement('script')
-			script.src = src
-			script.defer = true
+			script.src = urls[index]
+			script.onload = function () {
+				load_next(index + 1)
+			}
+			script.onerror = function () {
+				load_next(index + 1)
+			}
 			document.head.appendChild(script)
-		})
+		}
+
+		load_next(0)
 	})()
 </script>

--- a/frontend/app/src/components/partials/FooterScripts.astro
+++ b/frontend/app/src/components/partials/FooterScripts.astro
@@ -97,15 +97,13 @@ const DISABLED_CCPWGL = is_disabled_ccpwgl()
             document.querySelectorAll('.loader').forEach(e => e.classList.remove('active'))
             const content = document.getElementById('content')
                 || document.querySelector('.viewport-layout-inner')
-            if (content) {
+            if (content)
                 htmx.process(content)
-                if (typeof Alpine !== 'undefined')
-                    Alpine.initTree(content)
-            }
-
-            const fittings_finder = document.querySelector('.fittings-finder')
-            if (fittings_finder && typeof Alpine !== 'undefined')
-                Alpine.initTree(fittings_finder)
+            // Init from body so page bindings see Viewport x-data
+            // (color_blind_mode, ui_scaling, show_modal, get_*_icon, …).
+            // initTree(content) alone orphans those expressions after soft nav.
+            if (typeof Alpine !== 'undefined')
+                Alpine.initTree(document.body)
 
             if (window.ccpwgl_context)
                 window.ccpwgl_context = null

--- a/frontend/app/src/components/partials/GuestsFooterScripts.astro
+++ b/frontend/app/src/components/partials/GuestsFooterScripts.astro
@@ -34,11 +34,10 @@
             tippy('[data-tippy-content]', window.tippy_options)
             const content = document.getElementById('content')
                 || document.querySelector('.viewport-layout-inner')
-            if (content) {
+            if (content)
                 htmx.process(content)
-                if (typeof Alpine !== 'undefined')
-                    Alpine.initTree(content)
-            }
+            if (typeof Alpine !== 'undefined')
+                Alpine.initTree(document.body)
         })
     }
 </script>


### PR DESCRIPTION
## Summary
- Load Alpine CDN plugins sequentially (onload chain) so `$persist` registers before Alpine core, clearing FRONTEND-EP/FR `$persist is not a function` races after ClientRouter soft nav.
- Re-init Alpine from `document.body` on `astro:after-swap` (drop orphan `initTree(content)` / fittings_finder) so body-scoped bindings (`color_blind_mode`, `ui_scaling`, `show_modal`, `get_*_icon`, …) stay defined.
- FittingLink reads Alpine Persist’s `_x_render_enabled` via `localStorage` instead of `$persist(...)`, so `x-bind:href="link"` always has `link` on scope (FRONTEND-EN).
- Soft-fail Discord 4xx/5xx on Amarr and capital ping create/edit paths with `logger.warning` (CELERY-JM / CELERY-KD) instead of `logger.exception`.

## Test plan
- [x] `feed` unit tests for Discord 503/400 soft-fail + rate-limit warning
- [x] Browser soft-nav sweep on worktree frontend (`/`, `/alliance/`, `/ships/fittings/`, `/guides/`): zero `$persist` / `color_blind_mode` / `link` console errors; body Alpine scope intact after swaps
- [ ] Confirm FRONTEND-EP/FR/EN/EQ and CELERY-KD go quiet in Sentry after deploy (~24h)


Made with [Cursor](https://cursor.com)