### PR TITLE
Fix account Discord buttons and notification labels

### DIFF
--- a/frontend/app/src/components/blocks/Button.astro
+++ b/frontend/app/src/components/blocks/Button.astro
@@ -35,10 +35,31 @@ const x_data = attributes['x-data'] ?? ''
 const x_data_elements = x_data ? x_data.slice(1, -1) : ''
 const x_on = attributes['x-on:click.prevent'] ?? undefined
 
+delete attributes['x-data']
+delete attributes['x-on:click.prevent']
+
 const button_background_color = `var(--${color})`;
 const button_color = (color !== 'transparent' ? 'var(--button-color)' : 'var(--highlight)');
 
 const Element = href ? 'a' : 'button';
+
+const leaving_website_title = t('leaving_website').replace(/'/g, "\\'")
+const external_disclaimer_partial = translatePath('/partials/external_link_disclaimer_dialog/')
+const nested_x_data = external ? `{
+        hide_external_link_disclaimer: $persist(false),
+        show_external_link_disclaimer() {
+            const root_data = Alpine.$data(document.body)
+            if (!root_data || !root_data.show_alert_dialog) return Promise.resolve(false)
+            return root_data.show_alert_dialog({
+                title: '${leaving_website_title}',
+                partial: '${external_disclaimer_partial}',
+                accept_href: '${href}',
+            })
+        },
+        ${x_data_elements}
+    }` : (x_data_elements ? `{
+        ${x_data_elements}
+    }` : undefined)
 ---
 
 <Element
@@ -52,20 +73,7 @@ const Element = href ? 'a' : 'button';
 
     target={external || new_tab ? '_blank' : undefined }
     rel={external ? 'nofollow noopener noreferrer' : (new_tab ? 'noopener noreferrer' : undefined) }
-    x-data={external ? `{
-        hide_external_link_disclaimer: $persist(false),
-        show_external_link_disclaimer() {
-            show_alert_dialog({
-                title: '${t('leaving_website')}',
-                partial: '${translatePath('/partials/external_link_disclaimer_dialog/')}',
-            }).then(accepted => {
-                if (accepted) window.open('${href}', '_blank')
-            })
-        },
-        ${x_data_elements}
-    }` : `{
-        ${x_data_elements}
-    }`}
+    x-data={nested_x_data}
     x-on:click.prevent={external ?
         `hide_external_link_disclaimer ? window.open('${href}', '_blank') : show_external_link_disclaimer()` :
         x_on

--- a/frontend/app/src/components/blocks/ExternalLink.astro
+++ b/frontend/app/src/components/blocks/ExternalLink.astro
@@ -20,11 +20,12 @@ const {
     x-data={`{
         hide_external_link_disclaimer: $persist(false),
         show_external_link_disclaimer() {
-            show_alert_dialog({
-                title: '${t('leaving_website')}',
+            const root_data = Alpine.$data(document.body)
+            if (!root_data || !root_data.show_alert_dialog) return Promise.resolve(false)
+            return root_data.show_alert_dialog({
+                title: '${t('leaving_website').replace(/'/g, "\\'")}',
                 partial: '${translatePath('/partials/external_link_disclaimer_dialog/')}',
-            }).then(accepted => {
-                if (accepted) window.open('${href}', '_blank')
+                accept_href: '${href}',
             })
         }
     }`}

--- a/frontend/app/src/components/blocks/NotificationPreferences.astro
+++ b/frontend/app/src/components/blocks/NotificationPreferences.astro
@@ -57,11 +57,7 @@ const features_json = JSON.stringify(features ?? [])
                                 :checked="ch.enabled"
                                 @change="setChannel(ntype.key, ch.channel, $event.target.checked)"
                             />
-                            <span x-text="({
-                                web: '${channel_labels.web}',
-                                discord: '${channel_labels.discord}',
-                                eve_mail: '${channel_labels.eve_mail}',
-                            })[ch.channel] || ch.channel"></span>
+                            <span x-text={`(${JSON.stringify(channel_labels)})[ch.channel] || ch.channel`}></span>
                         </label>
                     </template>
                 </Flexblock>

--- a/frontend/app/src/i18n/ui.ts
+++ b/frontend/app/src/i18n/ui.ts
@@ -2226,7 +2226,7 @@ export const ui = {
         'grant_permission': 'Grant notifications permission',
         'notification_preferences': 'Notification settings',
         'notification_preferences_description': 'Pick how we reach you. Keep it simple — turn on only what you actually read.',
-        'notification_channel_web': 'Phone / browser popup',
+        'notification_channel_web': 'Browser notification',
         'notification_channel_discord': 'Discord message',
         'notification_channel_eve_mail': 'Eve mail',
         'notification_topic_subscribe': 'Also include me even if I haven\'t built lately',

--- a/frontend/app/src/pages/account.astro
+++ b/frontend/app/src/pages/account.astro
@@ -17,10 +17,9 @@ if (user.is_superuser) roles.push(t('administrator'))
 if (user.is_staff) roles.push(t('director'))
 const roles_semantic_list:string = (roles.length > 0 ? semantic_list(lang, roles) : t('default'))
 
-import type { SummaryCharacter, Player } from '@dtypes/api.minmatar.org'
+import type { SummaryCharacter } from '@dtypes/api.minmatar.org'
 import type { NotificationSubscription, CharacterErrorUI } from '@dtypes/layout_components'
 import { get_characters_summary_sorted, get_character_error_ui } from '@helpers/fetching/characters'
-import { get_current_player } from '@helpers/api.minmatar.org/players'
 import { get_user_subscriptions } from '@helpers/api.minmatar.org/notifications'
 import { get_notification_preferences } from '@helpers/api.minmatar.org/notification_preferences'
 import type { NotificationFeaturePreferences } from '@helpers/api.minmatar.org/notification_preferences'
@@ -33,7 +32,6 @@ let notification_subscriptions:NotificationSubscription[] = []
 let notification_features:NotificationFeaturePreferences[] = []
 let readiness_character_id = 0
 let character_errors:CharacterErrorUI[] = []
-let current_player:Player | null = null
 
 import { get_user_permissions } from '@helpers/permissions'
 
@@ -42,7 +40,6 @@ try {
     const character_summary = await get_characters_summary_sorted(auth_token as string)
     pilots = character_summary.characters ?? []
     character_errors = get_character_error_ui(pilots)
-    current_player = await get_current_player(auth_token as string)
 
     if (user_permissions.includes('eveonline.add_evecharactertag'))
         readiness_character_id = pilots[0]?.character_id ?? 0
@@ -105,7 +102,6 @@ import SwitchSquare from '@components/blocks/SwitchSquare.astro';
 import ErrorRefetch from '@components/blocks/ErrorRefetch.astro';
 import CopyToken from '@components/blocks/CopyToken.astro';
 import CharacterErrors from '@components/blocks/CharacterErrors.astro'
-import PrimeTimezone from '@components/blocks/PrimeTimezone.astro'
 
 import LogoutIcon from '@components/icons/buttons/LogoutIcon.astro';
 import RifterIcon from '@components/icons/RifterIcon.astro';
@@ -152,13 +148,6 @@ const page_title = t('account.page_title');
                 size='sm'
             >
                 {t('referral_links')}
-            </Button>
-            <Button
-                href="https://wiki.minmatar.org/en/guides/account-issues"
-                size='sm'
-                external={true}
-            >
-                {t('troubleshooting')}
             </Button>
             <Button
                 href="https://discord.com/invite/3hZfahmkFx"
@@ -240,15 +229,6 @@ const page_title = t('account.page_title');
                     <CharacterErrors character_errors={character_errors} />
                 }
 
-                {readiness_character_id > 0 && current_player &&
-                    <ComponentBlock width='narrow'>
-                        <PrimeTimezone
-                            prime_time={current_player.prime_time}
-                            nickname={current_player.nickname}
-                        />
-                    </ComponentBlock>
-                }
-
                 <ComponentBlock 
                     width='narrow'
                     x-data={`{
@@ -283,19 +263,6 @@ const page_title = t('account.page_title');
                             readonly={readonly}
                         />
                     }
-                </ComponentBlock>
-
-                <ComponentBlock width='narrow'>
-                    <Flexblock gap="var(--space-3xs)">
-                        <a
-                            href="https://developers.eveonline.com/authorized-apps"
-                            target="_blank"
-                            rel="nofollow noopener noreferrer"
-                        >
-                            {t('auth_third_party_link_link')}
-                        </a>
-                        <small>{t('auth_third_party_link_description')}</small>
-                    </Flexblock>
                 </ComponentBlock>
             </Context>
 
@@ -423,7 +390,7 @@ const page_title = t('account.page_title');
                         <DisableBlock x_model="danger_zone_enable">
                             <FlexInline
                                 justification='space-between'
-                                x-data={`{                                                
+                                x-data={`{
                                     async delete_account(proceed) {
                                         if (!proceed) return
                                         
@@ -434,16 +401,27 @@ const page_title = t('account.page_title');
                                         )
 
                                         if (!response.ok) {
-                                            show_alert_dialog({
-                                                title: '${t('delete_account_dialog_title')}',
-                                                content: '${t('delete_account_error')}'
-                                            })
+                                            const root_data = Alpine.$data(document.body)
+                                            if (root_data && root_data.show_alert_dialog) {
+                                                root_data.show_alert_dialog({
+                                                    title: '${t('delete_account_dialog_title')}',
+                                                    content: '${t('delete_account_error')}'
+                                                })
+                                            }
                                             return
                                         }
 
                                         const json = await response.json()
                                         if (json.redirect)
                                             navigate(json.redirect)
+                                    },
+                                    show_unregister_account_dialog() {
+                                        const root_data = Alpine.$data(document.body)
+                                        if (!root_data || !root_data.show_confirm_dialog) return
+                                        root_data.show_confirm_dialog({
+                                            title: '${t('delete_account_dialog_title')}',
+                                            content: '${t('delete_account_dialog_text')}'
+                                        }).then((accepted) => this.delete_account(accepted))
                                     }
                                 }`}
                             >
@@ -453,20 +431,25 @@ const page_title = t('account.page_title');
                                 <Button
                                     type="button"
                                     size='sm'
-                                    x-data={`{
-                                        show_unregister_account_dialog() {
-                                            show_confirm_dialog({
-                                                title: '${t('delete_account_dialog_title')}',
-                                                content: '${t('delete_account_dialog_text')}'
-                                            }).then( (accepted) => delete_account(accepted) )
-                                        }
-                                    }`}
                                     x-on:click="show_unregister_account_dialog()"
                                 >
                                     {t('delete_account')}
                                 </Button>
                             </FlexInline>
                         </DisableBlock>
+
+                        <FlexInline justification='space-between'>
+                            <TextGroup title={t('auth_third_party_link_link')}>
+                                <small>{t('auth_third_party_link_description')}</small>
+                            </TextGroup>
+                            <Button
+                                href="https://developers.eveonline.com/authorized-apps"
+                                size='sm'
+                                external={true}
+                            >
+                                {t('auth_third_party_link_link')}
+                            </Button>
+                        </FlexInline>
                     </Flexblock>
                 </ComponentBlock>
             </Context>

--- a/frontend/app/testing/components/blocks/Button.test.ts
+++ b/frontend/app/testing/components/blocks/Button.test.ts
@@ -6,5 +6,41 @@ test("Button defaults", async () => {
   const container = await AstroContainer.create();
   const result = await container.renderToString(Button, {});
 
-  // expect(result).toMatchSnapshot();
+  expect(result).toContain("[ button ]");
+});
+
+test("external Button looks up show_alert_dialog on body and passes accept_href", async () => {
+  const container = await AstroContainer.create();
+  const result = await container.renderToString(Button, {
+    props: {
+      href: "https://discord.com/invite/3hZfahmkFx",
+      external: true,
+      size: "sm",
+    },
+    slots: {
+      default: "Fleet Discord",
+    },
+  });
+
+  expect(result).toContain("Alpine.$data(document.body)");
+  expect(result).toContain("accept_href: 'https://discord.com/invite/3hZfahmkFx'");
+  expect(result).toContain("root_data.show_alert_dialog");
+  expect(result).not.toMatch(/[^.]show_alert_dialog\(\{/);
+});
+
+test("internal Button with href does not isolate an empty Alpine scope", async () => {
+  const container = await AstroContainer.create();
+  const result = await container.renderToString(Button, {
+    props: {
+      href: "/account/referrals/",
+      size: "sm",
+    },
+    slots: {
+      default: "Referral links",
+    },
+  });
+
+  expect(result).toContain('href="/account/referrals/"');
+  expect(result).not.toContain("x-data=");
+  expect(result).not.toContain("x-on:click.prevent");
 });


### PR DESCRIPTION
## Summary
- Fix external `Button`/`ExternalLink` looking up `show_alert_dialog` in an isolated Alpine scope so Fleet Discord and other external buttons work, and pass `accept_href` into the leaving-website dialog.
- Render notification channel labels instead of interpolating as `${channel_labels.web}`, and rename "Phone / browser popup" to "Browser notification".
- Remove the Troubleshooting header and timezone / PrimeTimezone prompt; move Authorized Third-Party applications into the Danger Zone as a button.

## Test plan
- [ ] Open `/account` while logged in.
- [ ] Click Fleet Discord: the leaving-website dialog appears, and Continue opens Discord.
- [ ] Notification settings show "Browser notification", "Discord message", and "Eve mail" (not `${channel_labels.web}`).
- [ ] Troubleshooting is gone from the account subheader.
- [ ] The timezone / PrimeTimezone prompt is gone.
- [ ] Danger Zone includes an Authorized Third-Party applications button that opens the CCP authorized-apps page (with the external-link dialog).
- [ ] Enable Danger Zone and confirm Delete account still shows the confirm dialog.
- [ ] Referral links still navigate without an empty Alpine `x-data` scope.


Made with [Cursor](https://cursor.com)