### PR TITLE
Remove Learning from the Our community card

### DIFF
--- a/frontend/app/src/components/blocks/AllianceTiles.astro
+++ b/frontend/app/src/components/blocks/AllianceTiles.astro
@@ -42,9 +42,5 @@ import Tile from '@components/blocks/Tile.astro';
         <Button size='sm' href={translatePath('/alliance/tribes/')}>
             {t('tribes.page_title')}
         </Button>
-
-        <Button size='sm' href={translatePath('/learning/')}>
-            {t('learning.page_title')}
-        </Button>
     </Tile>
 </Grid>

--- a/frontend/app/src/i18n/ui.ts
+++ b/frontend/app/src/i18n/ui.ts
@@ -1443,7 +1443,7 @@ export const ui = {
         'corporations.cover_alt': 'Outspace starry sky',
         
         'dna.leading_text': 'Minmatar Fleet breaks from the traditional alliance mold-embracing a bit of chaos, acting first, and sorting out the questions later. Learn what makes us tick.',
-        'community.leading_text': 'Get to know our community: corporations, specialized interest groups, teams, tribes, and the guides that help new pilots find their footing.',
+        'community.leading_text': 'Get to know our community: corporations, specialized interest groups, teams, and tribes.',
 
         'corporations.list.page_title': 'Corporations',
         'corporations.list.leading_text': 'Strong corporations build strong alliances. Learn more about the corporations, CEOs, and membership that make up the Minmatar Fleet Alliance. Perhaps you can submit an application of your own!',


### PR DESCRIPTION
## Summary
- Remove the Learning button from the Our community tile on the alliance page.
- Update the tile copy so it no longer mentions guides; Learning remains in the neocom.

## Test plan
- [ ] Open `/alliance/` and confirm Our community shows Corporations and Tribes only.
- [ ] Confirm Learning is still reachable from the neocom.


Made with [Cursor](https://cursor.com)