### PR TITLE
Fix Thinkspeak YouTube/Twitch connect feature_denied JSON page

### DIFF
--- a/backend/creators/router.py
+++ b/backend/creators/router.py
@@ -31,7 +31,10 @@ from creators.service import (
     link_reddit_username,
     upsert_account_from_oauth,
 )
-from groups.helpers.feature_access import require_feature
+from groups.helpers.feature_access import (
+    FEATURE_DENIED_DETAIL,
+    require_feature,
+)
 from users.redirects import oauth_redirect
 
 logger = logging.getLogger(__name__)
@@ -50,6 +53,32 @@ SESSION_PROVIDER_KEY = "creators_oauth_provider"
 SESSION_USER_KEY = "creators_oauth_user_id"
 
 FEATURE_CONNECT = "creators.connect"
+
+
+def _connect_user(request, token: Optional[str]):
+    """Prefer the browser JWT query param over a Django session user."""
+    if token:
+        authenticated = AuthBearer().authenticate(request, token)
+        if authenticated is not None:
+            return authenticated
+    auth = getattr(request, "auth", None)
+    if isinstance(auth, User) and getattr(auth, "is_authenticated", False):
+        return auth
+    user = request.user
+    if (
+        user is None
+        or isinstance(user, AnonymousUser)
+        or not getattr(user, "is_authenticated", False)
+    ):
+        return None
+    return user
+
+
+def _denied_response(redirect_url: str, code: str):
+    if not redirect_url:
+        return 403, {"detail": FEATURE_DENIED_DETAIL, "feature": code}
+    sep = "&" if "?" in redirect_url else "?"
+    return oauth_redirect(f"{redirect_url}{sep}error=FEATURE_DENIED")
 
 
 def _iso(dt) -> str | None:
@@ -198,22 +227,13 @@ def connect_provider(
     redirect_url: str,
     token: Optional[str] = None,
 ):
-    user = request.user
-    if (
-        user is None
-        or isinstance(user, AnonymousUser)
-        or not getattr(user, "is_authenticated", False)
-    ):
-        if token:
-            user = AuthBearer().authenticate(request, token)
-        else:
-            user = None
+    user = _connect_user(request, token)
     if user is None:
         return 401, {"detail": "Unauthorized"}
 
     denied = require_feature(user, FEATURE_CONNECT)
     if denied:
-        return denied
+        return _denied_response(redirect_url, FEATURE_CONNECT)
     if provider == CreatorProvider.REDDIT:
         return 400, {"detail": "use_put_reddit_username"}
     if provider not in OAUTH_PROVIDERS:

--- a/backend/creators/tests.py
+++ b/backend/creators/tests.py
@@ -64,8 +64,8 @@ class CreatorAccountsTestCase(TestCase):
             {"redirect_url": "https://example.com/done"},
             HTTP_AUTHORIZATION=f"Bearer {self.token}",
         )
-        self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()["feature"], "creators.connect")
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("error=FEATURE_DENIED", response["Location"])
 
     def test_list_accounts_requires_thinkspeak(self):
         response = self.client.get(
@@ -368,6 +368,20 @@ class CreatorAccountsTestCase(TestCase):
 
     def test_connect_accepts_token_query_param(self):
         self._grant_thinkspeak()
+        response = self.client.get(
+            "/api/creators/twitch/connect",
+            {
+                "redirect_url": "https://example.com/done",
+                "token": self.token,
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("id.twitch.tv/oauth2/authorize", response["Location"])
+
+    def test_connect_prefers_token_over_session_user(self):
+        self._grant_thinkspeak()
+        other = User.objects.create_user("not-thinkspeak")
+        self.client.force_login(other)
         response = self.client.get(
             "/api/creators/twitch/connect",
             {

--- a/backend/groups/helpers/feature_access.py
+++ b/backend/groups/helpers/feature_access.py
@@ -2,38 +2,83 @@
 
 from __future__ import annotations
 
+import time
+from dataclasses import dataclass
+
 from django.contrib.auth.models import AnonymousUser
 
 from groups.features.registry import FEATURE_DEFINITIONS
 from groups.features.types import FeatureScope
 from groups.models import PilotFeature, UserAffiliation, UserCommunityStatus
-from tribes.models import TribeGroupMembership
+from tribes.models import TribeGroup, TribeGroupMembership
 
 FEATURE_DENIED_DETAIL = "feature_denied"
+_CACHE_TTL_SECONDS = 30
 
-_feature_cache: dict[str, PilotFeature | None] | None = None
+
+@dataclass(frozen=True)
+class _FeatureSnapshot:
+    code: str
+    scope: str
+    legacy_permission: str
+    staff_permission: str
+    deny_community_statuses: tuple[str, ...]
+    affiliation_ids: frozenset[int]
+    tribe_group_ids: frozenset[int]
+    auth_group_ids: frozenset[int]
+
+
+_feature_cache: dict[str, _FeatureSnapshot] | None = None
+_feature_cache_at: float | None = None
 
 
 def clear_feature_cache() -> None:
     """Clear the in-process feature cache (for tests)."""
-    global _feature_cache  # pylint: disable=global-statement
+    global _feature_cache, _feature_cache_at  # pylint: disable=global-statement
     _feature_cache = None
+    _feature_cache_at = None
 
 
-def _load_feature_cache() -> dict[str, PilotFeature | None]:
-    global _feature_cache  # pylint: disable=global-statement
-    if _feature_cache is not None:
+def _load_feature_cache() -> dict[str, _FeatureSnapshot]:
+    global _feature_cache, _feature_cache_at  # pylint: disable=global-statement
+    now = time.monotonic()
+    if (
+        _feature_cache is not None
+        and _feature_cache_at is not None
+        and now - _feature_cache_at < _CACHE_TTL_SECONDS
+    ):
         return _feature_cache
     features = PilotFeature.objects.filter(is_active=True).prefetch_related(
         "affiliations",
         "tribe_groups",
         "auth_groups",
     )
-    _feature_cache = {feature.code: feature for feature in features}
+    snapshots: dict[str, _FeatureSnapshot] = {}
+    for feature in features:
+        snapshots[feature.code] = _FeatureSnapshot(
+            code=feature.code,
+            scope=feature.scope,
+            legacy_permission=feature.legacy_permission or "",
+            staff_permission=feature.staff_permission or "",
+            deny_community_statuses=tuple(
+                feature.deny_community_statuses or []
+            ),
+            affiliation_ids=frozenset(
+                feature.affiliations.values_list("pk", flat=True)
+            ),
+            tribe_group_ids=frozenset(
+                feature.tribe_groups.values_list("pk", flat=True)
+            ),
+            auth_group_ids=frozenset(
+                feature.auth_groups.values_list("pk", flat=True)
+            ),
+        )
+    _feature_cache = snapshots
+    _feature_cache_at = now
     return _feature_cache
 
 
-def _get_feature(code: str) -> PilotFeature | None:
+def _get_feature(code: str) -> _FeatureSnapshot | None:
     return _load_feature_cache().get(code)
 
 
@@ -63,32 +108,29 @@ def _has_legacy_permission(user, permission: str) -> bool:
     return user.has_perm(permission)
 
 
-def _community_status_blocks_scope(feature: PilotFeature, user) -> bool:
+def _community_status_blocks_scope(feature: _FeatureSnapshot, user) -> bool:
     status = user_community_status(user)
     if not status:
         return False
-    denied = feature.deny_community_statuses or []
-    return status in denied
+    return status in feature.deny_community_statuses
 
 
-def _evaluate_affiliation(feature: PilotFeature, user) -> bool:
+def _evaluate_affiliation(feature: _FeatureSnapshot, user) -> bool:
     affiliation = user_affiliation(user)
     if affiliation is None:
         return False
-    wired_ids = {row.pk for row in feature.affiliations.all()}
-    return affiliation.pk in wired_ids
+    return affiliation.pk in feature.affiliation_ids
 
 
 def _evaluate_tribe_membership(
-    feature: PilotFeature, user, tribe_group=None
+    feature: _FeatureSnapshot, user, tribe_group=None
 ) -> bool:
-    wired_ids = {row.pk for row in feature.tribe_groups.all()}
-    if not wired_ids:
+    if not feature.tribe_group_ids:
         return False
     qs = TribeGroupMembership.objects.filter(
         user=user,
         status=TribeGroupMembership.STATUS_ACTIVE,
-        tribe_group_id__in=wired_ids,
+        tribe_group_id__in=feature.tribe_group_ids,
     )
     if tribe_group is not None:
         qs = qs.filter(tribe_group_id=tribe_group.pk)
@@ -96,40 +138,44 @@ def _evaluate_tribe_membership(
 
 
 def _evaluate_tribe_group_target(
-    feature: PilotFeature, user, tribe_group
+    feature: _FeatureSnapshot, user, tribe_group
 ) -> bool:
     if tribe_group is None:
         return False
     if not _evaluate_affiliation(feature, user):
         return False
-    wired_ids = {row.pk for row in feature.tribe_groups.all()}
-    if wired_ids:
-        return tribe_group.pk in wired_ids
+    if feature.tribe_group_ids:
+        return tribe_group.pk in feature.tribe_group_ids
     return True
 
 
 def _evaluate_tribe_chief(
-    feature: PilotFeature, user, tribe=None, tribe_group=None
+    feature: _FeatureSnapshot, user, tribe=None, tribe_group=None
 ) -> bool:
     staff_perm = feature.staff_permission or feature.legacy_permission
     if staff_perm and _has_legacy_permission(user, staff_perm):
         return True
     if tribe_group is not None:
-        wired_ids = {row.pk for row in feature.tribe_groups.all()}
-        if wired_ids and tribe_group.pk not in wired_ids:
+        if (
+            feature.tribe_group_ids
+            and tribe_group.pk not in feature.tribe_group_ids
+        ):
             return False
         if tribe_group.chief_id == user.pk:
             return True
         return tribe_group.tribe.chief_id == user.pk
     if tribe is not None:
         return tribe.chief_id == user.pk
-    wired_groups = list(feature.tribe_groups.all())
-    if wired_groups:
-        for group in wired_groups:
-            if group.chief_id == user.pk:
-                return True
-            if group.tribe.chief_id == user.pk:
-                return True
+    if not feature.tribe_group_ids:
+        return False
+    groups = TribeGroup.objects.filter(
+        pk__in=feature.tribe_group_ids
+    ).select_related("tribe")
+    for group in groups:
+        if group.chief_id == user.pk:
+            return True
+        if group.tribe.chief_id == user.pk:
+            return True
     return False
 
 
@@ -137,7 +183,7 @@ def _user_auth_group_ids(user) -> set[int]:
     return set(user.groups.values_list("pk", flat=True))
 
 
-def _evaluate_resource_match(feature: PilotFeature, user, fleet) -> bool:
+def _evaluate_resource_match(feature: _FeatureSnapshot, user, fleet) -> bool:
     if fleet is None:
         return _evaluate_affiliation(feature, user)
     if _evaluate_affiliation(feature, user):
@@ -157,20 +203,19 @@ def _evaluate_resource_match(feature: PilotFeature, user, fleet) -> bool:
     return False
 
 
-def _evaluate_auth_group(feature: PilotFeature, user) -> bool:
-    wired_ids = {row.pk for row in feature.auth_groups.all()}
-    if not wired_ids:
+def _evaluate_auth_group(feature: _FeatureSnapshot, user) -> bool:
+    if not feature.auth_group_ids:
         return False
-    return bool(_user_auth_group_ids(user) & wired_ids)
+    return bool(_user_auth_group_ids(user) & feature.auth_group_ids)
 
 
-def _evaluate_staff(feature: PilotFeature, user) -> bool:
+def _evaluate_staff(feature: _FeatureSnapshot, user) -> bool:
     staff_perm = feature.staff_permission or feature.legacy_permission
     return _has_legacy_permission(user, staff_perm)
 
 
 def _evaluate_scope(
-    feature: PilotFeature,
+    feature: _FeatureSnapshot,
     user,
     *,
     tribe=None,

--- a/backend/groups/signals.py
+++ b/backend/groups/signals.py
@@ -4,7 +4,9 @@ from django.db.models import signals
 from django.dispatch import receiver
 
 from groups.helpers import sync_user_community_groups
+from groups.helpers.feature_access import clear_feature_cache
 from groups.models import (
+    PilotFeature,
     UserAffiliation,
     UserCommunityStatus,
     UserCommunityStatusHistory,
@@ -92,3 +94,31 @@ def user_community_status_post_save(sender, instance, created, **kwargs):
         )
     logger.info("User community status saved, syncing user community groups")
     sync_user_community_groups(instance.user)
+
+
+@receiver(
+    signals.post_save,
+    sender=PilotFeature,
+    dispatch_uid="pilot_feature_post_save",
+)
+def pilot_feature_post_save(sender, instance, **kwargs):
+    clear_feature_cache()
+
+
+@receiver(
+    signals.m2m_changed,
+    sender=PilotFeature.affiliations.through,
+    dispatch_uid="pilot_feature_affiliations_changed",
+)
+@receiver(
+    signals.m2m_changed,
+    sender=PilotFeature.tribe_groups.through,
+    dispatch_uid="pilot_feature_tribe_groups_changed",
+)
+@receiver(
+    signals.m2m_changed,
+    sender=PilotFeature.auth_groups.through,
+    dispatch_uid="pilot_feature_auth_groups_changed",
+)
+def pilot_feature_wiring_changed(sender, instance, **kwargs):
+    clear_feature_cache()

--- a/backend/groups/tests/test_feature_access.py
+++ b/backend/groups/tests/test_feature_access.py
@@ -15,7 +15,7 @@ from groups.management.commands.sync_pilot_features import (
     Command as SyncCommand,
 )
 from groups.models import AffiliationType, PilotFeature, UserAffiliation
-from tribes.models import Tribe, TribeGroup
+from tribes.models import Tribe, TribeGroup, TribeGroupMembership
 
 
 class FeatureAccessTestCase(TestCase):
@@ -146,6 +146,24 @@ class FeatureAccessTestCase(TestCase):
     def test_inactive_user_denied(self):
         user = User.objects.create_user(username="inactive", is_active=False)
         self.assertFalse(can_use_feature(user, "fleets.create"))
+
+    def test_tribe_membership_wiring_change_updates_cache(self):
+        user = User.objects.create_user(username="thinkspeak_user")
+        tribe = Tribe.objects.create(name="Pulse", slug="pulse")
+        tribe_group = TribeGroup.objects.create(
+            tribe=tribe, name="Thinkspeak", code="pulse.thinkspeak"
+        )
+        TribeGroupMembership.objects.create(
+            user=user,
+            tribe_group=tribe_group,
+            status=TribeGroupMembership.STATUS_ACTIVE,
+        )
+        feature = PilotFeature.objects.get(code="creators.connect")
+        feature.tribe_groups.clear()
+        clear_feature_cache()
+        self.assertFalse(can_use_feature(user, "creators.connect"))
+        feature.tribe_groups.set([tribe_group])
+        self.assertTrue(can_use_feature(user, "creators.connect"))
 
     def test_unknown_feature_checks_registry_legacy(self):
         user = User.objects.create_user(username="unknown_perm_user")

--- a/frontend/app/src/i18n/ui.ts
+++ b/frontend/app/src/i18n/ui.ts
@@ -91,6 +91,9 @@ export const ui = {
         'content.connect.reddit_placeholder': 'https://www.reddit.com/user/YourName/',
         'content.connect.reddit_modal_success': 'Reddit linked. Refreshing…',
         'content.connect.reddit_auth_required': 'Log in to link Reddit.',
+        'content.connect.feature_denied':
+            'Connecting Twitch, YouTube, or Reddit is limited to Thinkspeak members. Ask in Discord if you should be in that group.',
+        'content.connect.success': 'Creator account connected.',
 
         'guides.page_title': 'Guides',
         'guides.back_to_guides': 'Back to guides',

--- a/frontend/app/src/pages/alliance/content.astro
+++ b/frontend/app/src/pages/alliance/content.astro
@@ -16,7 +16,7 @@ const can_manage_content = Boolean(
 )
 const post_editor = can_manage_content ? (user as User).user_id : false
 
-import type { PostListUI } from '@dtypes/layout_components'
+import type { Alert, PostListUI } from '@dtypes/layout_components'
 import { fetch_posts_grouped_by_tags, fetch_posts } from '@helpers/fetching/posts'
 
 let posts: Record<string, PostListUI[]> = {}
@@ -40,6 +40,21 @@ try {
 }
 
 const CONTENT_SECTIONS_PARTIAL_URL = `${translatePath('/partials/content_sections_component')}?state=published`
+
+let connect_alert: Alert | false = false
+const connect_error = Astro.url.searchParams.get('error')
+const connected_provider = Astro.url.searchParams.get('connected')
+if (connect_error === 'FEATURE_DENIED') {
+    connect_alert = {
+        title: t('content.page_title'),
+        content: t('content.connect.feature_denied'),
+    }
+} else if (connected_provider) {
+    connect_alert = {
+        title: t('content.page_title'),
+        content: t('content.connect.success'),
+    }
+}
 
 import Viewport from '@layouts/Viewport.astro'
 
@@ -79,6 +94,11 @@ const page_title = t('content.page_title')
         }}
         wide={true}
         no_main_padding={false}
+        x-data={`{
+            init() {
+                ${connect_alert ? `show_alert_dialog(${JSON.stringify(connect_alert)})` : ''}
+            }
+        }`}
     >
         <FlexInline slot="header" justification='space-between' class="[ w-full ]">
             <Flexblock gap="var(--space-3xs)">


### PR DESCRIPTION
## Summary
- Thinkspeak members (e.g. orionsasolo) hitting Connect YouTube/Twitch were sent to the API and shown `{"detail":"feature_denied","feature":"creators.connect"}` instead of OAuth.
- Connect now prefers the site JWT, feature wiring is snapshotted with a short TTL and cleared on admin M2M changes, and a denied/success connect redirects back to the content page with an alert.

## Test plan
- [ ] As a Thinkspeak member, use Manage my content → Connect YouTube and complete Google OAuth (should not land on raw JSON).
- [ ] As a logged-in user who is not Thinkspeak, open the YouTube connect URL and confirm you return to `/alliance/content/` with the Thinkspeak-only message.
- [ ] Confirm Twitch connect still starts Twitch OAuth for Thinkspeak members.


Made with [Cursor](https://cursor.com)