### PR TITLE
Remove full_screen prop from Learn More button components

### DIFF
--- a/frontend/app/src/components/blocks/ButtonOrdersLearnMore.astro
+++ b/frontend/app/src/components/blocks/ButtonOrdersLearnMore.astro
@@ -29,7 +29,6 @@ import Markdown from '@components/blocks/Markdown.astro'
     narrow={false}
     size={size}
     max_width='800px'
-    full_screen={true}
     non_centered={false}
     transparent={true}
 >

--- a/frontend/app/src/components/blocks/ButtonSRPLearnMore.astro
+++ b/frontend/app/src/components/blocks/ButtonSRPLearnMore.astro
@@ -30,7 +30,6 @@ import Markdown from '@components/blocks/Markdown.astro'
     narrow={false}
     size={size}
     max_width='800px'
-    full_screen={true}
     non_centered={false}
     transparent={true}
 >


### PR DESCRIPTION
Both ButtonOrdersLearnMore and ButtonSRPLearnMore had full_screen={true} set on their Modal components. This prop is unnecessary and can be inherited from the modal defaults, keeping the components lean.