### PR TITLE
Keep alliance health lists in sync after status actions

### DIFF
--- a/backend/alliance/endpoints/health/helpers.py
+++ b/backend/alliance/endpoints/health/helpers.py
@@ -31,7 +31,7 @@ def viewer_context(user) -> ViewerContext:
     alliance_wide = executor or staff_only
     return ViewerContext(
         alliance_wide=alliance_wide,
-        home_corp_id=None if alliance_wide else viewer_home_corp_id(user),
+        home_corp_id=viewer_home_corp_id(user),
         can_mutate=executor or bool(corps),
         can_leave_any=bool(user and user.is_superuser),
         officer_corp_ids=corps,

--- a/backend/alliance/endpoints/health/post_status.py
+++ b/backend/alliance/endpoints/health/post_status.py
@@ -8,6 +8,9 @@ from alliance.endpoints.health.schemas import (
     HealthStatusChangeResponse,
 )
 from alliance.helpers.access import can_mutate_status, can_put_on_leave
+from alliance.helpers.health_snapshot_patch import (
+    apply_status_change_to_latest_snapshot,
+)
 from app.errors import ErrorResponse
 from authentication import AuthBearer
 from groups.helpers import process_bulk_community_status_row
@@ -97,6 +100,7 @@ def post_health_status(request, payload: HealthStatusChangeRequest):
         return 400, ErrorResponse(detail=error)
     if not applied:
         return 400, ErrorResponse(detail="Status was not applied")
+    apply_status_change_to_latest_snapshot(target.id, payload.action, current)
     return HealthStatusChangeResponse(
         user_id=target.id,
         status=new_status,

--- a/backend/alliance/endpoints/health/schemas.py
+++ b/backend/alliance/endpoints/health/schemas.py
@@ -4,6 +4,7 @@ from typing import Any, Literal, Protocol, TypeVar, Union
 
 from pydantic import BaseModel
 
+from alliance.helpers.health import is_gone_for_months_pilot
 from alliance.helpers.hygiene import classify_onboarding_need
 from alliance.helpers.player_prime_time import prime_time_labels_for_users
 
@@ -422,7 +423,7 @@ def overview_from_payload(
         status=StatusCounts(**(payload.get("status") or {})),
         status_windows=status_windows_from_payload(payload),
         signals_30d=Signals30(**(payload.get("signals_30d") or {})),
-        quiet=QuietCounts(**(payload.get("quiet") or {})),
+        quiet=quiet_counts_from_payload(payload),
         monthly=[MonthlyPoint(**m) for m in payload.get("monthly") or []],
         tribes_monthly=tribes_monthly_from_payload(payload),
         unknown_characters=unknown_characters_from_payload(payload),
@@ -432,10 +433,32 @@ def overview_from_payload(
     )
 
 
+def quiet_counts_from_payload(payload: dict[str, Any]) -> QuietCounts:
+    quiet = QuietCounts(**(payload.get("quiet") or {}))
+    dark_rows = (payload.get("attention") or {}).get("dark")
+    if dark_rows is not None:
+        quiet.dark = sum(
+            1
+            for row in dark_rows
+            if is_gone_for_months_pilot(
+                row.get("days_quiet"), row.get("active_months")
+            )
+        )
+    return quiet
+
+
 def attention_from_payload(
     payload: dict[str, Any], bucket: AttentionBucket
 ) -> HealthAttentionResponse:
     pilots = payload.get("attention", {}).get(bucket, [])
+    if bucket == "dark":
+        pilots = [
+            row
+            for row in pilots
+            if is_gone_for_months_pilot(
+                row.get("days_quiet"), row.get("active_months")
+            )
+        ]
     return HealthAttentionResponse(
         computed_at=str(payload.get("computed_at") or ""),
         bucket=bucket,

--- a/backend/alliance/helpers/access.py
+++ b/backend/alliance/helpers/access.py
@@ -56,13 +56,18 @@ def can_view_health(user: User) -> bool:
 
 
 def viewer_home_corp_id(user: User) -> int | None:
-    """Default corp filter for CEOs/directors. Executors have none (alliance-wide)."""
-    if is_alliance_executor(user):
+    """Default corp filter: primary MFA corp, else a corp they officer."""
+    if not user or not user.is_authenticated:
         return None
+    mfa_ids = set(
+        mfa_corporation_qs().values_list("corporation_id", flat=True)
+    )
+    primary = user_primary_character(user)
+    if primary and primary.corporation_id in mfa_ids:
+        return primary.corporation_id
     ids = officer_corp_ids(user)
     if len(ids) == 1:
         return next(iter(ids))
-    primary = user_primary_character(user)
     if primary and primary.corporation_id in ids:
         return primary.corporation_id
     if ids:

--- a/backend/alliance/helpers/health.py
+++ b/backend/alliance/helpers/health.py
@@ -65,6 +65,22 @@ def _month_key(dt: datetime | date) -> str:
     return f"{dt.year:04d}-{dt.month:02d}"
 
 
+GONE_FOR_MONTHS_DAYS = 90
+
+
+def is_gone_for_months_pilot(
+    days_quiet: int | str | None, active_months: int | None
+) -> bool:
+    """True when a stored attention row belongs in Gone for months."""
+    if days_quiet == "never" or days_quiet is None:
+        return False
+    try:
+        quiet_days = int(days_quiet)
+    except (TypeError, ValueError):
+        return False
+    return quiet_days >= GONE_FOR_MONTHS_DAYS and int(active_months or 0) >= 1
+
+
 def classify_quiet_attention(
     eligible: set[int],
     active_30d: set[int],
@@ -75,17 +91,18 @@ def classify_quiet_attention(
 ) -> tuple[set[int], set[int], set[int]]:
     """Split quiet members into fading, dark, and seasonal.
 
-    Dark is "gone for months": quiet for 90d and last seen before that.
-    Never-active newcomers stay out — they have not been in the group
-    long enough to be gone for months.
+    Dark is "gone for months": quiet for 90d, and they had at least one
+    active month in the last year. Never-active people stay out.
     """
     quiet_30 = eligible - active_30d
     fading = {uid for uid in quiet_30 if uid in active_90d}
-    gone_before = now - timedelta(days=90)
+    gone_before = now - timedelta(days=GONE_FOR_MONTHS_DAYS)
     dark = {
         uid
         for uid in quiet_30 - active_90d
-        if (last := last_activity.get(uid)) is not None and last < gone_before
+        if (last := last_activity.get(uid)) is not None
+        and last < gone_before
+        and len(months_active.get(uid, ())) >= 1
     }
     seasonal = {
         uid for uid in quiet_30 if len(months_active.get(uid, ())) >= 3

--- a/backend/alliance/helpers/health_snapshot_patch.py
+++ b/backend/alliance/helpers/health_snapshot_patch.py
@@ -1,0 +1,136 @@
+"""Cheap in-place snapshot edits after community-status actions.
+
+The hourly health snapshot is too expensive to rebuild after promote / leave /
+restore. Drop the person from the cached lists and bump the headcounts so the
+dashboard stays consistent until the next full refresh.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from alliance.helpers.health import is_gone_for_months_pilot, latest_snapshot
+from groups.models import UserCommunityStatus
+
+_ATTENTION_BUCKETS = ("fading", "dark", "seasonal")
+_TRIAL_BUCKETS = (
+    "approve",
+    "too_early",
+    "fail",
+    "nudge",
+    "hold",
+    "current",
+    "add",
+    "remove",
+    "flagged",
+    "passing",
+    "failing",
+    "evaluating",
+)
+_LEAVE_LISTS = (
+    "recommended",
+    "current",
+    "restore",
+    "inactive",
+    "returning",
+    "flagged",
+)
+
+
+def _drop_user(rows: Any, user_id: int) -> Any:
+    if not isinstance(rows, list):
+        return rows
+    return [row for row in rows if row.get("user_id") != user_id]
+
+
+def _bump_status(
+    payload: dict[str, Any], from_status: str | None, to_status: str
+) -> None:
+    status = payload.setdefault("status", {})
+    if from_status:
+        status[from_status] = max(0, int(status.get(from_status) or 0) - 1)
+    status[to_status] = int(status.get(to_status) or 0) + 1
+
+
+def _recount_quiet(payload: dict[str, Any]) -> None:
+    attention = payload.get("attention") or {}
+    payload["quiet"] = {
+        "fading": len(attention.get("fading") or []),
+        "dark": sum(
+            1
+            for row in attention.get("dark") or []
+            if is_gone_for_months_pilot(
+                row.get("days_quiet"), row.get("active_months")
+            )
+        ),
+        "seasonal": len(attention.get("seasonal") or []),
+    }
+
+
+def _recount_hygiene_lists(payload: dict[str, Any]) -> None:
+    hygiene = payload.get("hygiene") or {}
+    trial = hygiene.get("trial") or {}
+    buckets = trial.get("buckets") or {}
+    if buckets:
+        counts = trial.setdefault("counts", {})
+        for key, rows in buckets.items():
+            if isinstance(rows, list):
+                counts[key] = len(rows)
+    leave = hygiene.get("leave") or {}
+    counts = leave.setdefault("counts", {})
+    for key in _LEAVE_LISTS:
+        rows = leave.get(key)
+        if isinstance(rows, list):
+            counts[key] = len(rows)
+    if isinstance(leave.get("recommended"), list):
+        counts["add"] = len(leave["recommended"])
+    if isinstance(leave.get("restore"), list):
+        counts["remove"] = len(leave["restore"])
+
+
+def apply_status_change_to_latest_snapshot(
+    user_id: int, action: str, from_status: str | None
+) -> None:
+    snap = latest_snapshot()
+    if snap is None or not snap.payload:
+        return
+    payload = copy.deepcopy(snap.payload)
+
+    attention = payload.setdefault("attention", {})
+    for bucket in _ATTENTION_BUCKETS:
+        attention[bucket] = _drop_user(attention.get(bucket), user_id)
+
+    hygiene = payload.setdefault("hygiene", {})
+    trial = hygiene.setdefault("trial", {})
+    buckets = trial.setdefault("buckets", {})
+    for key in _TRIAL_BUCKETS:
+        buckets[key] = _drop_user(buckets.get(key), user_id)
+
+    leave = hygiene.setdefault("leave", {})
+    for key in _LEAVE_LISTS:
+        leave[key] = _drop_user(leave.get(key), user_id)
+
+    if action == "promote":
+        _bump_status(
+            payload,
+            UserCommunityStatus.STATUS_TRIAL,
+            UserCommunityStatus.STATUS_ACTIVE,
+        )
+    elif action == "leave":
+        _bump_status(
+            payload,
+            from_status or UserCommunityStatus.STATUS_ACTIVE,
+            UserCommunityStatus.STATUS_ON_LEAVE,
+        )
+    elif action == "restore":
+        _bump_status(
+            payload,
+            UserCommunityStatus.STATUS_ON_LEAVE,
+            UserCommunityStatus.STATUS_ACTIVE,
+        )
+
+    _recount_quiet(payload)
+    _recount_hygiene_lists(payload)
+    snap.payload = payload
+    snap.save(update_fields=["payload"])

--- a/backend/alliance/tests/test_health.py
+++ b/backend/alliance/tests/test_health.py
@@ -823,6 +823,41 @@ class AllianceHealthEndpointTestCase(TestCase):
         self.assertEqual(response.json()["viewer"]["alliance_wide"], True)
         self.assertEqual(response.json()["viewer"]["can_leave_any"], False)
         self.assertEqual(response.json()["viewer"]["ceo_corp_ids"], [])
+        self.assertIsNone(response.json()["viewer"]["home_corp_id"])
+
+    def test_people_home_corp_defaults_to_primary(self):
+        people, token = self._people_user()
+        alliance = EveAlliance.objects.create(
+            alliance_id=99011978,
+            name="Minmatar Fleet Alliance",
+            ticker="MFA",
+        )
+        corp = EveCorporation.objects.create(
+            corporation_id=1000301,
+            name="People Home Corp",
+            ticker="PHOM",
+            alliance=alliance,
+        )
+        people_char = EveCharacter.objects.create(
+            character_id=910301,
+            character_name="People Pilot",
+            corporation_id=1000301,
+            user=people,
+        )
+        EvePlayer.objects.create(
+            nickname="people_exec",
+            user=people,
+            primary_character=people_char,
+        )
+        corp.save()
+        response = self.client.get(
+            "/api/alliance/health/overview",
+            **self._auth(token),
+        )
+        self.assertEqual(response.status_code, 200)
+        viewer = response.json()["viewer"]
+        self.assertEqual(viewer["alliance_wide"], True)
+        self.assertEqual(viewer["home_corp_id"], 1000301)
 
     def test_status_promote_as_people(self):
         token = self._people_user()[1]

--- a/backend/alliance/tests/test_health.py
+++ b/backend/alliance/tests/test_health.py
@@ -1,5 +1,6 @@
 """Tests for alliance health compute + endpoints."""
 
+from copy import deepcopy
 from datetime import timedelta
 
 import jwt
@@ -15,6 +16,7 @@ from groups.management.commands.sync_pilot_features import (
 from groups.models import UserCommunityStatus
 
 from alliance.endpoints.health.schemas import (
+    attention_from_payload,
     leave_from_payload,
     onboarding_from_payload,
     overview_from_payload,
@@ -302,8 +304,16 @@ class AllianceHealthEndpointTestCase(TestCase):
                             "corp": "Test Corp",
                             "status": "trial",
                             "days_quiet": 100,
+                            "active_months": 2,
+                        },
+                        {
+                            "user_id": 2,
+                            "pilot": "Never Flew",
+                            "corp": "Test Corp",
+                            "status": "trial",
+                            "days_quiet": "never",
                             "active_months": 0,
-                        }
+                        },
                     ],
                     "seasonal": [],
                 },
@@ -579,6 +589,34 @@ class AllianceHealthEndpointTestCase(TestCase):
         self.assertEqual(len(body["pilots"]), 1)
         self.assertEqual(body["pilots"][0]["pilot"], "Quiet Pilot")
 
+    def test_attention_dark_drops_never_active_snapshot_rows(self):
+        body = attention_from_payload(
+            {
+                "attention": {
+                    "dark": [
+                        {
+                            "user_id": 1,
+                            "pilot": "Gone",
+                            "corp": "Test",
+                            "status": "active",
+                            "days_quiet": 200,
+                            "active_months": 4,
+                        },
+                        {
+                            "user_id": 2,
+                            "pilot": "Never",
+                            "corp": "Test",
+                            "status": "trial",
+                            "days_quiet": "never",
+                            "active_months": 0,
+                        },
+                    ]
+                }
+            },
+            "dark",
+        )
+        self.assertEqual([p.pilot for p in body.pilots], ["Gone"])
+
     def test_corporations_and_cohorts(self):
         corps = self.client.get(
             "/api/alliance/health/corporations",
@@ -599,9 +637,11 @@ class AllianceHealthEndpointTestCase(TestCase):
             **self._auth(self.staff_token),
         )
         self.assertEqual(response.status_code, 200)
-        hygiene = response.json()["hygiene"]
+        body = response.json()
+        hygiene = body["hygiene"]
         self.assertEqual(hygiene["trial"]["approve"], 1)
         self.assertEqual(hygiene["leave"]["recommended"], 1)
+        self.assertEqual(body["quiet"]["dark"], 1)
 
     def test_trials_approve_bucket(self):
         response = self.client.get(
@@ -1078,6 +1118,58 @@ class AllianceHealthEndpointTestCase(TestCase):
             UserCommunityStatus.STATUS_ACTIVE,
         )
 
+    def test_restore_drops_user_from_snapshot_lists(self):
+        token = self._people_user()[1]
+        on_leave = User.objects.create_user(username="leave_listed")
+        UserCommunityStatus.objects.create(
+            user=on_leave, status=UserCommunityStatus.STATUS_ON_LEAVE
+        )
+        snap = AllianceHealthSnapshot.objects.order_by("-computed_at").first()
+        payload = deepcopy(snap.payload)
+        row = {
+            "user_id": on_leave.id,
+            "username": "leave_listed",
+            "pilot": "Leave Listed",
+            "corp": "Test Corp",
+            "fleets": 4,
+            "kills": 2,
+            "voice_hours": 3.0,
+            "story": "Restore",
+            "conf": "medium",
+            "reason": "On leave with participation",
+        }
+        leave = payload["hygiene"]["leave"]
+        leave["returning"] = [row]
+        leave["restore"] = [row]
+        leave["current"] = [row]
+        leave["inactive"] = []
+        payload["status"]["on_leave"] = 4
+        payload["status"]["active"] = 10
+        snap.payload = payload
+        snap.save(update_fields=["payload"])
+
+        response = self.client.post(
+            "/api/alliance/health/status",
+            data={"user_id": on_leave.id, "action": "restore"},
+            content_type="application/json",
+            **self._auth(token),
+        )
+        self.assertEqual(response.status_code, 200)
+        snap.refresh_from_db()
+        leave = snap.payload["hygiene"]["leave"]
+        self.assertEqual(leave["returning"], [])
+        self.assertEqual(leave["restore"], [])
+        self.assertEqual(leave["current"], [])
+        self.assertEqual(leave["counts"]["returning"], 0)
+        self.assertEqual(snap.payload["status"]["on_leave"], 3)
+        self.assertEqual(snap.payload["status"]["active"], 11)
+        listed = self.client.get(
+            "/api/alliance/health/leave?bucket=returning",
+            **self._auth(self.staff_token),
+        )
+        self.assertEqual(listed.status_code, 200)
+        self.assertEqual(listed.json()["pilots"], [])
+
     def test_restore_rejects_non_leave(self):
         token = self._people_user()[1]
         active = User.objects.create_user(username="still_active")
@@ -1204,6 +1296,20 @@ class ClassifyQuietAttentionTestCase(TestCase):
         )
         self.assertEqual(fading, set())
         self.assertEqual(dark, set())
+        self.assertEqual(seasonal, set())
+
+    def test_zero_active_months_is_not_dark(self):
+        now = timezone.now()
+        fading, dark, seasonal = classify_quiet_attention(
+            eligible={1},
+            active_30d=set(),
+            active_90d=set(),
+            last_activity={1: now - timedelta(days=120)},
+            months_active={},
+            now=now,
+        )
+        self.assertEqual(dark, set())
+        self.assertEqual(fading, set())
         self.assertEqual(seasonal, set())
 
     def test_prior_activity_is_dark(self):

--- a/frontend/app/src/components/blocks/AllianceHealthPagedTable.astro
+++ b/frontend/app/src/components/blocks/AllianceHealthPagedTable.astro
@@ -72,7 +72,7 @@ const initial_page = page_query?.page ?? 1
         match_count: rows.length,
         total_pages: 1,
         url_section: url_section ?? '',
-        url_defaults: { corp: 'all', page: 1 },
+        url_defaults: { corp: initial, page: 1 },
         row_selector: 'tr[data-search]',
         sort: false,
     })})`}

--- a/frontend/app/src/components/blocks/AllianceHealthPilotList.astro
+++ b/frontend/app/src/components/blocks/AllianceHealthPilotList.astro
@@ -117,7 +117,7 @@ const csv_headers = csv_headers_from_pilot(colored_rows[0], {
         csv_filename,
         url_section: url_section ?? '',
         url_defaults: {
-            corp: 'all',
+            corp: initial,
             by: default_by,
             dir: default_dir,
             page: 1,

--- a/frontend/app/src/components/blocks/AllianceHealthTrialsTable.astro
+++ b/frontend/app/src/components/blocks/AllianceHealthTrialsTable.astro
@@ -9,7 +9,10 @@ import type {
 } from '@helpers/alliance_health_pilot_list'
 import { health_confidence_label, health_pilot_card_id } from '@helpers/alliance_health_pilot_list'
 
-import { alliance_health_table_params } from '@helpers/api.minmatar.org/alliance_health'
+import {
+    alliance_health_table_params,
+    can_promote_alliance_health_trial,
+} from '@helpers/api.minmatar.org/alliance_health'
 import { query_string } from '@helpers/string'
 import AllianceHealthPilotList from '@components/blocks/AllianceHealthPilotList.astro'
 
@@ -44,22 +47,16 @@ const extra_query = alliance_health_table_params({
     officer_corp_ids,
 })
 
-const can_act = (pilot: AllianceHealthTrialPilot) => {
-    const ready =
-        pilot.decision === 'approve' ||
-        bucket === 'approve' ||
-        bucket === 'remove' ||
-        (pilot.decision == null &&
-            bucket === 'passing' &&
-            (pilot.alliance_days ?? 0) >= 60)
-    return (
-        can_promote &&
-        ready &&
-        (alliance_wide ||
-            (pilot.corporation_id != null &&
-                officer_corp_ids.includes(pilot.corporation_id)))
-    )
-}
+const can_act = (pilot: AllianceHealthTrialPilot) =>
+    can_promote_alliance_health_trial({
+        can_mutate: can_promote,
+        bucket,
+        alliance_wide,
+        officer_corp_ids,
+        corporation_id: pilot.corporation_id,
+        decision: pilot.decision,
+        alliance_days: pilot.alliance_days,
+    })
 
 const order_by_options: AllianceHealthOrderOption[] = [
     { id: 'fleets', label: t('alliance.health.col.fleets'), kind: 'number' },

--- a/frontend/app/src/helpers/api.minmatar.org/alliance_health.ts
+++ b/frontend/app/src/helpers/api.minmatar.org/alliance_health.ts
@@ -148,3 +148,58 @@ export function can_leave_alliance_health_pilot(
         corporation_id != null && ceo_corp_ids.includes(corporation_id)
     )
 }
+
+export function can_act_on_alliance_health_corp(
+    alliance_wide: boolean,
+    corporation_id: number | null | undefined,
+    officer_corp_ids: number[],
+): boolean {
+    if (alliance_wide) return true
+    return (
+        corporation_id != null && officer_corp_ids.includes(corporation_id)
+    )
+}
+
+export function can_promote_alliance_health_trial(opts: {
+    can_mutate: boolean
+    bucket: AllianceHealthTrialBucket | string
+    alliance_wide: boolean
+    officer_corp_ids: number[]
+    corporation_id?: number | null
+    decision?: string | null
+    alliance_days?: number | null
+}): boolean {
+    if (!opts.can_mutate) return false
+    if (
+        !can_act_on_alliance_health_corp(
+            opts.alliance_wide,
+            opts.corporation_id,
+            opts.officer_corp_ids,
+        )
+    ) {
+        return false
+    }
+    if (opts.decision === 'too_early') return false
+    if (opts.decision === 'approve') return true
+    const bucket = opts.bucket as AllianceHealthTrialBucket
+    switch (bucket) {
+        case 'approve':
+        case 'remove':
+            return true
+        case 'passing':
+            return opts.alliance_days == null || opts.alliance_days >= 60
+        case 'current':
+        case 'failing':
+        case 'evaluating':
+        case 'add':
+        case 'flagged':
+        case 'too_early':
+        case 'fail':
+        case 'nudge':
+            return false
+        default: {
+            const _never: never = bucket
+            return _never
+        }
+    }
+}

--- a/frontend/app/src/pages/alliance/health.astro
+++ b/frontend/app/src/pages/alliance/health.astro
@@ -113,7 +113,7 @@ const home_corp_name =
               (row) => row.corporation_id === viewer.home_corp_id,
           )?.name ?? 'all'
         : 'all'
-const initial_corp = alliance_wide ? 'all' : home_corp_name
+const initial_corp = home_corp_name
 
 import Viewport from '@layouts/Viewport.astro'
 import PageWide from '@components/page/PageWide.astro'
@@ -278,7 +278,8 @@ const last_updated_text = overview?.computed_at
                                 pilots={trials.pilots}
                                 can_promote={
                                     can_mutate &&
-                                    (trials.bucket === 'passing' ||
+                                    (trials.bucket === 'current' ||
+                                        trials.bucket === 'passing' ||
                                         trials.bucket === 'remove' ||
                                         trials.bucket === 'approve')
                                 }

--- a/frontend/app/src/pages/partials/alliance_health_trials_component.astro
+++ b/frontend/app/src/pages/partials/alliance_health_trials_component.astro
@@ -86,7 +86,12 @@ const PARTIAL_URL = translatePath('/partials/alliance_health_trials_component')
     ) : (
         <AllianceHealthTrialsTable
             pilots={pilots}
-            can_promote={can_mutate && (bucket === 'passing' || bucket === 'approve' || bucket === 'remove')}
+            can_promote={can_mutate && (
+                bucket === 'current' ||
+                bucket === 'passing' ||
+                bucket === 'approve' ||
+                bucket === 'remove'
+            )}
             officer_corp_ids={officer_corp_ids}
             alliance_wide={alliance_wide}
             initial_corp={initial_corp}

--- a/frontend/app/testing/helpers/alliance_health.test.ts
+++ b/frontend/app/testing/helpers/alliance_health.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { can_promote_alliance_health_trial } from '@helpers/api.minmatar.org/alliance_health'
+
+const base = {
+    can_mutate: true,
+    alliance_wide: true,
+    officer_corp_ids: [] as number[],
+    corporation_id: 1,
+}
+
+describe('can_promote_alliance_health_trial', () => {
+    it('shows promote on the default current tab for approve decisions', () => {
+        expect(
+            can_promote_alliance_health_trial({
+                ...base,
+                bucket: 'current',
+                decision: 'approve',
+                alliance_days: 70,
+            }),
+        ).toBe(true)
+    })
+
+    it('hides promote on current for people who are not approve-ready', () => {
+        expect(
+            can_promote_alliance_health_trial({
+                ...base,
+                bucket: 'current',
+                decision: 'nudge',
+                alliance_days: 80,
+            }),
+        ).toBe(false)
+    })
+
+    it('shows promote on passing when tenure is unknown', () => {
+        expect(
+            can_promote_alliance_health_trial({
+                ...base,
+                bucket: 'passing',
+                decision: null,
+                alliance_days: null,
+            }),
+        ).toBe(true)
+    })
+
+    it('hides promote for too-early pilots on passing', () => {
+        expect(
+            can_promote_alliance_health_trial({
+                ...base,
+                bucket: 'passing',
+                decision: 'too_early',
+                alliance_days: 20,
+            }),
+        ).toBe(false)
+    })
+
+    it('requires mutate permission', () => {
+        expect(
+            can_promote_alliance_health_trial({
+                ...base,
+                can_mutate: false,
+                bucket: 'passing',
+                decision: 'approve',
+                alliance_days: 70,
+            }),
+        ).toBe(false)
+    })
+})


### PR DESCRIPTION
## Summary
- After promote, put on leave, or take off leave, patch the cached health snapshot in place so the person disappears from those lists without a 12-month rebuild.
- Hide never-active pilots (`days quiet = never`, `active months = 0`) from Gone for months even on an old snapshot.
- Default every health list to the viewer's primary MFA corporation (All is still available).
- Show **Promote to member** on On trial for approve-ready people, and on Passing unless they are too-early.

## Test plan
- [ ] Take someone off leave on Returning; switch tabs and confirm they do not come back.
- [ ] Put someone on leave from Needs attention; they stay off that list after a tab change.
- [ ] Promote a trial; they stay off the list after a tab change.
- [ ] Gone for months no longer lists people with 0 active months / days quiet never.
- [ ] Open `/alliance/health` with no corp query params: lists start on your corp, not All.
- [ ] Approve-ready trials show Promote on On trial; too-early people on Passing do not.