### PR TITLE
Set player prime time from corporation applications

### DIFF
--- a/backend/applications/prime_time.py
+++ b/backend/applications/prime_time.py
@@ -1,0 +1,92 @@
+"""Parse application timezone answers onto EvePlayer.prime_time."""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from django.contrib.auth.models import User
+
+from eveonline.helpers.characters import user_player
+from eveonline.models import EvePlayer
+
+logger = logging.getLogger(__name__)
+
+PRIME_TIME_CODES = tuple(choice[0] for choice in EvePlayer.prime_choices)
+
+# Longest labels first so "USTZ - AUTZ" is not treated as "USTZ".
+TIMEZONE_LABEL_TO_CODE = (
+    ("USTZ - AUTZ", "US_AP"),
+    ("AUTZ - EUTZ", "AP_EU"),
+    ("EUTZ - USTZ", "EU_US"),
+    ("USTZ", "US"),
+    ("AUTZ", "AP"),
+    ("EUTZ", "EU"),
+)
+
+TIMEZONE_LINE_RE = re.compile(r"(?im)^-\s*Timezone:\s*(.+)$")
+CODE_TOKEN_RE = re.compile(
+    r"(?<![A-Za-z_])(" + "|".join(PRIME_TIME_CODES) + r")(?![A-Za-z_])"
+)
+
+
+def parse_application_prime_time(description: str) -> str | None:
+    """Return an EvePlayer.prime_time code from a stored application description."""
+    if not description:
+        return None
+
+    match = TIMEZONE_LINE_RE.search(description)
+    if not match:
+        return None
+
+    line = match.group(1).strip()
+    bucket = line
+    for separator in ("→", "->"):
+        if separator in line:
+            bucket = line.rsplit(separator, 1)[-1].strip()
+            break
+
+    for haystack in (bucket, line):
+        parsed = _prime_time_from_text(haystack)
+        if parsed:
+            return parsed
+
+    return None
+
+
+def apply_application_prime_time(user: User, description: str) -> None:
+    """Set EvePlayer.prime_time from an application description when parseable."""
+    prime_time = parse_application_prime_time(description)
+    if not prime_time:
+        return
+
+    player = user_player(user)
+    if not player:
+        logger.info(
+            "Skipping prime_time update for user %s; no EvePlayer",
+            user.id,
+        )
+        return
+
+    if player.prime_time == prime_time:
+        return
+
+    player.prime_time = prime_time
+    player.save(update_fields=["prime_time", "modified_at"])
+    logger.info(
+        "Set prime_time=%s for user %s from corporation application",
+        prime_time,
+        user.id,
+    )
+
+
+def _prime_time_from_text(text: str) -> str | None:
+    for label, code in TIMEZONE_LABEL_TO_CODE:
+        if label in text:
+            return code
+
+    token = CODE_TOKEN_RE.search(text)
+    if token:
+        return token.group(1)
+
+    return None

--- a/backend/applications/router.py
+++ b/backend/applications/router.py
@@ -16,6 +16,7 @@ from .l3arn import (
     validate_l3arn_application_description,
 )
 from .models import EveCorporationApplication
+from .prime_time import apply_application_prime_time
 from groups.helpers.feature_access import can_use_feature
 
 router = Router(tags=["Applications"])
@@ -114,6 +115,7 @@ def create_corporation_application(
         user_id=request.user.id,
         description=payload.description,
     )
+    apply_application_prime_time(request.user, payload.description)
 
     logger.info(
         "Application to %s submitted by %s",

--- a/backend/applications/tests.py
+++ b/backend/applications/tests.py
@@ -17,6 +17,7 @@ from applications.prime_time import (
     apply_application_prime_time,
     parse_application_prime_time,
 )
+from applications.signals import eve_corporation_application_post_save
 from discord.models import DiscordUser
 from eveonline.models import EveCharacter, EveCorporation, EvePlayer
 from eveonline.helpers.characters import set_primary_character, user_player
@@ -348,6 +349,11 @@ class EveCorporationApplicationSignalTest(TestCase):
     """Test case for the application signal handlers."""
 
     def test_application_post_save_signal(self):
+        signals.post_save.connect(
+            eve_corporation_application_post_save,
+            sender=EveCorporationApplication,
+            dispatch_uid="eve_corporation_application_post_save",
+        )
         signals.post_save.disconnect(
             sender=EveCharacter,
             dispatch_uid="populate_eve_character_public_data",
@@ -460,6 +466,14 @@ class ApplicationPrimeTimeTest(TestCase):
         )
         self.client = Client()
         super().setUp()
+
+    def tearDown(self):
+        signals.post_save.connect(
+            eve_corporation_application_post_save,
+            sender=EveCorporationApplication,
+            dispatch_uid="eve_corporation_application_post_save",
+        )
+        super().tearDown()
 
     def test_parse_application_prime_time_from_ustz_label(self):
         description = (

--- a/backend/applications/tests.py
+++ b/backend/applications/tests.py
@@ -13,9 +13,13 @@ from applications.l3arn import (
     validate_l3arn_application_description,
 )
 from applications.models import EveCorporationApplication
+from applications.prime_time import (
+    apply_application_prime_time,
+    parse_application_prime_time,
+)
 from discord.models import DiscordUser
-from eveonline.models import EveCharacter, EveCorporation
-from eveonline.helpers.characters import set_primary_character
+from eveonline.models import EveCharacter, EveCorporation, EvePlayer
+from eveonline.helpers.characters import set_primary_character, user_player
 
 BASE_URL = "/api/applications/"
 
@@ -436,3 +440,114 @@ class EveCorporationApplicationSignalTest(TestCase):
             self.assertIn("Source Corporation", message)
             self.assertIn("Target Corporation", message)
             self.assertIn("Recruiter", message)
+
+
+class ApplicationPrimeTimeTest(TestCase):
+    """Parse application timezone lines onto EvePlayer.prime_time."""
+
+    def setUp(self):
+        signals.post_save.disconnect(
+            sender=EveCharacter,
+            dispatch_uid="populate_eve_character_public_data",
+        )
+        signals.post_save.disconnect(
+            sender=EveCorporationApplication,
+            dispatch_uid="eve_corporation_application_post_save",
+        )
+        signals.post_save.disconnect(
+            sender=EveCorporation,
+            dispatch_uid="eve_corporation_post_save",
+        )
+        self.client = Client()
+        super().setUp()
+
+    def test_parse_application_prime_time_from_ustz_label(self):
+        description = (
+            "Questionnaire:\n"
+            "- Timezone: America/New_York (EDT) — US region, evenings → USTZ\n"
+            "- Roles interested in: Fleet damage"
+        )
+        self.assertEqual(parse_application_prime_time(description), "US")
+
+    def test_parse_application_prime_time_compound_labels(self):
+        cases = (
+            ("USTZ - AUTZ", "US_AP"),
+            ("AUTZ - EUTZ", "AP_EU"),
+            ("EUTZ - USTZ", "EU_US"),
+            ("AUTZ", "AP"),
+            ("EUTZ", "EU"),
+        )
+        for label, code in cases:
+            description = f"Questionnaire:\n- Timezone: Asia/Tokyo — AP region, evenings → {label}\n"
+            self.assertEqual(
+                parse_application_prime_time(description),
+                code,
+                msg=label,
+            )
+
+    def test_parse_application_prime_time_missing_line(self):
+        self.assertIsNone(
+            parse_application_prime_time("Please accept my application.")
+        )
+
+    def test_apply_application_prime_time_sets_player(self):
+        EvePlayer.objects.create(user=self.user, nickname="Player One")
+        apply_application_prime_time(
+            self.user,
+            "Questionnaire:\n- Timezone: Europe/London — EU region, evenings → EUTZ\n",
+        )
+        self.assertEqual(user_player(self.user).prime_time, "EU")
+
+    def test_apply_application_prime_time_skips_missing_player(self):
+        apply_application_prime_time(
+            self.user,
+            "Questionnaire:\n- Timezone: Europe/London — EU region, evenings → EUTZ\n",
+        )
+        self.assertIsNone(user_player(self.user))
+
+    def test_create_corporation_application_sets_prime_time(self):
+        EvePlayer.objects.create(user=self.user, nickname="Player One")
+        corporation = EveCorporation.objects.create(
+            corporation_id=123,
+            name="Test Corporation",
+        )
+        description = (
+            "I want to join.\n\n"
+            "Questionnaire:\n"
+            "- Timezone: America/New_York (EDT) — US region, evenings → USTZ\n"
+            "- Roles interested in: Fleet damage\n"
+        )
+
+        response = self.client.post(
+            f"{BASE_URL}corporations/{corporation.corporation_id}/applications",
+            data={"description": description},
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(user_player(self.user).prime_time, "US")
+
+    def test_create_corporation_application_without_timezone_leaves_prime_time(
+        self,
+    ):
+        player = EvePlayer.objects.create(
+            user=self.user,
+            nickname="Player One",
+            prime_time="AP",
+        )
+        corporation = EveCorporation.objects.create(
+            corporation_id=123,
+            name="Test Corporation",
+        )
+
+        response = self.client.post(
+            f"{BASE_URL}corporations/{corporation.corporation_id}/applications",
+            data={"description": "Please accept me."},
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        player.refresh_from_db()
+        self.assertEqual(player.prime_time, "AP")


### PR DESCRIPTION
## Summary
- On corporation application submit, parse the questionnaire `- Timezone:` line (USTZ / AUTZ / EUTZ buckets) and write `EvePlayer.prime_time`.
- Leave existing prime time unchanged when the description has no parseable timezone, and skip users who do not yet have an `EvePlayer`.

## Test plan
- [ ] Submit an L3ARN or corp application with a completed timezone step and confirm `EvePlayer.prime_time` matches the bucket (e.g. evenings US → `US`).
- [ ] Submit a freeform application with no timezone line and confirm an existing `prime_time` is not overwritten.
- [ ] `pipenv run python manage.py test applications.tests.ApplicationPrimeTimeTest --settings=app.settings_test`


Made with [Cursor](https://cursor.com)