### PR TITLE
Stop alliance health promote button from flashing off

### DIFF
--- a/frontend/app/src/components/blocks/AllianceHealthBucketTabs.astro
+++ b/frontend/app/src/components/blocks/AllianceHealthBucketTabs.astro
@@ -56,6 +56,7 @@ delete attributes.class
                     hx-get={tab.href}
                     hx-target={`#${table_id}`}
                     hx-swap="innerHTML"
+                    hx-trigger="click"
                     hx-indicator=".loader"
                 >
                     {tab.label} ({tab.count})

--- a/frontend/app/src/components/blocks/AllianceHealthPilotCard.astro
+++ b/frontend/app/src/components/blocks/AllianceHealthPilotCard.astro
@@ -141,6 +141,7 @@ if (row.timezone) sorts.tz = row.timezone.toLowerCase()
                     narrow={true}
                     color="transparent"
                     type="button"
+                    off_disable={true}
                     class="[ alliance-health-pilot-card__action ]"
                     data-confirm-title={row.action.confirm_title}
                     data-confirm-content={row.action.confirm_content}

--- a/frontend/app/src/components/blocks/AllianceHealthPilotList.astro
+++ b/frontend/app/src/components/blocks/AllianceHealthPilotList.astro
@@ -8,7 +8,7 @@ import type {
     AllianceHealthOrderOption,
     AllianceHealthPilotListRow,
 } from '@helpers/alliance_health_pilot_list'
-import { apply_list_metric_tones, csv_headers_from_pilot, default_health_order_dir } from '@helpers/alliance_health_pilot_list'
+import { apply_list_metric_tones, csv_headers_from_pilot, default_health_order_dir, paged_health_list_rows } from '@helpers/alliance_health_pilot_list'
 import {
     read_alliance_health_list_state,
     type AllianceHealthUrlSection,
@@ -92,6 +92,17 @@ const order_kinds: Record<string, AllianceHealthOrderKind> = Object.fromEntries(
     chips.map((chip) => [chip.id, chip.kind]),
 )
 const colored_rows = apply_list_metric_tones(rows)
+const visible_keys = new Set(
+    paged_health_list_rows(colored_rows, {
+        corp: list_corp,
+        search: initial_search,
+        order_by,
+        order_dir,
+        order_kinds,
+        page: initial_page,
+        page_size,
+    }).map((row) => row.row_id ?? `${row.name}:${row.corp}`),
+)
 const csv_headers = csv_headers_from_pilot(colored_rows[0], {
     pilot: t('alliance.health.col.pilot'),
     corp: t('alliance.health.col.corp'),
@@ -183,9 +194,16 @@ const csv_headers = csv_headers_from_pilot(colored_rows[0], {
             x-ref="body"
             x-init="$nextTick(() => refresh())"
         >
-            {colored_rows.map((row) => (
-                <AllianceHealthPilotCard row={row} />
-            ))}
+            {colored_rows.map((row) => {
+                const visible = visible_keys.has(row.row_id ?? `${row.name}:${row.corp}`)
+                return (
+                    <AllianceHealthPilotCard
+                        row={row}
+                        hidden={visible ? undefined : true}
+                        class:list={[!visible && 'is-hidden']}
+                    />
+                )
+            })}
         </div>
 
         {rows.length === 0 ? (

--- a/frontend/app/src/components/partials/AllianceHealthPilotAlpine.astro
+++ b/frontend/app/src/components/partials/AllianceHealthPilotAlpine.astro
@@ -77,7 +77,12 @@
             replace_health_url(section, patch, defaults, hash)
         },
         writeBucket(section, bucket, default_bucket) {
-            replace_health_url(section, { bucket }, { bucket: default_bucket }, true)
+            replace_health_url(
+                section,
+                { bucket, page: 1 },
+                { bucket: default_bucket, page: 1 },
+                true,
+            )
         },
     }
 </script>

--- a/frontend/app/src/helpers/alliance_health_pilot_list.ts
+++ b/frontend/app/src/helpers/alliance_health_pilot_list.ts
@@ -132,6 +132,49 @@ export function compare_health_sort_values(
     }
 }
 
+export function row_health_sort_value(
+    row: AllianceHealthPilotListRow,
+    order_by: string,
+): string {
+    if (order_by === 'name') return row.name.toLowerCase()
+    if (order_by === 'corp') return row.corp.toLowerCase()
+    if (order_by === 'tz') return (row.timezone ?? '').toLowerCase()
+    const metric = row.metrics.find((item) => item.id === order_by)
+    return sort_value_attr(metric?.sort)
+}
+
+export function paged_health_list_rows(
+    rows: AllianceHealthPilotListRow[],
+    opts: {
+        corp: string
+        search?: string
+        order_by: string
+        order_dir: AllianceHealthOrderDir
+        order_kinds: Record<string, AllianceHealthOrderKind>
+        page: number
+        page_size: number
+    },
+): AllianceHealthPilotListRow[] {
+    const q = (opts.search ?? '').trim().toLowerCase()
+    const matched = rows.filter((row) => {
+        if (opts.corp !== 'all' && row.corp !== opts.corp) return false
+        if (q && !row.search_text.includes(q)) return false
+        return true
+    })
+    const kind = opts.order_kinds[opts.order_by] ?? 'text'
+    const sorted = [...matched].sort((a, b) =>
+        compare_health_sort_values(
+            row_health_sort_value(a, opts.order_by),
+            row_health_sort_value(b, opts.order_by),
+            kind,
+            opts.order_dir,
+        ),
+    )
+    const page = Math.max(1, opts.page)
+    const start = (page - 1) * opts.page_size
+    return sorted.slice(start, start + opts.page_size)
+}
+
 export function sort_value_attr(value: number | string | null | undefined): string {
     if (value == null || value === '') return ''
     if (typeof value === 'number' && Number.isNaN(value)) return ''

--- a/frontend/app/testing/helpers/alliance_health_pilot_list.test.ts
+++ b/frontend/app/testing/helpers/alliance_health_pilot_list.test.ts
@@ -8,6 +8,7 @@ import {
     health_confidence_label,
     health_pilot_card_id,
     next_health_order_state,
+    paged_health_list_rows,
     tone_vs_median,
 } from '@helpers/alliance_health_pilot_list'
 
@@ -106,6 +107,36 @@ describe('alliance_health_pilot_list', () => {
     it('builds unique card ids per section', () => {
         expect(health_pilot_card_id('attention', 42)).toBe('alliance-health-attention-42')
         expect(health_pilot_card_id('trials', 42)).toBe('alliance-health-trials-42')
+    })
+
+    it('pages the same corp-filtered fleet order Alpine uses', () => {
+        const row = (
+            name: string,
+            corp: string,
+            fleets: number,
+        ) => ({
+            name,
+            corp,
+            search_text: name.toLowerCase(),
+            metrics: [{ id: 'fleets', label: 'Fleets', value: String(fleets), sort: fleets }],
+        })
+        const page = paged_health_list_rows(
+            [
+                row('low', 'home', 2),
+                row('high', 'home', 40),
+                row('other', 'away', 99),
+                row('mid', 'home', 10),
+            ],
+            {
+                corp: 'home',
+                order_by: 'fleets',
+                order_dir: 'desc',
+                order_kinds: { fleets: 'number' },
+                page: 1,
+                page_size: 2,
+            },
+        )
+        expect(page.map((item) => item.name)).toEqual(['high', 'mid'])
     })
 
     it('escapes CSV fields and builds a matrix', () => {

--- a/frontend/app/testing/helpers/alliance_health_url.test.ts
+++ b/frontend/app/testing/helpers/alliance_health_url.test.ts
@@ -76,4 +76,16 @@ describe('alliance_health_url', () => {
         })
         expect(patch_from_alliance_health_params(params, 'leave')).toEqual({})
     })
+
+    it('clears a stale page when switching buckets', () => {
+        const params = new URLSearchParams('trials_p=2')
+        write_alliance_health_list_params(
+            params,
+            'trials',
+            { bucket: 'passing', page: 1 },
+            { bucket: 'current', page: 1 },
+        )
+        expect(params.get('trials')).toBe('passing')
+        expect(params.has('trials_p')).toBe(false)
+    })
 })


### PR DESCRIPTION
## Summary
- Alliance health lists now server-render the same corp/sort/page Alpine would show, so Promote (and other row actions) no longer appear on cards that vanish a moment later.
- Switching trial/leave/attention tabs resets the list to page 1 so a leftover pager query does not hide the new bucket.
- Row action buttons skip the default disabled-until-Alpine flicker.

## Test plan
- [ ] Open `/alliance/health` as someone who can promote; confirm Promote stays visible on approve-ready pilots on the first page of the corp-filtered list.
- [ ] Confirm cards below page size 5 are only on later pages, not briefly on first paint.
- [ ] Switch On trial → Passing (and back) and confirm the list starts on page 1 with stable action buttons.
- [ ] From `frontend/app/`: `npm run test -- testing/helpers/alliance_health_pilot_list.test.ts testing/helpers/alliance_health_url.test.ts`


Made with [Cursor](https://cursor.com)