### PR TITLE
Match market contracts from items when titles are wrong

### DIFF
--- a/backend/market/helpers/contract_items.py
+++ b/backend/market/helpers/contract_items.py
@@ -13,10 +13,12 @@ from eveonline.models import (
 )
 
 from market.helpers.contract_match import (
+    fittings_for_contract_items,
     is_match_accepted,
+    match_contract_to_fitting,
     normalize_contract_items,
-    score_contract_against_fitting,
 )
+from market.helpers.contracts import record_unmatched_market_contract
 from market.models import EveMarketContract, EveMarketContractItem
 
 logger = logging.getLogger(__name__)
@@ -49,13 +51,18 @@ def apply_content_match(
     contract: EveMarketContract, contract_items: dict[int, int]
 ):
     """
-    Require name AND content: score only against the title-resolved fitting.
+    Assign the best hull/module match from contract items.
 
-    Keep fitting when module-weighted coverage >= MATCH_THRESHOLD; otherwise
-    clear fitting (keep match_score for admin). Freeze via items_fetched.
+    Title is only a tie-break (preferred_fitting). Wrong or truncated names
+    still match when contents cover a catalog fit at MATCH_THRESHOLD.
+    Freeze via items_fetched.
     """
     named = contract.fitting
-    if not named:
+    candidates = fittings_for_contract_items(
+        contract_items, preferred_fitting=named
+    )
+    if not candidates:
+        contract.fitting = None
         contract.match_score = 0.0
         contract.match_is_flagged = True
         contract.save(
@@ -63,17 +70,19 @@ def apply_content_match(
         )
         return None, 0.0, [], []
 
-    score, missing, extra = score_contract_against_fitting(
-        contract_items, named
+    best, score, missing, extra = match_contract_to_fitting(
+        contract_items, candidates, preferred_fitting=named
     )
+    accepted = is_match_accepted(score)
     contract.match_score = score
-    contract.match_is_flagged = bool(score < 1.0) if score else True
-    if is_match_accepted(score):
-        contract.fitting = named
+    if accepted:
+        contract.fitting = best
+        contract.match_is_flagged = bool(score < 1.0)
     else:
         contract.fitting = None
+        contract.match_is_flagged = True
     contract.save(update_fields=["fitting", "match_score", "match_is_flagged"])
-    return named if is_match_accepted(score) else None, score, missing, extra
+    return contract.fitting, score, missing, extra
 
 
 def fetch_public_contract_items(contract_id: int) -> tuple[bool, list[dict]]:
@@ -144,4 +153,7 @@ def fetch_and_match_contract_items(contract_id: int) -> bool:
 
     aggregated = store_contract_items(contract, raw_items)
     apply_content_match(contract, aggregated)
+    contract.refresh_from_db()
+    if contract.is_public and contract.fitting_id is None:
+        record_unmatched_market_contract(contract)
     return True

--- a/backend/market/helpers/contract_match.py
+++ b/backend/market/helpers/contract_match.py
@@ -149,6 +149,23 @@ def score_contract_against_fitting(
     return score, missing, extra
 
 
+def fittings_for_contract_items(
+    contract_items: dict[int, int],
+    preferred_fitting: EveFitting | None = None,
+) -> list[EveFitting]:
+    """Active fittings whose hull is in the contract, plus a title hint if any."""
+    hull_ids = [type_id for type_id in contract_items.keys() if type_id]
+    fittings_by_id: dict[int, EveFitting] = {}
+    if hull_ids:
+        for fitting in EveFitting.objects.filter(
+            deleted__isnull=True, ship_id__in=hull_ids
+        ):
+            fittings_by_id[fitting.id] = fitting
+    if preferred_fitting is not None:
+        fittings_by_id[preferred_fitting.id] = preferred_fitting
+    return list(fittings_by_id.values())
+
+
 def match_contract_to_fitting(
     contract_items: dict[int, int],
     candidates,

--- a/backend/market/helpers/contracts.py
+++ b/backend/market/helpers/contracts.py
@@ -276,9 +276,9 @@ def create_or_update_contract_from_db_contract(
 ) -> bool:
     """
     Create or update EveMarketContract from an EveCharacterContract or
-    EveCorporationContract. Only stores if type is item_exchange, location
-    matches, and title matches a known fitting (exact / alias / unique
-    tag-strip). Content matching then verifies modules against that fit.
+    EveCorporationContract. Stores item_exchange contracts at the location.
+    Title is a hint when it matches a known fitting (exact / alias / unique
+    tag-strip); items later assign or correct the fit.
 
     Once items have been fetched and a content match frozen, fitting/match_score
     are not overwritten from the contract title.
@@ -300,13 +300,6 @@ def create_or_update_contract_from_db_contract(
         )
         return False
     fitting = get_fitting_for_contract(db_contract.title or "")
-    if not fitting:
-        logger.info(
-            "Skipping contract %s: no fitting found for title %r",
-            db_contract.contract_id,
-            db_contract.title or "",
-        )
-        return False
     status = _map_contract_status(db_contract.status or "")
     issuer_corporation_id = None
     if getattr(db_contract, "for_corporation", False):
@@ -347,9 +340,6 @@ def create_or_update_contract(esi_contract, location: EveLocation):
         return
 
     fitting = get_fitting_for_contract(esi_contract["title"])
-    if not fitting:
-        record_unmatched_contract(esi_contract, location)
-        return
 
     contract, _ = EveMarketContract.objects.get_or_create(
         id=esi_contract["contract_id"],
@@ -382,9 +372,23 @@ def create_or_update_contract(esi_contract, location: EveLocation):
     contract.save()
 
 
+def record_unmatched_market_contract(contract: EveMarketContract):
+    """Record a public contract that items could not assign to a catalog fit."""
+    if not contract.is_public or not contract.location_id:
+        return
+    record_unmatched_contract(
+        {
+            "contract_id": contract.id,
+            "issuer_id": contract.issuer_external_id,
+            "title": contract.title,
+        },
+        contract.location,
+    )
+
+
 def record_unmatched_contract(esi_contract, location: EveLocation):
     logger.info(
-        "Ignoring public contract %d, unknown fitting: %s",
+        "Public contract %s did not match a catalog fit: %s",
         esi_contract["contract_id"],
         esi_contract["title"],
     )

--- a/backend/market/tasks.py
+++ b/backend/market/tasks.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.core.cache import cache
-from django.db.models import Q
+from django.db.models import F, Q
 from django.utils import timezone
 from celery import chord, group
 
@@ -510,7 +510,7 @@ def fetch_eve_market_contracts():
             items_fetched=False,
             status="outstanding",
         )
-        .order_by("issued_at", "id")
+        .order_by(F("fitting_id").asc(nulls_last=True), "issued_at", "id")
         .values_list("id", flat=True)[:CONTRACT_ITEMS_FETCH_CAP]
     )
     scheduled = 0

--- a/backend/market/tests/test_helpers.py
+++ b/backend/market/tests/test_helpers.py
@@ -90,6 +90,21 @@ class CreateOrUpdateContractFromDbContractStatusTestCase(TestCase):
         self.assertEqual("expired", contract.status)
         self.assertFalse(contract.is_public)
 
+    def test_unknown_title_is_still_stored(self):
+        db_contract = self._db_contract(
+            contract_id=230437069, status="outstanding"
+        )
+        db_contract.title = "[FL33T] Torpedo"
+        self.assertTrue(
+            create_or_update_contract_from_db_contract(
+                db_contract, self.location
+            )
+        )
+        contract = EveMarketContract.objects.get(id=230437069)
+        self.assertEqual("[FL33T] Torpedo", contract.title)
+        self.assertEqual("outstanding", contract.status)
+        self.assertIsNone(contract.fitting_id)
+
     def test_resync_keeps_deleted_contract_expired(self):
         EveMarketContract.objects.create(
             id=230437068,

--- a/backend/market/tests/test_market_vision.py
+++ b/backend/market/tests/test_market_vision.py
@@ -359,7 +359,7 @@ Hail S x2000
         self.assertTrue(missing)
 
     def test_highest_percent_wins_close_fits(self):
-        """Named Buffer only keeps when items match Buffer (not Active)."""
+        """Items pick Active vs Buffer; title is only a tie-break."""
         _make_typed_eve_type(37604, "Apostle", 6, "Ship")
         _make_typed_eve_type(2048, "Damage Control II", 7, "Module")
         _make_typed_eve_type(
@@ -402,14 +402,14 @@ Armor Energizing Charge x1000
             fitting=buffer,
             is_public=False,
         )
-        # Active hull modules under a Buffer title → name matches, fit does not
+        # Active hull modules under a Buffer title → items assign Active.
         apply_content_match(
             buffer_contract,
             {37604: 1, 2048: 1, 41459: 1, 41490: 1000},
         )
         buffer_contract.refresh_from_db()
-        self.assertIsNone(buffer_contract.fitting_id)
-        self.assertLess(buffer_contract.match_score, MATCH_THRESHOLD)
+        self.assertEqual(active.id, buffer_contract.fitting_id)
+        self.assertGreaterEqual(buffer_contract.match_score, MATCH_THRESHOLD)
 
         active_contract = EveMarketContract.objects.create(
             id=50008,
@@ -532,8 +532,8 @@ Armor Energizing Charge x1000
         self.assertIn(verified.id, stock_ids)
         self.assertNotIn(failed.id, stock_ids)
 
-    def test_nonsense_title_is_not_content_matched(self):
-        """Wrong/missing title never assigns from contents alone."""
+    def test_wrong_title_is_content_matched(self):
+        """Truncated or wrong title still assigns from hull/module contents."""
         location = _make_location(location_id=9104)
         _make_typed_eve_type(37604, "Apostle", 6, "Ship")
         _make_typed_eve_type(2048, "Damage Control II", 7, "Module")
@@ -566,8 +566,8 @@ Damage Control II
             {37604: 1, 2048: 1, 20245: 1},
         )
         contract.refresh_from_db()
-        self.assertIsNone(contract.fitting_id)
-        self.assertEqual(0.0, contract.match_score)
+        self.assertEqual(buffer.id, contract.fitting_id)
+        self.assertGreaterEqual(contract.match_score, MATCH_THRESHOLD)
 
         named = EveMarketContract.objects.create(
             id=50009,
@@ -583,6 +583,42 @@ Damage Control II
         named.refresh_from_db()
         self.assertEqual(buffer.id, named.fitting_id)
         self.assertGreaterEqual(named.match_score, MATCH_THRESHOLD)
+
+    def test_truncated_title_picks_matching_hull_variant(self):
+        """[FL33T] Torpedo contents match Torpedo Typhoon, not Cruise."""
+        location = _make_location(location_id=9106)
+        _make_typed_eve_type(644, "Typhoon", 6, "Ship")
+        _make_typed_eve_type(2410, "Heavy Missile Launcher II", 7, "Module")
+        _make_typed_eve_type(2420, "Torpedo Launcher II", 7, "Module")
+        cruise = EveFitting.objects.create(
+            name="[FL33T] Cruise Typhoon",
+            ship_id=644,
+            eft_format="""[Typhoon, [FL33T] Cruise Typhoon]
+Heavy Missile Launcher II
+""",
+        )
+        torpedo = EveFitting.objects.create(
+            name="[FL33T] Torpedo Typhoon",
+            ship_id=644,
+            eft_format="""[Typhoon, [FL33T] Torpedo Typhoon]
+Torpedo Launcher II
+""",
+        )
+        contract = EveMarketContract.objects.create(
+            id=50010,
+            title="[FL33T] Torpedo",
+            price=1,
+            issuer_external_id=1,
+            status="outstanding",
+            location=location,
+            fitting=None,
+            is_public=True,
+        )
+        apply_content_match(contract, {644: 1, 2420: 1})
+        contract.refresh_from_db()
+        self.assertEqual(torpedo.id, contract.fitting_id)
+        self.assertNotEqual(cruise.id, contract.fitting_id)
+        self.assertGreaterEqual(contract.match_score, MATCH_THRESHOLD)
 
 
 class SellOrderRowsTestCase(TestCase):

--- a/backend/market/tests/test_tasks.py
+++ b/backend/market/tests/test_tasks.py
@@ -169,23 +169,17 @@ class MarketTaskTestCase(TestCase):
 
         fetch_eve_market_contracts()
 
-        contracts = EveMarketContract.objects.all()
-
-        self.assertEqual(1, contracts.count())
-        self.assertEqual(10000001, contracts[0].id)
-        self.assertEqual(fitting.id, contracts[0].fitting.id)
+        contracts = {c.id: c for c in EveMarketContract.objects.all()}
+        self.assertEqual({10000001, 10000002}, set(contracts))
+        self.assertEqual(fitting.id, contracts[10000001].fitting_id)
+        self.assertIsNone(contracts[10000002].fitting_id)
         self.assertEqual(
-            location.location_id, contracts[0].location.location_id
+            location.location_id, contracts[10000001].location.location_id
         )
 
-        contract_errors = EveMarketContractError.objects.all()
-        self.assertEqual(1, contract_errors.count())
-        self.assertEqual("Random contract", contract_errors.first().title)
-        self.assertEqual(
-            "Seller", contract_errors.first().issuer.character_name
-        )
-        items_task_mock.apply_async.assert_called_once()
-        _, kwargs = items_task_mock.apply_async.call_args
+        self.assertEqual(0, EveMarketContractError.objects.count())
+        self.assertEqual(2, items_task_mock.apply_async.call_count)
+        _, kwargs = items_task_mock.apply_async.call_args_list[0]
         self.assertEqual("market", kwargs["queue"])
         self.assertEqual(0, kwargs["countdown"])
 


### PR DESCRIPTION
## Summary
- Title is no longer a hard gate: item-exchange contracts at market locations are stored even when the name does not match a catalog fit.
- After ESI items are fetched, hull/module coverage assigns the best catalog fit (80%+); the title is only a tie-break. Truncated names like `[FL33T] Torpedo` can count as Torpedo Typhoon stock.
- Alliance unmatched-title errors are recorded after a failed content match, not at list sync.

## Test plan
- [ ] `pipenv run python manage.py test market.tests.test_market_vision.ContractMatchTestCase market.tests.test_helpers market.tests.test_tasks.MarketTaskTestCase --settings=app.settings_test`
- [ ] After deploy/sync, confirm Holdings `[FL33T] Torpedo` contracts at Amamake show on Torpedo Typhoon stock instead of 0
- [ ] Confirm a random public item-exchange with no matching hull does not inflate doctrine stock
- [ ] Confirm Active vs Buffer FAX still split correctly when modules differ (wrong title should follow items)


Made with [Cursor](https://cursor.com)