### PR TITLE
Add per-corporation counts to alliance health buckets

### DIFF
--- a/backend/alliance/endpoints/health/schemas.py
+++ b/backend/alliance/endpoints/health/schemas.py
@@ -5,8 +5,13 @@ from typing import Any, Literal, Protocol, TypeVar, Union
 from pydantic import BaseModel
 
 from alliance.helpers.health import is_gone_for_months_pilot
-from alliance.helpers.hygiene import classify_onboarding_need
+from alliance.helpers.hygiene import (
+    classify_onboarding_need,
+    trial_under_min_tenure,
+)
 from alliance.helpers.player_prime_time import prime_time_labels_for_users
+
+CountModelT = TypeVar("CountModelT", bound=BaseModel)
 
 
 class StatusCounts(BaseModel):
@@ -155,6 +160,8 @@ class HealthAttentionResponse(BaseModel):
     computed_at: str
     bucket: Literal["fading", "dark", "seasonal"]
     pilots: list[AttentionPilot]
+    counts: QuietCounts = QuietCounts()
+    counts_by_corp: dict[str, QuietCounts] = {}
 
 
 class CorporationHealthRow(BaseModel):
@@ -242,6 +249,7 @@ class HealthTrialsResponse(BaseModel):
     computed_at: str
     bucket: TrialBucket
     counts: TrialHygieneCounts
+    counts_by_corp: dict[str, TrialHygieneCounts] = {}
     pilots: list[TrialHygienePilot]
 
 
@@ -249,6 +257,7 @@ class HealthOnboardingResponse(BaseModel):
     computed_at: str
     bucket: Literal["first_week", "more_fleets"]
     counts: OnboardingCounts
+    counts_by_corp: dict[str, OnboardingCounts] = {}
     pilots: list[TrialHygienePilot]
 
 
@@ -272,6 +281,7 @@ class HealthLeaveResponse(BaseModel):
     computed_at: str
     bucket: LeaveBucket
     counts: LeaveHygieneCounts
+    counts_by_corp: dict[str, LeaveHygieneCounts] = {}
     pilots: list[LeaveHygienePilot]
 
 
@@ -351,21 +361,29 @@ def hygiene_counts_from_payload(  # noqa: C901
         counts.trial.flagged = counts.trial.fail + counts.trial.nudge
     if counts.trial.passing == 0:
         if buckets.get("passing"):
-            counts.trial.passing = len(buckets["passing"])
-        else:
-            counts.trial.passing = (
-                counts.trial.approve + counts.trial.too_early
+            counts.trial.passing = sum(
+                1
+                for row in buckets["passing"]
+                if not trial_under_min_tenure(row.get("alliance_days"))
             )
+        else:
+            counts.trial.passing = counts.trial.approve
     if counts.trial.failing == 0:
         if buckets.get("failing"):
-            counts.trial.failing = len(buckets["failing"])
+            counts.trial.failing = sum(
+                1
+                for row in buckets["failing"]
+                if not trial_under_min_tenure(row.get("alliance_days"))
+            )
         else:
             counts.trial.failing = counts.trial.fail
     if counts.trial.evaluating == 0:
         if buckets.get("evaluating"):
             counts.trial.evaluating = len(buckets["evaluating"])
         else:
-            counts.trial.evaluating = counts.trial.nudge + counts.trial.hold
+            counts.trial.evaluating = (
+                counts.trial.nudge + counts.trial.hold + counts.trial.too_early
+            )
     if counts.trial.current == 0:
         if buckets.get("current"):
             counts.trial.current = len(buckets["current"])
@@ -433,6 +451,32 @@ def overview_from_payload(
     )
 
 
+def _row_corp_name(row: Any) -> str:
+    if isinstance(row, dict):
+        name = row.get("corp") or ""
+    else:
+        name = getattr(row, "corp", None) or ""
+    return str(name).strip() or "—"
+
+
+def counts_by_corp_from_bucket_rows(
+    bucket_rows: dict[str, list],
+    model_cls: type[CountModelT],
+) -> dict[str, CountModelT]:
+    fields = tuple(model_cls.model_fields)
+    empty = {field: 0 for field in fields}
+    tallies: dict[str, dict[str, int]] = {"all": dict(empty)}
+    for bucket, rows in bucket_rows.items():
+        if bucket not in model_cls.model_fields:
+            continue
+        tallies["all"][bucket] = len(rows)
+        for row in rows:
+            corp = _row_corp_name(row)
+            slot = tallies.setdefault(corp, dict(empty))
+            slot[bucket] = slot.get(bucket, 0) + 1
+    return {name: model_cls(**vals) for name, vals in tallies.items()}
+
+
 def quiet_counts_from_payload(payload: dict[str, Any]) -> QuietCounts:
     quiet = QuietCounts(**(payload.get("quiet") or {}))
     dark_rows = (payload.get("attention") or {}).get("dark")
@@ -447,10 +491,10 @@ def quiet_counts_from_payload(payload: dict[str, Any]) -> QuietCounts:
     return quiet
 
 
-def attention_from_payload(
+def _attention_bucket_rows(
     payload: dict[str, Any], bucket: AttentionBucket
-) -> HealthAttentionResponse:
-    pilots = payload.get("attention", {}).get(bucket, [])
+) -> list:
+    pilots = list(payload.get("attention", {}).get(bucket, []) or [])
     if bucket == "dark":
         pilots = [
             row
@@ -459,10 +503,25 @@ def attention_from_payload(
                 row.get("days_quiet"), row.get("active_months")
             )
         ]
+    return pilots
+
+
+def attention_from_payload(
+    payload: dict[str, Any], bucket: AttentionBucket
+) -> HealthAttentionResponse:
+    bucket_rows = {
+        name: _attention_bucket_rows(payload, name)
+        for name in ("fading", "dark", "seasonal")
+    }
+    by_corp = counts_by_corp_from_bucket_rows(bucket_rows, QuietCounts)
     return HealthAttentionResponse(
         computed_at=str(payload.get("computed_at") or ""),
         bucket=bucket,
-        pilots=_apply_timezones([AttentionPilot(**p) for p in pilots]),
+        counts=by_corp.get("all", QuietCounts()),
+        counts_by_corp=by_corp,
+        pilots=_apply_timezones(
+            [AttentionPilot(**p) for p in bucket_rows[bucket]]
+        ),
     )
 
 
@@ -485,43 +544,109 @@ def cohorts_from_payload(payload: dict[str, Any]) -> HealthCohortsResponse:
     )
 
 
+def _trial_row_user_id(row: Any) -> Any:
+    if isinstance(row, dict):
+        return row.get("user_id")
+    return getattr(row, "user_id", None)
+
+
+def _trial_row_alliance_days(row: Any) -> int | None:
+    if isinstance(row, dict):
+        return row.get("alliance_days")
+    return getattr(row, "alliance_days", None)
+
+
+def _trial_extend_unique(target: list, rows: list, seen: set) -> None:
+    for row in rows:
+        uid = _trial_row_user_id(row)
+        if uid in seen:
+            continue
+        seen.add(uid)
+        target.append(row)
+
+
+def _trial_bucket_rows(trial: dict[str, Any], bucket: TrialBucket) -> list:
+    buckets = trial.get("buckets") or {}
+    if bucket == "remove":
+        return buckets.get("remove") or buckets.get("approve") or []
+    if bucket == "flagged":
+        return buckets.get("flagged") or (
+            (buckets.get("fail") or []) + (buckets.get("nudge") or [])
+        )
+    if bucket == "add":
+        return buckets.get("add") or []
+    if bucket == "current":
+        pilots = buckets.get("current") or []
+        if not pilots:
+            for key in ("approve", "too_early", "fail", "nudge", "hold"):
+                pilots = pilots + (buckets.get(key) or [])
+        return pilots
+    if bucket in ("passing", "failing", "evaluating"):
+        return _trial_selector_rows(trial)[bucket]
+    return buckets.get(bucket) or []
+
+
+def _trial_selector_rows(trial: dict[str, Any]) -> dict[str, list]:
+    buckets = trial.get("buckets") or {}
+
+    def raw(name: str, fallbacks: tuple[str, ...]) -> list:
+        if buckets.get(name):
+            return list(buckets[name])
+        rows: list = []
+        for key in fallbacks:
+            rows.extend(buckets.get(key) or [])
+        return rows
+
+    passing_raw = raw("passing", ("approve", "too_early"))
+    failing_raw = raw("failing", ("fail",))
+    evaluating = raw("evaluating", ("nudge", "hold"))
+    passing: list = []
+    failing: list = []
+    early: list = []
+    for row in passing_raw:
+        if trial_under_min_tenure(_trial_row_alliance_days(row)):
+            early.append(row)
+        else:
+            passing.append(row)
+    for row in failing_raw:
+        if trial_under_min_tenure(_trial_row_alliance_days(row)):
+            early.append(row)
+        else:
+            failing.append(row)
+    seen = {_trial_row_user_id(row) for row in evaluating}
+    _trial_extend_unique(evaluating, buckets.get("too_early") or [], seen)
+    _trial_extend_unique(evaluating, early, seen)
+    return {
+        "passing": passing,
+        "failing": failing,
+        "evaluating": evaluating,
+    }
+
+
 def trials_from_payload(
     payload: dict[str, Any], bucket: TrialBucket
 ) -> HealthTrialsResponse:
     hygiene = payload.get("hygiene") or {}
     trial = hygiene.get("trial") or {}
     counts = TrialHygieneCounts(**(trial.get("counts") or {}))
-    buckets = trial.get("buckets") or {}
-    if bucket == "remove":
-        pilots = buckets.get("remove") or buckets.get("approve") or []
-    elif bucket == "flagged":
-        pilots = buckets.get("flagged") or (
-            (buckets.get("fail") or []) + (buckets.get("nudge") or [])
-        )
-    elif bucket == "passing":
-        pilots = buckets.get("passing") or (
-            (buckets.get("approve") or []) + (buckets.get("too_early") or [])
-        )
-    elif bucket == "failing":
-        pilots = buckets.get("failing") or buckets.get("fail") or []
-    elif bucket == "evaluating":
-        pilots = buckets.get("evaluating") or (
-            (buckets.get("nudge") or []) + (buckets.get("hold") or [])
-        )
-    elif bucket == "current":
-        pilots = buckets.get("current") or []
-        if not pilots:
-            for key in ("approve", "too_early", "fail", "nudge", "hold"):
-                pilots = pilots + (buckets.get(key) or [])
-    elif bucket == "add":
-        pilots = buckets.get("add") or []
-    else:
-        pilots = buckets.get(bucket) or []
+    tab_rows = {
+        name: _trial_bucket_rows(trial, name)
+        for name in ("current", "passing", "failing", "evaluating")
+    }
+    by_corp = counts_by_corp_from_bucket_rows(tab_rows, TrialHygieneCounts)
+    all_counts = by_corp.get("all", TrialHygieneCounts())
+    counts.current = all_counts.current
+    counts.passing = all_counts.passing
+    counts.failing = all_counts.failing
+    counts.evaluating = all_counts.evaluating
     return HealthTrialsResponse(
         computed_at=str(payload.get("computed_at") or ""),
         bucket=bucket,
         counts=counts,
-        pilots=_apply_timezones([TrialHygienePilot(**p) for p in pilots]),
+        counts_by_corp=by_corp,
+        pilots=_apply_timezones(
+            [TrialHygienePilot(**p) for p in _trial_bucket_rows(trial, bucket)]
+        ),
     )
 
 
@@ -541,13 +666,21 @@ def onboarding_from_payload(
             first_week.append(pilot)
         elif need == "more_fleets":
             more_fleets.append(pilot)
+    by_corp = counts_by_corp_from_bucket_rows(
+        {"first_week": first_week, "more_fleets": more_fleets},
+        OnboardingCounts,
+    )
     return HealthOnboardingResponse(
         computed_at=str(payload.get("computed_at") or ""),
         bucket=bucket,
-        counts=OnboardingCounts(
-            first_week=len(first_week),
-            more_fleets=len(more_fleets),
+        counts=by_corp.get(
+            "all",
+            OnboardingCounts(
+                first_week=len(first_week),
+                more_fleets=len(more_fleets),
+            ),
         ),
+        counts_by_corp=by_corp,
         pilots=first_week if bucket == "first_week" else more_fleets,
     )
 
@@ -573,24 +706,17 @@ def _fill_leave_selector_counts(
     return counts
 
 
-def leave_from_payload(
-    payload: dict[str, Any], bucket: LeaveBucket = "current"
-) -> HealthLeaveResponse:
-    hygiene = payload.get("hygiene") or {}
-    leave = hygiene.get("leave") or {}
-    counts = _fill_leave_selector_counts(
-        LeaveHygieneCounts(**(leave.get("counts") or {})), leave
-    )
+def _leave_bucket_rows(leave: dict[str, Any], bucket: LeaveBucket) -> list:
     if bucket == "add":
-        pilots = leave.get("recommended") or leave.get("add") or []
-    elif bucket in ("remove", "returning"):
-        pilots = (
+        return leave.get("recommended") or leave.get("add") or []
+    if bucket in ("remove", "returning"):
+        return (
             leave.get("returning")
             or leave.get("restore")
             or leave.get("remove")
             or []
         )
-    elif bucket == "inactive":
+    if bucket == "inactive":
         pilots = leave.get("inactive") or []
         if not pilots:
             current = leave.get("current") or []
@@ -606,13 +732,35 @@ def leave_from_payload(
                 for row in current
                 if row.get("user_id") not in returning_ids
             ]
-    else:
-        pilots = leave.get(bucket) or []
+        return pilots
+    return leave.get(bucket) or []
+
+
+def leave_from_payload(
+    payload: dict[str, Any], bucket: LeaveBucket = "current"
+) -> HealthLeaveResponse:
+    hygiene = payload.get("hygiene") or {}
+    leave = hygiene.get("leave") or {}
+    counts = _fill_leave_selector_counts(
+        LeaveHygieneCounts(**(leave.get("counts") or {})), leave
+    )
+    tab_rows = {
+        name: _leave_bucket_rows(leave, name)
+        for name in ("current", "inactive", "returning")
+    }
+    by_corp = counts_by_corp_from_bucket_rows(tab_rows, LeaveHygieneCounts)
+    all_counts = by_corp.get("all", LeaveHygieneCounts())
+    counts.current = all_counts.current
+    counts.inactive = all_counts.inactive
+    counts.returning = all_counts.returning
     return HealthLeaveResponse(
         computed_at=str(payload.get("computed_at") or ""),
         bucket=bucket,
         counts=counts,
-        pilots=_apply_timezones([LeaveHygienePilot(**p) for p in pilots]),
+        counts_by_corp=by_corp,
+        pilots=_apply_timezones(
+            [LeaveHygienePilot(**p) for p in _leave_bucket_rows(leave, bucket)]
+        ),
     )
 
 

--- a/backend/alliance/helpers/hygiene.py
+++ b/backend/alliance/helpers/hygiene.py
@@ -36,6 +36,11 @@ def gang_bucket(size: int) -> str:
     return "blob"
 
 
+def trial_under_min_tenure(alliance_days: Optional[int]) -> bool:
+    """True until alliance tenure is known and at least MIN_APPROVE_DAYS."""
+    return alliance_days is None or alliance_days < MIN_APPROVE_DAYS
+
+
 def classify_onboarding_need(
     *,
     fleets: int,
@@ -167,7 +172,7 @@ def classify_trial(
     )
     path = path_label(strong, medium)
     would_approve = bool(strong) or len(medium) >= 2
-    too_early = alliance_days is None or alliance_days < MIN_APPROVE_DAYS
+    too_early = trial_under_min_tenure(alliance_days)
 
     if would_approve and recent and too_early:
         days_txt = (
@@ -813,12 +818,12 @@ def assemble_hygiene(
         "nudge", []
     )
     trial_remove = trial_public.get("approve", [])
-    trial_passing = trial_public.get("approve", []) + trial_public.get(
-        "too_early", []
-    )
+    trial_passing = trial_public.get("approve", [])
     trial_failing = trial_public.get("fail", [])
-    trial_evaluating = trial_public.get("nudge", []) + trial_public.get(
-        "hold", []
+    trial_evaluating = (
+        trial_public.get("nudge", [])
+        + trial_public.get("hold", [])
+        + trial_public.get("too_early", [])
     )
     trial_public["current"] = trial_current
     trial_public["add"] = trial_add

--- a/backend/alliance/tests/test_health.py
+++ b/backend/alliance/tests/test_health.py
@@ -562,9 +562,9 @@ class AllianceHealthEndpointTestCase(TestCase):
         self.assertEqual(overview.unknown_characters, [])
         self.assertEqual(overview.hygiene.trial.remove, 1)
         self.assertEqual(overview.hygiene.trial.flagged, 7)
-        self.assertEqual(overview.hygiene.trial.passing, 3)
+        self.assertEqual(overview.hygiene.trial.passing, 1)
         self.assertEqual(overview.hygiene.trial.failing, 3)
-        self.assertEqual(overview.hygiene.trial.evaluating, 9)
+        self.assertEqual(overview.hygiene.trial.evaluating, 11)
         self.assertEqual(overview.hygiene.leave.add, 1)
         self.assertEqual(overview.monthly[0].small_gang, 0)
         trials = trials_from_payload(legacy, "current")
@@ -577,6 +577,53 @@ class AllianceHealthEndpointTestCase(TestCase):
         self.assertEqual(leave.counts.recommended, 1)
         self.assertEqual(leave.counts.returning, 0)
         self.assertEqual(leave.counts.inactive, 0)
+
+    def test_trials_under_60_days_are_evaluating_not_passing(self):
+        def row(user_id, days, decision="approve"):
+            return {
+                "user_id": user_id,
+                "username": f"u{user_id}",
+                "pilot": f"Pilot {user_id}",
+                "corp": "Test Corp",
+                "corporation_id": 1,
+                "character_id": user_id,
+                "alliance_days": days,
+                "fleets": 5,
+                "kills": 12,
+                "kills_small": 9,
+                "voice_hours": 6.0,
+                "slice_30d": "2F/4K/2h",
+                "days_since_activity": 8,
+                "path": "Mixed",
+                "conf": "high",
+                "reason": "on track",
+                "decision": decision,
+            }
+
+        payload = {
+            "hygiene": {
+                "trial": {
+                    "counts": {"approve": 1, "too_early": 1, "nudge": 1},
+                    "buckets": {
+                        "passing": [
+                            row(1, 70, "approve"),
+                            row(2, 18, "too_early"),
+                        ],
+                        "too_early": [row(2, 18, "too_early")],
+                        "evaluating": [row(3, 40, "nudge")],
+                        "failing": [row(4, 20, "fail")],
+                    },
+                }
+            }
+        }
+        passing = trials_from_payload(payload, "passing")
+        evaluating = trials_from_payload(payload, "evaluating")
+        failing = trials_from_payload(payload, "failing")
+        self.assertEqual([p.user_id for p in passing.pilots], [1])
+        self.assertEqual({p.user_id for p in evaluating.pilots}, {2, 3, 4})
+        self.assertEqual(failing.pilots, [])
+        self.assertEqual(passing.counts.passing, 1)
+        self.assertEqual(passing.counts.evaluating, 3)
 
     def test_attention_dark(self):
         response = self.client.get(
@@ -616,6 +663,51 @@ class AllianceHealthEndpointTestCase(TestCase):
             "dark",
         )
         self.assertEqual([p.pilot for p in body.pilots], ["Gone"])
+
+    def test_attention_counts_split_by_corp(self):
+        body = attention_from_payload(
+            {
+                "attention": {
+                    "fading": [
+                        {
+                            "user_id": 1,
+                            "pilot": "A",
+                            "corp": "FOSFO",
+                            "status": "active",
+                            "days_quiet": 10,
+                            "active_months": 4,
+                        },
+                        {
+                            "user_id": 2,
+                            "pilot": "B",
+                            "corp": "TDT",
+                            "status": "active",
+                            "days_quiet": 12,
+                            "active_months": 3,
+                        },
+                    ],
+                    "dark": [],
+                    "seasonal": [
+                        {
+                            "user_id": 3,
+                            "pilot": "C",
+                            "corp": "FOSFO",
+                            "status": "active",
+                            "days_quiet": 40,
+                            "active_months": 6,
+                        },
+                    ],
+                }
+            },
+            "fading",
+        )
+        self.assertEqual(body.counts.fading, 2)
+        self.assertEqual(body.counts.seasonal, 1)
+        self.assertEqual(body.counts_by_corp["FOSFO"].fading, 1)
+        self.assertEqual(body.counts_by_corp["FOSFO"].seasonal, 1)
+        self.assertEqual(body.counts_by_corp["TDT"].fading, 1)
+        self.assertEqual(body.counts_by_corp["TDT"].seasonal, 0)
+        self.assertEqual(len(body.pilots), 2)
 
     def test_corporations_and_cohorts(self):
         corps = self.client.get(

--- a/backend/alliance/tests/test_hygiene.py
+++ b/backend/alliance/tests/test_hygiene.py
@@ -10,6 +10,7 @@ from alliance.helpers.hygiene import (
     classify_trial,
     gang_bucket,
     slice_30d,
+    trial_under_min_tenure,
 )
 
 
@@ -133,6 +134,9 @@ class ClassifyTrialTestCase(TestCase):
 
     def test_min_approve_days_constant(self):
         self.assertEqual(MIN_APPROVE_DAYS, 60)
+        self.assertTrue(trial_under_min_tenure(None))
+        self.assertTrue(trial_under_min_tenure(59))
+        self.assertFalse(trial_under_min_tenure(60))
 
 
 class ClassifyLeaveTestCase(TestCase):

--- a/frontend/app/src/components/blocks/AllianceHealthAttention.astro
+++ b/frontend/app/src/components/blocks/AllianceHealthAttention.astro
@@ -16,6 +16,7 @@ interface Props {
     bucket: AllianceHealthAttentionBucket
     partial_url: string
     initial_corp?: string
+    counts_by_corp?: Record<string, AllianceHealthQuietCounts>
     can_mutate?: boolean
     alliance_wide?: boolean
     officer_corp_ids?: number[]
@@ -29,6 +30,7 @@ const {
     bucket,
     partial_url,
     initial_corp = 'all',
+    counts_by_corp = {},
     can_mutate = false,
     alliance_wide = false,
     officer_corp_ids = [],
@@ -42,13 +44,19 @@ const default_bucket = ALLIANCE_HEALTH_DEFAULT_BUCKETS.attention
 const tab_query = (id: AllianceHealthAttentionBucket) =>
     alliance_health_table_params({
         bucket: id,
-        corp: initial_corp,
+        include_corp: false,
         can_mutate,
         alliance_wide,
         officer_corp_ids,
         can_leave_any,
         ceo_corp_ids,
     })
+
+const counts = {
+    fading: quiet.fading,
+    dark: quiet.dark,
+    seasonal: quiet.seasonal,
+}
 
 const tabs = [
     { id: 'fading', count: quiet.fading, label: t('alliance.health.bucket.fading') },
@@ -70,6 +78,9 @@ const tabs = [
     default_bucket={default_bucket}
     table_id="alliance-health-attention-table"
     tabs={tabs}
+    initial_corp={initial_corp}
+    counts={counts}
+    counts_by_corp={counts_by_corp}
 >
     <slot />
 </AllianceHealthBucketTabs>

--- a/frontend/app/src/components/blocks/AllianceHealthBucketTabs.astro
+++ b/frontend/app/src/components/blocks/AllianceHealthBucketTabs.astro
@@ -1,5 +1,6 @@
 ---
 import type { AllianceHealthUrlSection } from '@helpers/alliance_health_url'
+import { alliance_health_counts_for_corp } from '@helpers/api.minmatar.org/alliance_health'
 
 import FlexInline from '@components/compositions/FlexInline.astro'
 import Flexblock from '@components/compositions/Flexblock.astro'
@@ -21,6 +22,9 @@ interface Props {
     default_bucket: string
     table_id: string
     tabs: AllianceHealthBucketTab[]
+    initial_corp?: string
+    counts?: Record<string, number>
+    counts_by_corp?: Record<string, Record<string, number>>
     [propName: string]: any
 }
 
@@ -32,20 +36,41 @@ const {
     default_bucket,
     table_id,
     tabs,
+    initial_corp = 'all',
+    counts = {},
+    counts_by_corp = {},
     ...attributes
 } = Astro.props
 delete attributes.class
+
+const filtered = alliance_health_counts_for_corp(counts, counts_by_corp, initial_corp)
+const tabs_for_corp = tabs.map((tab) => ({
+    ...tab,
+    count: Number(filtered[tab.id] ?? tab.count ?? 0),
+}))
+const alpine = {
+    bucket,
+    corp: initial_corp,
+    counts,
+    counts_by_corp,
+}
 ---
 
 <section
     class:list={['[ alliance-health-bucket-tabs ]', Astro.props.class]}
     id={section_id}
     aria-label={aria_label}
-    x-data={`{ bucket: '${bucket}' }`}
+    x-data={`{
+        bucket: ${JSON.stringify(alpine.bucket)},
+        corp: ${JSON.stringify(alpine.corp)},
+        counts: ${JSON.stringify(alpine.counts)},
+        counts_by_corp: ${JSON.stringify(alpine.counts_by_corp)},
+    }`}
+    x-on:alliance-health-corp={`corp = $event.detail`}
 >
     <Flexblock gap="var(--space-m)">
         <FlexInline gap="var(--space-2xs)">
-            {tabs.map((tab) => (
+            {tabs_for_corp.map((tab) => (
                 <Button
                     size="sm"
                     class={tab.id === bucket ? 'is-active' : undefined}
@@ -58,8 +83,9 @@ delete attributes.class
                     hx-swap="innerHTML"
                     hx-trigger="click"
                     hx-indicator=".loader"
+                    hx-vals="js:{corp: (Alpine.$data(this.closest('.alliance-health-bucket-tabs')) || {corp: 'all'}).corp}"
                 >
-                    {tab.label} ({tab.count})
+                    {tab.label} (<span x-text={`((corp === 'all' ? counts : (counts_by_corp[corp] || {}))['${tab.id}'] || 0)`}>{tab.count}</span>)
                 </Button>
             ))}
         </FlexInline>

--- a/frontend/app/src/components/blocks/AllianceHealthLeave.astro
+++ b/frontend/app/src/components/blocks/AllianceHealthLeave.astro
@@ -16,6 +16,7 @@ interface Props {
     bucket: AllianceHealthLeaveBucket
     partial_url: string
     initial_corp?: string
+    counts_by_corp?: Record<string, AllianceHealthLeaveCounts>
     can_mutate?: boolean
     alliance_wide?: boolean
     officer_corp_ids?: number[]
@@ -29,6 +30,7 @@ const {
     bucket,
     partial_url,
     initial_corp = 'all',
+    counts_by_corp = {},
     can_mutate = false,
     alliance_wide = false,
     officer_corp_ids = [],
@@ -42,7 +44,7 @@ const default_bucket = ALLIANCE_HEALTH_DEFAULT_BUCKETS.leave
 const tab_query = (id: AllianceHealthLeaveBucket) =>
     alliance_health_table_params({
         bucket: id,
-        corp: initial_corp,
+        include_corp: false,
         can_mutate,
         alliance_wide,
         officer_corp_ids,
@@ -70,6 +72,9 @@ const tabs = [
     default_bucket={default_bucket}
     table_id="alliance-health-leave-table"
     tabs={tabs}
+    initial_corp={initial_corp}
+    counts={counts}
+    counts_by_corp={counts_by_corp}
 >
     <slot />
 </AllianceHealthBucketTabs>

--- a/frontend/app/src/components/blocks/AllianceHealthLeaveTable.astro
+++ b/frontend/app/src/components/blocks/AllianceHealthLeaveTable.astro
@@ -19,6 +19,7 @@ interface Props {
     officer_corp_ids?: number[]
     alliance_wide?: boolean
     initial_corp?: string
+    corp_options?: string[]
     bucket?: string
     partial_url?: string
     [propName: string]: any
@@ -30,6 +31,7 @@ const {
     officer_corp_ids = [],
     alliance_wide = false,
     initial_corp = 'all',
+    corp_options = [],
     bucket = 'current',
     partial_url = translatePath('/partials/alliance_health_leave_component'),
     ...attributes
@@ -116,6 +118,7 @@ const rows: AllianceHealthPilotListRow[] = pilots.map((pilot) => {
         order_by_options={order_by_options}
         default_order_by="fleets"
         initial_corp={initial_corp}
+        corp_options={corp_options}
         csv_filename={`health-leave-${bucket}.csv`}
         url_section="leave"
     />

--- a/frontend/app/src/components/blocks/AllianceHealthOnboarding.astro
+++ b/frontend/app/src/components/blocks/AllianceHealthOnboarding.astro
@@ -16,6 +16,7 @@ interface Props {
     bucket: AllianceHealthOnboardingBucket
     partial_url: string
     initial_corp?: string
+    counts_by_corp?: Record<string, AllianceHealthOnboardingCounts>
     [propName: string]: any
 }
 
@@ -24,6 +25,7 @@ const {
     bucket,
     partial_url,
     initial_corp = 'all',
+    counts_by_corp = {},
     ...attributes
 } = Astro.props
 delete attributes.class
@@ -44,7 +46,7 @@ const tabs = [
     ...tab,
     href: `${partial_url}?${alliance_health_table_params({
         bucket: tab.id,
-        corp: initial_corp,
+        include_corp: false,
     })}`,
 }))
 ---
@@ -59,6 +61,9 @@ const tabs = [
     default_bucket={default_bucket}
     table_id="alliance-health-onboarding-table"
     tabs={tabs}
+    initial_corp={initial_corp}
+    counts={counts}
+    counts_by_corp={counts_by_corp}
 >
     <slot />
 </AllianceHealthBucketTabs>

--- a/frontend/app/src/components/blocks/AllianceHealthOnboardingTable.astro
+++ b/frontend/app/src/components/blocks/AllianceHealthOnboardingTable.astro
@@ -16,6 +16,7 @@ import AllianceHealthPilotList from '@components/blocks/AllianceHealthPilotList.
 interface Props {
     pilots: AllianceHealthTrialPilot[]
     initial_corp?: string
+    corp_options?: string[]
     bucket?: AllianceHealthOnboardingBucket
     [propName: string]: any
 }
@@ -23,6 +24,7 @@ interface Props {
 const {
     pilots,
     initial_corp = 'all',
+    corp_options = [],
     bucket = 'first_week',
     ...attributes
 } = Astro.props
@@ -97,6 +99,7 @@ const rows: AllianceHealthPilotListRow[] = pilots.map((pilot) => ({
         order_by_options={order_by_options}
         default_order_by={default_order_by}
         initial_corp={initial_corp}
+        corp_options={corp_options}
         csv_filename={`health-needs-attention-${bucket}.csv`}
         url_section="onboarding"
     />

--- a/frontend/app/src/components/blocks/AllianceHealthPilotList.astro
+++ b/frontend/app/src/components/blocks/AllianceHealthPilotList.astro
@@ -28,6 +28,7 @@ interface Props {
     default_order_by?: string
     enable_corp_filter?: boolean
     initial_corp?: string
+    corp_options?: string[]
     page_size?: number
     csv_filename?: string
     url_section?: AllianceHealthUrlSection
@@ -41,6 +42,7 @@ const {
     default_order_by,
     enable_corp_filter = true,
     initial_corp = 'all',
+    corp_options = [],
     page_size = 5,
     csv_filename = 'alliance-health.csv',
     url_section,
@@ -48,12 +50,11 @@ const {
 } = Astro.props
 delete attributes.class
 
-const corps = Array.from(
+const row_corps = Array.from(
     new Set(rows.map((row) => row.corp).filter((name): name is string => !!name && name !== '—')),
-).sort((a, b) => a.localeCompare(b))
+)
 
-const initial = corps.includes(initial_corp) ? initial_corp : 'all'
-
+const default_corp = initial_corp || 'all'
 const chips: AllianceHealthOrderOption[] = [
     { id: 'name', label: t('alliance.health.order.name'), kind: 'text' },
     ...order_by_options.filter((opt) => opt.id !== 'name'),
@@ -69,7 +70,7 @@ const default_dir: AllianceHealthOrderDir = default_health_order_dir(
 const page_query =
     url_section && !Astro.url.pathname.includes('/partials/')
         ? read_alliance_health_list_state(Astro.url.searchParams, url_section, {
-            corp: initial,
+            corp: default_corp,
             by: default_by,
             dir: default_dir,
             page: 1,
@@ -83,10 +84,16 @@ const order_by =
 const order_dir: AllianceHealthOrderDir = page_query?.dir ?? default_dir
 const initial_search = page_query?.q ?? ''
 const initial_page = page_query?.page ?? 1
-const list_corp =
-    page_query?.corp && (page_query.corp === 'all' || corps.includes(page_query.corp))
-        ? page_query.corp
-        : initial
+const list_corp = page_query?.corp ?? default_corp
+const corps = Array.from(
+    new Set(
+        [
+            ...corp_options,
+            ...row_corps,
+            ...(list_corp && list_corp !== 'all' ? [list_corp] : []),
+        ].filter((name): name is string => !!name && name !== '—'),
+    ),
+).sort((a, b) => a.localeCompare(b))
 
 const order_kinds: Record<string, AllianceHealthOrderKind> = Object.fromEntries(
     chips.map((chip) => [chip.id, chip.kind]),
@@ -128,7 +135,7 @@ const csv_headers = csv_headers_from_pilot(colored_rows[0], {
         csv_filename,
         url_section: url_section ?? '',
         url_defaults: {
-            corp: initial,
+            corp: default_corp,
             by: default_by,
             dir: default_dir,
             page: 1,

--- a/frontend/app/src/components/blocks/AllianceHealthPilotsTable.astro
+++ b/frontend/app/src/components/blocks/AllianceHealthPilotsTable.astro
@@ -16,6 +16,7 @@ import AllianceHealthPilotList from '@components/blocks/AllianceHealthPilotList.
 interface Props {
     pilots: AllianceHealthAttentionPilot[]
     initial_corp?: string
+    corp_options?: string[]
     can_leave_any?: boolean
     ceo_corp_ids?: number[]
     bucket?: string
@@ -26,6 +27,7 @@ interface Props {
 const {
     pilots,
     initial_corp = 'all',
+    corp_options = [],
     can_leave_any = false,
     ceo_corp_ids = [],
     bucket = 'fading',
@@ -105,6 +107,7 @@ const rows: AllianceHealthPilotListRow[] = pilots.map((pilot) => ({
         order_by_options={order_by_options}
         default_order_by="quiet"
         initial_corp={initial_corp}
+        corp_options={corp_options}
         csv_filename={`health-at-risk-${bucket}.csv`}
         url_section="attention"
     />

--- a/frontend/app/src/components/blocks/AllianceHealthTrials.astro
+++ b/frontend/app/src/components/blocks/AllianceHealthTrials.astro
@@ -16,6 +16,7 @@ interface Props {
     bucket: AllianceHealthTrialBucket
     partial_url: string
     initial_corp?: string
+    counts_by_corp?: Record<string, AllianceHealthTrialCounts>
     can_mutate?: boolean
     alliance_wide?: boolean
     officer_corp_ids?: number[]
@@ -27,6 +28,7 @@ const {
     bucket,
     partial_url,
     initial_corp = 'all',
+    counts_by_corp = {},
     can_mutate = false,
     alliance_wide = false,
     officer_corp_ids = [],
@@ -38,7 +40,7 @@ const default_bucket = ALLIANCE_HEALTH_DEFAULT_BUCKETS.trials
 const tab_query = (id: AllianceHealthTrialBucket) =>
     alliance_health_table_params({
         bucket: id,
-        corp: initial_corp,
+        include_corp: false,
         can_mutate,
         alliance_wide,
         officer_corp_ids,
@@ -46,9 +48,9 @@ const tab_query = (id: AllianceHealthTrialBucket) =>
 
 const tabs = [
     { id: 'current', count: counts.current, label: t('alliance.health.selector.current_trial') },
-    { id: 'passing', count: counts.passing ?? ((counts.approve ?? 0) + (counts.too_early ?? 0)), label: t('alliance.health.selector.passing_trial') },
+    { id: 'passing', count: counts.passing ?? counts.approve, label: t('alliance.health.selector.passing_trial') },
     { id: 'failing', count: counts.failing ?? counts.fail, label: t('alliance.health.selector.failing_trial') },
-    { id: 'evaluating', count: counts.evaluating ?? ((counts.nudge ?? 0) + (counts.hold ?? 0)), label: t('alliance.health.selector.evaluating_trial') },
+    { id: 'evaluating', count: counts.evaluating ?? ((counts.nudge ?? 0) + (counts.hold ?? 0) + (counts.too_early ?? 0)), label: t('alliance.health.selector.evaluating_trial') },
 ].map((tab) => ({
     ...tab,
     href: `${partial_url}?${tab_query(tab.id as AllianceHealthTrialBucket)}`,
@@ -65,6 +67,9 @@ const tabs = [
     default_bucket={default_bucket}
     table_id="alliance-health-trials-table"
     tabs={tabs}
+    initial_corp={initial_corp}
+    counts={counts}
+    counts_by_corp={counts_by_corp}
 >
     <slot />
 </AllianceHealthBucketTabs>

--- a/frontend/app/src/components/blocks/AllianceHealthTrialsTable.astro
+++ b/frontend/app/src/components/blocks/AllianceHealthTrialsTable.astro
@@ -22,6 +22,7 @@ interface Props {
     officer_corp_ids?: number[]
     alliance_wide?: boolean
     initial_corp?: string
+    corp_options?: string[]
     bucket?: string
     partial_url?: string
     [propName: string]: any
@@ -33,6 +34,7 @@ const {
     officer_corp_ids = [],
     alliance_wide = false,
     initial_corp = 'all',
+    corp_options = [],
     bucket = 'current',
     partial_url = translatePath('/partials/alliance_health_trials_component'),
     ...attributes
@@ -149,6 +151,7 @@ const rows: AllianceHealthPilotListRow[] = pilots.map((pilot) => {
         order_by_options={order_by_options}
         default_order_by="fleets"
         initial_corp={initial_corp}
+        corp_options={corp_options}
         csv_filename={`health-trials-${bucket}.csv`}
         url_section="trials"
     />

--- a/frontend/app/src/components/partials/AllianceHealthPilotAlpine.astro
+++ b/frontend/app/src/components/partials/AllianceHealthPilotAlpine.astro
@@ -112,13 +112,18 @@
             ...config,
             init() {
                 this.apply_url()
+                this.$dispatch('alliance-health-corp', this.corp)
                 this.$nextTick(() => this.refresh())
                 if (this.$refs.body && typeof MutationObserver !== 'undefined') {
                     this._row_observer = new MutationObserver(() => this.refresh())
                     this._row_observer.observe(this.$refs.body, { childList: true })
                 }
-                this.$watch('search', () => { this.page = 1; this.refresh(); this.sync_url() })
-                this.$watch('corp', () => { this.page = 1; this.refresh(); this.sync_url() })
+                this.$watch('corp', () => {
+                    this.page = 1
+                    this.refresh()
+                    this.sync_url()
+                    this.$dispatch('alliance-health-corp', this.corp)
+                })
                 this.$watch('page', () => { this.refresh(); this.sync_url() })
                 if (this.sort) {
                     this.$watch('order_by', () => { this.page = 1; this.refresh(); this.sync_url() })

--- a/frontend/app/src/helpers/api.minmatar.org/alliance_health.ts
+++ b/frontend/app/src/helpers/api.minmatar.org/alliance_health.ts
@@ -118,9 +118,38 @@ export async function post_alliance_health_status(
     return await response.json()
 }
 
+export function alliance_health_counts_for_corp<T extends Record<string, number>>(
+    counts: T,
+    counts_by_corp: Record<string, T> | undefined,
+    corp: string,
+): T {
+    if (!corp || corp === 'all') {
+        return counts_by_corp?.all ?? counts
+    }
+    if (counts_by_corp?.[corp]) return counts_by_corp[corp]
+    const zero = { ...counts }
+    for (const key of Object.keys(zero) as (keyof T)[]) {
+        zero[key] = 0 as T[keyof T]
+    }
+    return zero
+}
+
+export function alliance_health_corp_options(
+    counts_by_corp: Record<string, unknown> | undefined,
+    extra: string[] = [],
+): string[] {
+    const names = new Set(
+        [...Object.keys(counts_by_corp ?? {}), ...extra].filter(
+            (name) => name && name !== 'all' && name !== '—',
+        ),
+    )
+    return [...names].sort((a, b) => a.localeCompare(b))
+}
+
 export function alliance_health_table_params(opts: {
     bucket: string
     corp?: string
+    include_corp?: boolean
     can_mutate?: boolean
     alliance_wide?: boolean
     officer_corp_ids?: number[]
@@ -129,7 +158,7 @@ export function alliance_health_table_params(opts: {
 }): string {
     return query_string({
         bucket: opts.bucket,
-        corp: opts.corp ?? 'all',
+        ...(opts.include_corp === false ? {} : { corp: opts.corp ?? 'all' }),
         can_mutate: opts.can_mutate ? '1' : '0',
         alliance_wide: opts.alliance_wide ? '1' : '0',
         officer_corps: (opts.officer_corp_ids ?? []).join(','),
@@ -187,7 +216,7 @@ export function can_promote_alliance_health_trial(opts: {
         case 'remove':
             return true
         case 'passing':
-            return opts.alliance_days == null || opts.alliance_days >= 60
+            return (opts.alliance_days ?? 0) >= 60
         case 'current':
         case 'failing':
         case 'evaluating':

--- a/frontend/app/src/pages/alliance/health.astro
+++ b/frontend/app/src/pages/alliance/health.astro
@@ -38,6 +38,7 @@ import {
     get_alliance_health_trials,
 } from '@helpers/api.minmatar.org/alliance_health'
 import { parse_alliance_health_bucket } from '@helpers/alliance_health_url'
+import { alliance_health_corp_options } from '@helpers/api.minmatar.org/alliance_health'
 import { from_now_diff } from '@helpers/date'
 
 let overview: AllianceHealthOverview | null = null
@@ -205,6 +206,7 @@ const last_updated_text = overview?.computed_at
                         </Flexblock>
                         <AllianceHealthOnboarding
                             counts={onboarding.counts}
+                            counts_by_corp={onboarding.counts_by_corp}
                             bucket={onboarding.bucket}
                             partial_url={ONBOARDING_PARTIAL_URL}
                             initial_corp={initial_corp}
@@ -212,6 +214,10 @@ const last_updated_text = overview?.computed_at
                             <AllianceHealthOnboardingTable
                                 pilots={onboarding.pilots}
                                 initial_corp={initial_corp}
+                                corp_options={alliance_health_corp_options(
+                                    onboarding.counts_by_corp,
+                                    [initial_corp],
+                                )}
                                 bucket={onboarding.bucket}
                             />
                         </AllianceHealthOnboarding>
@@ -223,7 +229,8 @@ const last_updated_text = overview?.computed_at
                             <small>{t('alliance.health.attention.caption')}</small>
                         </Flexblock>
                         <AllianceHealthAttention
-                            quiet={overview.quiet}
+                            quiet={attention.counts ?? overview.quiet}
+                            counts_by_corp={attention.counts_by_corp}
                             bucket={attention.bucket}
                             partial_url={ATTENTION_PARTIAL_URL}
                             initial_corp={initial_corp}
@@ -236,6 +243,10 @@ const last_updated_text = overview?.computed_at
                             <AllianceHealthPilotsTable
                                 pilots={attention.pilots}
                                 initial_corp={initial_corp}
+                                corp_options={alliance_health_corp_options(
+                                    attention.counts_by_corp,
+                                    [initial_corp],
+                                )}
                                 can_leave_any={can_leave_any}
                                 ceo_corp_ids={ceo_corp_ids}
                                 bucket={attention.bucket}
@@ -266,7 +277,8 @@ const last_updated_text = overview?.computed_at
                             <small>{t('alliance.health.trials.caption')}</small>
                         </Flexblock>
                         <AllianceHealthTrials
-                            counts={overview.hygiene?.trial ?? trials.counts}
+                            counts={trials.counts}
+                            counts_by_corp={trials.counts_by_corp}
                             bucket={trials.bucket}
                             partial_url={TRIALS_PARTIAL_URL}
                             initial_corp={initial_corp}
@@ -286,6 +298,10 @@ const last_updated_text = overview?.computed_at
                                 officer_corp_ids={officer_corp_ids}
                                 alliance_wide={alliance_wide}
                                 initial_corp={initial_corp}
+                                corp_options={alliance_health_corp_options(
+                                    trials.counts_by_corp,
+                                    [initial_corp],
+                                )}
                                 bucket={trials.bucket}
                                 partial_url={TRIALS_PARTIAL_URL}
                             />
@@ -298,7 +314,8 @@ const last_updated_text = overview?.computed_at
                             <small>{t('alliance.health.leave.caption')}</small>
                         </Flexblock>
                         <AllianceHealthLeave
-                            counts={overview.hygiene?.leave ?? leave.counts}
+                            counts={leave.counts}
+                            counts_by_corp={leave.counts_by_corp}
                             bucket={leave.bucket}
                             partial_url={LEAVE_PARTIAL_URL}
                             initial_corp={initial_corp}
@@ -316,6 +333,10 @@ const last_updated_text = overview?.computed_at
                                 officer_corp_ids={officer_corp_ids}
                                 alliance_wide={alliance_wide}
                                 initial_corp={initial_corp}
+                                corp_options={alliance_health_corp_options(
+                                    leave.counts_by_corp,
+                                    [initial_corp],
+                                )}
                                 bucket={leave.bucket}
                                 partial_url={LEAVE_PARTIAL_URL}
                             />

--- a/frontend/app/src/pages/partials/alliance_health_attention_component.astro
+++ b/frontend/app/src/pages/partials/alliance_health_attention_component.astro
@@ -41,6 +41,7 @@ const ceo_corp_ids = (Astro.url.searchParams.get('ceo_corps') ?? '')
     .filter((value) => !Number.isNaN(value) && value > 0)
 
 let pilots: AllianceHealthAttentionPilot[] = []
+let corp_options: string[] = []
 let data_fetching_error: any
 
 if (Astro.request.method === 'POST' && action === 'leave' && user_id) {
@@ -59,6 +60,9 @@ try {
         bucket,
     )
     pilots = attention.pilots
+    corp_options = Object.keys(attention.counts_by_corp ?? {}).filter(
+        (name) => name && name !== 'all' && name !== '—',
+    )
 } catch (error) {
     data_fetching_error = error
 }
@@ -79,6 +83,7 @@ const PARTIAL_URL = translatePath('/partials/alliance_health_attention_component
         <AllianceHealthPilotsTable
             pilots={pilots}
             initial_corp={initial_corp}
+            corp_options={corp_options}
             can_leave_any={can_leave_any}
             ceo_corp_ids={ceo_corp_ids}
             bucket={bucket}

--- a/frontend/app/src/pages/partials/alliance_health_leave_component.astro
+++ b/frontend/app/src/pages/partials/alliance_health_leave_component.astro
@@ -47,6 +47,7 @@ const officer_corp_ids = (Astro.url.searchParams.get('officer_corps') ?? '')
     .filter((value) => !Number.isNaN(value) && value > 0)
 
 let pilots: AllianceHealthLeavePilot[] = []
+let corp_options: string[] = []
 let data_fetching_error: any
 
 if (Astro.request.method === 'POST' && action === 'restore' && user_id) {
@@ -62,6 +63,9 @@ if (Astro.request.method === 'POST' && action === 'restore' && user_id) {
 try {
     const leave = await get_alliance_health_leave(auth_token as string, bucket)
     pilots = leave.pilots
+    corp_options = Object.keys(leave.counts_by_corp ?? {}).filter(
+        (name) => name && name !== 'all' && name !== '—',
+    )
 } catch (error) {
     data_fetching_error = error
 }
@@ -85,6 +89,7 @@ const PARTIAL_URL = translatePath('/partials/alliance_health_leave_component')
             officer_corp_ids={officer_corp_ids}
             alliance_wide={alliance_wide}
             initial_corp={initial_corp}
+            corp_options={corp_options}
             bucket={bucket}
             partial_url={PARTIAL_URL}
         />

--- a/frontend/app/src/pages/partials/alliance_health_onboarding_component.astro
+++ b/frontend/app/src/pages/partials/alliance_health_onboarding_component.astro
@@ -27,6 +27,7 @@ const initial_corp = Astro.url.searchParams.get('corp') || 'all'
 let pilots: Awaited<
     ReturnType<typeof get_alliance_health_onboarding>
 >['pilots'] = []
+let corp_options: string[] = []
 let data_fetching_error: any
 
 try {
@@ -35,6 +36,9 @@ try {
         bucket,
     )
     pilots = onboarding.pilots
+    corp_options = Object.keys(onboarding.counts_by_corp ?? {}).filter(
+        (name) => name && name !== 'all' && name !== '—',
+    )
 } catch (error) {
     data_fetching_error = error
 }
@@ -55,6 +59,7 @@ const PARTIAL_URL = translatePath('/partials/alliance_health_onboarding_componen
         <AllianceHealthOnboardingTable
             pilots={pilots}
             initial_corp={initial_corp}
+            corp_options={corp_options}
             bucket={bucket}
         />
     )

--- a/frontend/app/src/pages/partials/alliance_health_trials_component.astro
+++ b/frontend/app/src/pages/partials/alliance_health_trials_component.astro
@@ -52,6 +52,7 @@ const officer_corp_ids = (Astro.url.searchParams.get('officer_corps') ?? '')
     .filter((value) => !Number.isNaN(value) && value > 0)
 
 let pilots: AllianceHealthTrialPilot[] = []
+let corp_options: string[] = []
 let data_fetching_error: any
 
 if (Astro.request.method === 'POST' && action === 'promote' && user_id) {
@@ -67,6 +68,9 @@ if (Astro.request.method === 'POST' && action === 'promote' && user_id) {
 try {
     const trials = await get_alliance_health_trials(auth_token as string, bucket)
     pilots = trials.pilots
+    corp_options = Object.keys(trials.counts_by_corp ?? {}).filter(
+        (name) => name && name !== 'all' && name !== '—',
+    )
 } catch (error) {
     data_fetching_error = error
 }
@@ -95,6 +99,7 @@ const PARTIAL_URL = translatePath('/partials/alliance_health_trials_component')
             officer_corp_ids={officer_corp_ids}
             alliance_wide={alliance_wide}
             initial_corp={initial_corp}
+            corp_options={corp_options}
             bucket={bucket}
             partial_url={PARTIAL_URL}
         />

--- a/frontend/app/src/types/api.minmatar.org.ts
+++ b/frontend/app/src/types/api.minmatar.org.ts
@@ -2129,6 +2129,8 @@ export interface AllianceHealthAttention {
     computed_at:    string;
     bucket:         AllianceHealthAttentionBucket;
     pilots:         AllianceHealthAttentionPilot[];
+    counts:         AllianceHealthQuietCounts;
+    counts_by_corp: Record<string, AllianceHealthQuietCounts>;
 }
 
 export interface AllianceHealthTrialPilot {
@@ -2156,6 +2158,7 @@ export interface AllianceHealthTrials {
     computed_at:    string;
     bucket:         AllianceHealthTrialBucket;
     counts:         AllianceHealthTrialCounts;
+    counts_by_corp: Record<string, AllianceHealthTrialCounts>;
     pilots:         AllianceHealthTrialPilot[];
 }
 
@@ -2170,6 +2173,7 @@ export interface AllianceHealthOnboarding {
     computed_at:    string;
     bucket:         AllianceHealthOnboardingBucket;
     counts:         AllianceHealthOnboardingCounts;
+    counts_by_corp: Record<string, AllianceHealthOnboardingCounts>;
     pilots:         AllianceHealthTrialPilot[];
 }
 
@@ -2193,6 +2197,7 @@ export interface AllianceHealthLeave {
     computed_at:    string;
     bucket:         AllianceHealthLeaveBucket;
     counts:         AllianceHealthLeaveCounts;
+    counts_by_corp: Record<string, AllianceHealthLeaveCounts>;
     pilots:         AllianceHealthLeavePilot[];
 }
 

--- a/frontend/app/testing/helpers/alliance_health.test.ts
+++ b/frontend/app/testing/helpers/alliance_health.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { can_promote_alliance_health_trial } from '@helpers/api.minmatar.org/alliance_health'
+import {
+    alliance_health_corp_options,
+    alliance_health_counts_for_corp,
+    can_promote_alliance_health_trial,
+} from '@helpers/api.minmatar.org/alliance_health'
 
 const base = {
     can_mutate: true,
@@ -31,7 +35,15 @@ describe('can_promote_alliance_health_trial', () => {
         ).toBe(false)
     })
 
-    it('shows promote on passing when tenure is unknown', () => {
+    it('hides promote on passing when tenure is under 60 days', () => {
+        expect(
+            can_promote_alliance_health_trial({
+                ...base,
+                bucket: 'passing',
+                decision: null,
+                alliance_days: 40,
+            }),
+        ).toBe(false)
         expect(
             can_promote_alliance_health_trial({
                 ...base,
@@ -39,7 +51,7 @@ describe('can_promote_alliance_health_trial', () => {
                 decision: null,
                 alliance_days: null,
             }),
-        ).toBe(true)
+        ).toBe(false)
     })
 
     it('hides promote for too-early pilots on passing', () => {
@@ -63,5 +75,37 @@ describe('can_promote_alliance_health_trial', () => {
                 alliance_days: 70,
             }),
         ).toBe(false)
+    })
+})
+
+describe('alliance_health_counts_for_corp', () => {
+    const all = { fading: 4, dark: 2, seasonal: 1 }
+    const by_corp = {
+        all,
+        FOSFO: { fading: 1, dark: 0, seasonal: 1 },
+    }
+
+    it('uses the selected corp tab totals', () => {
+        expect(alliance_health_counts_for_corp(all, by_corp, 'FOSFO')).toEqual({
+            fading: 1,
+            dark: 0,
+            seasonal: 1,
+        })
+    })
+
+    it('keeps alliance totals for all corporations', () => {
+        expect(alliance_health_counts_for_corp(all, by_corp, 'all')).toEqual(all)
+    })
+
+    it('zeros a corp that is not in the map', () => {
+        expect(alliance_health_counts_for_corp(all, by_corp, 'TDT')).toEqual({
+            fading: 0,
+            dark: 0,
+            seasonal: 0,
+        })
+    })
+
+    it('lists corps from the count map', () => {
+        expect(alliance_health_corp_options(by_corp, ['TDT'])).toEqual(['FOSFO', 'TDT'])
     })
 })


### PR DESCRIPTION
## Summary

Breaks down each alliance health bucket by corporation so the CEO briefing can be filtered to a single corp.

- Adds `counts_by_corp` to the attention/quiet, trials, onboarding, and on-leave health responses (a generic `counts_by_corp_from_bucket_rows` tallier over the pydantic count models).
- Wires corp-scoped tabs/filtering through the health UI (`AllianceHealthBucketTabs`, the block/table components, the Alpine pilot state, and the page/partials).
- Refines trial tenure counting so pilots under the minimum tenure are excluded from passing/failing tallies.

## Test plan

- `backend/alliance/tests/test_health.py` and `test_hygiene.py` updated for the new per-corp counts.
- `frontend/app/testing/helpers/alliance_health.test.ts` updated.
- Pre-commit (black/flake8/pylint) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)