### PR TITLE
Fix alliance health bucket tab filtering and tone down tab design

### DIFF
--- a/frontend/app/src/components/blocks/AllianceHealthBucketTabs.astro
+++ b/frontend/app/src/components/blocks/AllianceHealthBucketTabs.astro
@@ -83,9 +83,9 @@ const alpine = {
                     hx-swap="innerHTML"
                     hx-trigger="click"
                     hx-indicator=".loader"
-                    hx-vals="js:{corp: (Alpine.$data(this.closest('.alliance-health-bucket-tabs')) || {corp: 'all'}).corp}"
+                    x-bind:hx-vals={`JSON.stringify({ corp })`}
                 >
-                    {tab.label} (<span x-text={`((corp === 'all' ? counts : (counts_by_corp[corp] || {}))['${tab.id}'] || 0)`}>{tab.count}</span>)
+                    <span>{tab.label} (<span x-text={`((corp === 'all' ? counts : (counts_by_corp[corp] || {}))['${tab.id}'] || 0)`}>{tab.count}</span>)</span>
                 </Button>
             ))}
         </FlexInline>
@@ -103,8 +103,7 @@ const alpine = {
 
 <style lang="scss">
     .alliance-health-bucket-tabs :global(button.button.is-active) {
-        background-color: var(--fleet-yellow);
-        border-color: var(--fleet-yellow);
-        color: var(--background);
+        border-color: var(--alliance-blue);
+        color: var(--highlight);
     }
 </style>


### PR DESCRIPTION
The tab design on the alliance health page changed more than intended in #2665, and the bucket tab filters stopped working (clicking **Passing** on the trials section didn't change the table).

## Filter bug (broken tab switching)

#2665 added corp forwarding to the bucket tabs via:

```
hx-vals="js:{corp: (Alpine.$data(this.closest('.alliance-health-bucket-tabs')) || {corp: 'all'}).corp}"
```

htmx evaluates a `js:` expression as `Function("return (…)")()` — called with **no `this` binding**, so `this` is `window`. `window.closest(...)` throws a `TypeError`, and htmx's `maybeEval` doesn't catch it, so the exception aborted the click handler *before* the GET was issued. Result: clicking any bucket tab did nothing.

Fixed by building the attribute with **Alpine** (`x-bind:hx-vals`), which evaluates in the element's own scope where `corp` is already synced via the `alliance-health-corp` event — the same pattern used in `Modal.astro`/`ConfirmDialog.astro`. htmx then reads it as plain JSON, no eval.

## Wild size / spacing

`Button` wraps its slot in a `FlexInline` flexbox. #2665 changed the count from a plain text run to `{label} (<span>…</span>)`, which flex-split the label into three separate items — text, the `<span>`, and `)` — each pushed apart by the flex `gap` (the `(   1   )` gaps and bloated tabs). Wrapped the label+count back into a single `<span>` so it's one flex item.

## Active tab style

Reverted the bold solid fleet-yellow pill back to the prior subtle blue outline (`--alliance-blue` border, `--highlight` text, transparent background).

This is a shared component, so the fix applies to all health tab sections (trials, onboarding, on-leave, attention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)