### PR TITLE
Fix EsiClient import path in tech seed_data

### DIFF
--- a/backend/tech/seed_data.py
+++ b/backend/tech/seed_data.py
@@ -11,8 +11,8 @@ from eveonline.models import (
     EveCorporation,
     EveCharacter,
     EveTag,
-    EsiClient,
 )
+from eveonline.client import EsiClient
 from posts.models import EveTag as PostsEveTag
 from market.models import EveMarketContractExpectation
 from groups.models import AffiliationType, EveCorporationGroup


### PR DESCRIPTION
## Problem

Running the tech seed raised:

```
ImportError: cannot import name 'EsiClient' from 'eveonline.models'
```

Some devs hit this and others didn't, depending on whether they had the amended `seed_data.py` — it's not an environment or Pipfile issue, just a wrong import path.

## Cause

`EsiClient` lives in `eveonline.client`, not `eveonline.models`. It was moved to the client module in #1829 ("Rearchitect ESI fetching to avoid rate limits"), and every other file in the repo imports it from there (`from eveonline.client import EsiClient`, 39 call sites). `backend/tech/seed_data.py` was the sole outlier, importing it from `eveonline.models`, whose `__init__.py` only re-exports ORM model classes.

## Fix

Move `EsiClient` out of the `eveonline.models` import group and import it from `eveonline.client`, matching the rest of the codebase. Verified no other files import client-only symbols (`EsiClient`, `EsiResponse`, `esi_for`, `esi_public`, `live_esi_allowed`) from `eveonline.models`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)