### PR TITLE
Fix survey tenure; simplify completion screen; order progress by population

### DIFF
--- a/backend/surveys/helpers/corp_history.py
+++ b/backend/surveys/helpers/corp_history.py
@@ -51,6 +51,37 @@ def _has_graduated(corps) -> bool:
     return False
 
 
+def alliance_join_date(user):
+    """Earliest start_date among the member's alliance corporations, i.e. when
+    they first joined the community. Read-only ESI-history data; None if unknown.
+    """
+    try:
+        pc = user_primary_character(user)
+        if not pc:
+            return None
+        alliance_id = getattr(pc, "alliance_id", None) or FL33T_ALLIANCE_ID
+
+        history = list(
+            pc.corporation_history.order_by("start_date", "record_id")
+        )
+        if not history:
+            return None
+
+        alliance_corp_ids = set(
+            EveCorporation.objects.filter(
+                corporation_id__in={row.corporation_id for row in history},
+                alliance__alliance_id=alliance_id,
+            ).values_list("corporation_id", flat=True)
+        )
+        for row in history:  # ordered earliest first
+            if row.corporation_id in alliance_corp_ids:
+                return row.start_date
+        return None
+    except Exception:  # pragma: no cover - defensive
+        logger.debug("alliance_join_date failed", exc_info=True)
+        return None
+
+
 def alliance_corp_history(user) -> dict:
     """Return {"corps": [...], "graduated": bool} for the member's time in the
     alliance's corporations, most-tenured first."""

--- a/backend/surveys/helpers/tenure.py
+++ b/backend/surveys/helpers/tenure.py
@@ -12,13 +12,29 @@ from surveys.constants import (
     COHORT_NEW,
     COHORT_VETERAN,
 )
+from surveys.helpers.corp_history import alliance_join_date
 
 logger = logging.getLogger(__name__)
 
 
 def member_join_date(user):
-    """Earliest community-status history → EvePlayer.created_at → date_joined."""
-    # 1. Community status history (most semantically "joined the community").
+    """Alliance corp-history join → community-status history →
+    EvePlayer.created_at → date_joined."""
+    # 1. Earliest ESI corporation-history start in an alliance corp — the true
+    # "joined the community" date. Everything below is a fallback for members
+    # whose corp history hasn't synced.
+    try:
+        joined = alliance_join_date(user)
+        if joined:
+            return joined
+    except Exception:  # pragma: no cover - defensive
+        logger.debug(
+            "alliance_join_date lookup failed for %s", user, exc_info=True
+        )
+
+    # 2. Community status history. NOTE: this only goes back to when community
+    # status tracking launched (2026-03-01), so it understates tenure for
+    # members who joined earlier — hence it sits below corp history.
     try:
         first = (
             user.community_status_history.order_by("changed_at")
@@ -30,7 +46,7 @@ def member_join_date(user):
     except Exception:  # pragma: no cover - defensive
         logger.debug("no community_status_history for %s", user, exc_info=True)
 
-    # 2. EvePlayer.created_at.
+    # 3. EvePlayer.created_at.
     try:
         player = getattr(user, "eveplayer", None)
         if player and player.created_at:
@@ -38,7 +54,7 @@ def member_join_date(user):
     except Exception:  # pragma: no cover - defensive
         pass
 
-    # 3. Django account creation.
+    # 4. Django account creation.
     return user.date_joined
 
 

--- a/backend/surveys/tests/test_tenure.py
+++ b/backend/surveys/tests/test_tenure.py
@@ -1,0 +1,107 @@
+from datetime import timedelta
+
+import factory
+from django.contrib.auth.models import User
+from django.db.models import signals
+from django.test import TestCase
+from django.utils import timezone
+
+from eveonline.models import (
+    EveAlliance,
+    EveCharacter,
+    EveCharacterCorporationHistory,
+    EveCorporation,
+    EvePlayer,
+)
+from groups.models import UserCommunityStatusHistory
+from surveys.helpers.tenure import member_join_date, tenure_days
+
+FL33T_ALLIANCE_ID = 99011978
+
+
+class TenureTests(TestCase):
+    @factory.django.mute_signals(signals.pre_save, signals.post_save)
+    def setUp(self):
+        self.user = User.objects.create(username="pilot")
+        self.alliance = EveAlliance.objects.create(
+            alliance_id=FL33T_ALLIANCE_ID
+        )
+        self.corp = EveCorporation.objects.create(
+            corporation_id=98000001,
+            name="Rattini Tribe",
+            ticker="A-RAT",
+            alliance=self.alliance,
+        )
+        self.character = EveCharacter.objects.create(
+            character_id=90000001,
+            character_name="Testpilot",
+            corporation_id=self.corp.corporation_id,
+            alliance_id=FL33T_ALLIANCE_ID,
+            user=self.user,
+        )
+        EvePlayer.objects.create(
+            user=self.user,
+            primary_character=self.character,
+            nickname=self.user.username,
+        )
+
+    @factory.django.mute_signals(signals.pre_save, signals.post_save)
+    def test_corp_history_beats_recent_community_status(self):
+        """Tenure must reflect the real corp-join date, not the recently-launched
+        community-status audit log (regression for the 171d bug)."""
+        joined_at = timezone.now() - timedelta(days=1376)
+        EveCharacterCorporationHistory.objects.create(
+            character=self.character,
+            record_id=1,
+            corporation_id=self.corp.corporation_id,
+            start_date=joined_at,
+        )
+        # A far more recent community-status row must NOT win.
+        UserCommunityStatusHistory.objects.create(
+            user=self.user, to_status="active"
+        )
+
+        self.assertEqual(member_join_date(self.user), joined_at)
+        self.assertEqual(tenure_days(self.user), 1376)
+
+    @factory.django.mute_signals(signals.pre_save, signals.post_save)
+    def test_earliest_alliance_stint_wins_across_multiple_corps(self):
+        """A move between two alliance corps counts from the first alliance corp."""
+        second_corp = EveCorporation.objects.create(
+            corporation_id=98000002,
+            name="Rattini Academy",
+            ticker="L3ARN",
+            alliance=self.alliance,
+        )
+        first = timezone.now() - timedelta(days=1000)
+        second = timezone.now() - timedelta(days=200)
+        EveCharacterCorporationHistory.objects.create(
+            character=self.character,
+            record_id=1,
+            corporation_id=second_corp.corporation_id,
+            start_date=first,
+        )
+        EveCharacterCorporationHistory.objects.create(
+            character=self.character,
+            record_id=2,
+            corporation_id=self.corp.corporation_id,
+            start_date=second,
+        )
+
+        self.assertEqual(member_join_date(self.user), first)
+
+    @factory.django.mute_signals(signals.pre_save, signals.post_save)
+    def test_falls_back_when_no_corp_history(self):
+        """With no corp history, tenure falls back to the community-status log."""
+        UserCommunityStatusHistory.objects.create(
+            user=self.user, to_status="active"
+        )
+        joined = member_join_date(self.user)
+        self.assertIsNotNone(joined)
+        # No corp history rows exist, so the fallback signal is used.
+        self.assertEqual(
+            EveCharacterCorporationHistory.objects.filter(
+                character=self.character
+            ).count(),
+            0,
+        )

--- a/frontend/app/src/pages/surveys/[id]/fill.astro
+++ b/frontend/app/src/pages/surveys/[id]/fill.astro
@@ -18,7 +18,6 @@ if (!user)
 const campaign_id = parseInt(Astro.params.id as string)
 
 import type {
-    GivebackCard,
     MemberContext,
     MyResponse,
     SurveyAnswerInput,
@@ -26,7 +25,6 @@ import type {
     SurveyQuestions,
 } from '@dtypes/survey'
 import {
-    get_giveback,
     get_my_response,
     get_survey_context,
     get_survey_questions,
@@ -36,7 +34,6 @@ import {
 let questions: SurveyQuestions | null = null
 let context: MemberContext | null = null
 let prior: MyResponse | null = null
-let giveback: GivebackCard | null = null
 let submitted = false
 let submit_error: string | null = null
 let data_fetching_error: any
@@ -103,7 +100,6 @@ if (Astro.request.method === 'POST' && questions) {
         )
         if (result.ok) {
             submitted = true
-            giveback = await get_giveback(auth_token as string, campaign_id)
         } else {
             submit_error = result.detail || 'Could not save your response.'
         }
@@ -138,7 +134,6 @@ import Button from '@components/blocks/Button.astro'
 import SurveyContextConfirm from '@components/blocks/survey/SurveyContextConfirm.astro'
 import SurveyContextPanel from '@components/blocks/survey/SurveyContextPanel.astro'
 import SurveyField from '@components/blocks/survey/SurveyField.astro'
-import SurveyGivebackCard from '@components/blocks/survey/SurveyGivebackCard.astro'
 import { get_player_icon, get_corporation_logo } from '@helpers/eve_image_server'
 
 const page_title = questions?.title ?? 'Community Survey'
@@ -163,15 +158,14 @@ const est_minutes = Math.max(3, Math.round((total_questions * 15) / 60))
             </ComponentBlock>
         )}
 
-        {submitted && giveback && (
+        {submitted && (
             <Flexblock gap="var(--space-xl)">
                 <ComponentBlock>
                     <Flexblock gap="var(--space-s)">
                         <h2>Thank you — your response is in. o7</h2>
-                        <p>Here's your quarter, and the alliance's.</p>
+                        <p>We've recorded your response.</p>
                     </Flexblock>
                 </ComponentBlock>
-                <SurveyGivebackCard giveback={giveback} />
                 <FlexInline>
                     <Button color="green" href={translatePath('/surveys')}>Done</Button>
                 </FlexInline>

--- a/frontend/app/src/pages/surveys/index.astro
+++ b/frontend/app/src/pages/surveys/index.astro
@@ -244,7 +244,10 @@ const page_title = 'Community Survey'
                         {can_manage && progress[c.id] && progress[c.id].corps.length > 0 && (
                             <div class="[ corp-progress ]">
                                 <span class="[ cp-title ]">Fill-out progress</span>
-                                {progress[c.id].corps.map((cp: any) => (
+                                {progress[c.id].corps
+                                    .slice()
+                                    .sort((a: any, b: any) => a.total - b.total)
+                                    .map((cp: any) => (
                                     <div class="[ cp-row ]">
                                         <img class="[ cp-logo ]" src={get_corporation_logo(cp.corporation_id, 32)} alt={cp.corporation_name} width="22" height="22" loading="lazy" />
                                         <span class="[ cp-name ]">{cp.corporation_name}</span>


### PR DESCRIPTION
## Summary

Three survey fixes, following up on the native quarterly community survey (#2669).

### 1. Tenure showed ~171d for everyone who joined before March 2026
`member_join_date()` used `community_status_history` as its top signal, but that table's `changed_at` is `auto_now_add` and the table only launched 2026-03-01 (migration `groups/0018`). For any member who joined earlier, tenure was capped at the *feature's* age (~171d today) instead of their real corp tenure — a member with 1376 days in Rattini Tribe showed 171d.

Fix: add `alliance_join_date()` in `corp_history.py`, reading the earliest ESI corporation-history `start_date` among the member's alliance corps, and make it the top signal in `member_join_date()`. The existing community-status → `EvePlayer.created_at` → `date_joined` chain stays as a fallback for members whose corp history hasn't synced.

Tenure is defined as **time since first joining an alliance corp**, which avoids overstating it for veterans who join fresh (it won't count their pre-alliance EVE career).

New regression tests in `surveys/tests/test_tenure.py` cover: corp history beats a recent community-status row, earliest alliance stint wins across a corp move, and the fallback path with no corp history.

### 2. Simplify the post-submit screen to an acknowledgement
The completion screen now just confirms the response was recorded, dropping the per-member "Your quarter" / "The alliance" giveback stat cards and the `get_giveback` fetch behind them. The `SurveyGivebackCard` component is left in place for later reuse.

### 3. Order the fill-out progress list by population
The leadership-only fill-out progress list is now ordered by corp population (`cp.total`) ascending, smallest to largest.

## Test plan
- [x] `manage.py test surveys.tests.test_tenure surveys.tests.test_autofill` — 5 passing (run in the mysqlclient app image against the dev db)
- [ ] Verify the completion screen renders the acknowledgement after submitting
- [ ] Verify the fill-out progress list ordering as leadership

🤖 Generated with [Claude Code](https://claude.com/claude-code)