### PR TITLE
Add Gukarla and Resbroko (Hydra) industry parks to the planner

### DIFF
--- a/backend/industry/helpers/facility_api.py
+++ b/backend/industry/helpers/facility_api.py
@@ -9,12 +9,16 @@ from industry.helpers.facility_profiles import (
     AMAMAKE_SYSTEM_NAME,
     AUNER_SYSTEM_NAME,
     BASGERIN_SYSTEM_NAME,
+    GUKARLA_SYSTEM_NAME,
+    RESBROKO_SYSTEM_NAME,
     FACILITY_PROFILES,
     FACILITY_SYSTEM_IDS,
     FacilityBonuses,
     JobClass,
+    RigFit,
     get_facility_profile,
     get_facility_reprocessing,
+    get_facility_structures,
     get_facility_system_id,
 )
 
@@ -22,51 +26,8 @@ FACILITY_SYSTEM_NAMES: Dict[str, str] = {
     "amamake": AMAMAKE_SYSTEM_NAME,
     "auner": AUNER_SYSTEM_NAME,
     "basgerin": BASGERIN_SYSTEM_NAME,
-}
-
-_JOB_CLASS_ROLE = {
-    JobClass.SHIP_MANUFACTURING: "ship",
-    JobClass.COMPONENT_MANUFACTURING: "component",
-    JobClass.REACTION: "reaction",
-}
-
-# EVE type IDs for freeport structures / fitted industry rigs.
-SOTIYO_TYPE_ID = 35827
-TATARA_TYPE_ID = 35836
-
-_RIG_SHIP_MFG = {
-    "name": "Standup XL-Set Ship Manufacturing Efficiency I",
-    "type_id": 37180,
-    "job_class": JobClass.SHIP_MANUFACTURING.value,
-}
-_RIG_THUKKER = {
-    "name": (
-        "Standup XL-Set Thukker Structure and Component "
-        "Manufacturing Efficiency"
-    ),
-    "type_id": 45548,
-    "job_class": JobClass.COMPONENT_MANUFACTURING.value,
-}
-_RIG_LAB = {
-    "name": "Standup XL-Set Laboratory Optimization I",
-    "type_id": 37183,
-    "job_class": None,
-}
-_RIG_REACTOR = {
-    "name": "Standup L-Set Reactor Efficiency II",
-    "type_id": 46497,
-    "job_class": JobClass.REACTION.value,
-}
-_RIG_REPROCESS = {
-    "name": "Standup L-Set Reprocessing Monitor II",
-    "type_id": 46640,
-    "job_class": None,
-}
-
-_JOB_CLASS_RIG = {
-    JobClass.SHIP_MANUFACTURING: _RIG_SHIP_MFG,
-    JobClass.COMPONENT_MANUFACTURING: _RIG_THUKKER,
-    JobClass.REACTION: _RIG_REACTOR,
+    "gukarla": GUKARLA_SYSTEM_NAME,
+    "resbroko": RESBROKO_SYSTEM_NAME,
 }
 
 _JOB_CLASS_LABEL = {
@@ -91,19 +52,6 @@ def facility_key_for_system(system_id: int) -> Optional[str]:
         if int(sid) == int(system_id):
             return key
     return None
-
-
-def _structure_kind(structure_name: str) -> str:
-    lower = structure_name.lower()
-    if "tatara" in lower or "reaction" in lower:
-        return "tatara"
-    return "sotiyo"
-
-
-def _structure_type_id(kind: str) -> int:
-    if kind == "tatara":
-        return TATARA_TYPE_ID
-    return SOTIYO_TYPE_ID
 
 
 def _pct_label(fraction: float) -> str:
@@ -146,70 +94,69 @@ def _job_class_effects(bonuses: FacilityBonuses) -> List[str]:
     return effects
 
 
-def _lab_rig_payload() -> Dict[str, Any]:
-    return {
-        **_RIG_LAB,
-        "effects": [
-            "Reduces laboratory research, copy, and invention job times",
-        ],
-    }
-
-
-def _reprocess_rig_payload(key: str) -> Dict[str, Any]:
+def _reprocess_effects(key: str) -> List[str]:
     rp = get_facility_reprocessing(key)
+    return [
+        f"Facility base yield {_pct_label(rp.facility_base_yield())}",
+        f"Max-skills refine ≈ {_pct_label(rp.refine_rate())}",
+        f"Reprocessing tax {_pct_label(rp.facility_tax)}",
+    ]
+
+
+def _rig_payload(
+    rig: RigFit,
+    key: str,
+    profile: Dict[JobClass, FacilityBonuses],
+) -> Dict[str, Any]:
+    if rig.job_class is not None:
+        bonuses = profile[rig.job_class]
+        effects = _me_te_effects(
+            _JOB_CLASS_LABEL[rig.job_class], bonuses.rig_me, bonuses.rig_te
+        )
+    elif rig.aux == "lab":
+        effects = [
+            "Reduces laboratory research, copy, and invention job times",
+        ]
+    elif rig.aux == "reprocess":
+        effects = _reprocess_effects(key)
+    else:
+        effects = []
     return {
-        **_RIG_REPROCESS,
-        "effects": [
-            f"Facility base yield {_pct_label(rp.facility_base_yield())}",
-            f"Max-skills refine ≈ {_pct_label(rp.refine_rate())}",
-            f"Reprocessing tax {_pct_label(rp.facility_tax)}",
-        ],
+        "name": rig.name,
+        "type_id": rig.type_id,
+        "job_class": rig.job_class.value if rig.job_class else None,
+        "effects": effects,
     }
+
+
+def _structure_role_effects_for(
+    structure_name: str, profile: Dict[JobClass, FacilityBonuses]
+) -> List[str]:
+    """Role ME/TE/ISK lines from the first job class using this structure."""
+    for job_class in JobClass:
+        bonuses = profile[job_class]
+        if bonuses.structure_name == structure_name:
+            return _structure_role_effects(bonuses)
+    return []
 
 
 def _structures_for_profile(
     key: str, profile: Dict[JobClass, FacilityBonuses]
 ) -> List[Dict[str, Any]]:
-    """Unique structures with type icons and fitted rigs for the UI."""
-    by_name: Dict[str, Dict[str, Any]] = {}
-    order: List[str] = []
-
-    for job_class in JobClass:
-        bonuses = profile[job_class]
-        name = bonuses.structure_name
-        if name not in by_name:
-            kind = _structure_kind(name)
-            by_name[name] = {
-                "role": _JOB_CLASS_ROLE[job_class],
-                "name": name,
-                "kind": kind,
-                "type_id": _structure_type_id(kind),
-                "effects": _structure_role_effects(bonuses),
-                "rigs": [],
-            }
-            order.append(name)
-
-        rig_meta = _JOB_CLASS_RIG[job_class]
-        label = _JOB_CLASS_LABEL[job_class]
-        by_name[name]["rigs"].append(
-            {
-                "name": rig_meta["name"],
-                "type_id": rig_meta["type_id"],
-                "job_class": rig_meta["job_class"],
-                "effects": _me_te_effects(
-                    label, bonuses.rig_me, bonuses.rig_te
-                ),
-            }
-        )
-
-    for name in order:
-        entry = by_name[name]
-        if entry["kind"] == "sotiyo":
-            entry["rigs"].append(_lab_rig_payload())
-        elif entry["kind"] == "tatara":
-            entry["rigs"].append(_reprocess_rig_payload(key))
-
-    return [by_name[name] for name in order]
+    """Fitted structures with type icons and rigs for the UI."""
+    return [
+        {
+            "role": structure.role,
+            "name": structure.name,
+            "kind": structure.kind,
+            "type_id": structure.type_id,
+            "effects": _structure_role_effects_for(structure.name, profile),
+            "rigs": [
+                _rig_payload(rig, key, profile) for rig in structure.rigs
+            ],
+        }
+        for structure in get_facility_structures(key)
+    ]
 
 
 def list_facility_summaries() -> List[Dict[str, Any]]:
@@ -224,9 +171,9 @@ def _reprocessing_payload(key: str) -> Dict[str, Any]:
     rp = get_facility_reprocessing(key)
     return {
         "structure_name": rp.structure_name,
-        "structure_type_id": TATARA_TYPE_ID,
+        "structure_type_id": rp.structure_type_id,
         "rig_name": rp.rig_name,
-        "rig_type_id": _RIG_REPROCESS["type_id"],
+        "rig_type_id": rp.rig_type_id,
         "facility_base_yield": rp.facility_base_yield(),
         "refine_rate": rp.refine_rate(),
         "facility_tax": rp.facility_tax,
@@ -260,15 +207,13 @@ def facility_detail(key: str) -> Dict[str, Any]:
     job_classes = []
     for job_class in JobClass:
         b = profile[job_class]
-        kind = _structure_kind(b.structure_name)
-        rig_meta = _JOB_CLASS_RIG[job_class]
         job_classes.append(
             {
                 "job_class": job_class.value,
                 "structure_name": b.structure_name,
-                "structure_type_id": _structure_type_id(kind),
-                "rig_name": rig_meta["name"],
-                "rig_type_id": rig_meta["type_id"],
+                "structure_type_id": b.structure_type_id,
+                "rig_name": b.rig_name,
+                "rig_type_id": b.rig_type_id,
                 "role_me": b.role_me,
                 "role_te": b.role_te,
                 "rig_me": b.rig_me,

--- a/backend/industry/helpers/facility_profiles.py
+++ b/backend/industry/helpers/facility_profiles.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict
+from typing import Dict, List, Optional, Tuple
 
 
 class JobClass(str, Enum):
@@ -57,6 +57,12 @@ class FacilityBonuses:
     # Multiplicative bonus on system-index gross cost (e.g. -0.5 for FW -50%).
     # Does not apply to facility tax or SCC surcharge.
     system_cost_bonus: float = 0.0
+    # Structure hull + representative rig for this job class (UI / API only;
+    # the numeric bonuses above are what the planner actually costs with).
+    structure_kind: str = "sotiyo"
+    structure_type_id: int = 0
+    rig_name: str = ""
+    rig_type_id: int = 0
 
     @property
     def effective_me(self) -> float:
@@ -89,6 +95,10 @@ class ReprocessingProfile:
     structure_modifier: float = 0.0
     # Corp reprocessing tax on Tatara output value (e.g. 2.5%).
     facility_tax: float = 0.0
+    # Structure hull + representative rig (UI / API only).
+    structure_kind: str = "tatara"
+    structure_type_id: int = 0
+    rig_type_id: int = 0
 
     def facility_base_yield(self) -> float:
         """Structure + rig yield as a fraction (before character skills)."""
@@ -126,6 +136,102 @@ class ReprocessingProfile:
         return math.floor(output_value * self.facility_tax)
 
 
+@dataclass(frozen=True)
+class RigFit:
+    """A fitted Standup rig, for the planner facility card (display only)."""
+
+    name: str
+    type_id: int
+    # Job class this rig accelerates (drives the ME/TE effect label). None for
+    # auxiliary rigs whose bonus the planner does not cost with:
+    #   aux="lab" (research), aux="reprocess" (reprocessing yield).
+    job_class: Optional[JobClass] = None
+    aux: str = ""
+
+
+@dataclass(frozen=True)
+class StructureFit:
+    """A fitted freeport structure with its full rig complement (display)."""
+
+    role: str  # "ship" | "component" | "reaction" | "reprocessing"
+    name: str  # matches the FacilityBonuses / ReprocessingProfile it backs
+    kind: str  # "sotiyo" | "azbel" | "athanor" | "tatara"
+    type_id: int
+    rigs: Tuple[RigFit, ...] = ()
+
+
+# --- EVE type IDs: freeport structures + fitted industry rigs ---
+SOTIYO_TYPE_ID = 35827
+TATARA_TYPE_ID = 35836
+AZBEL_TYPE_ID = 35826
+ATHANOR_TYPE_ID = 35835
+
+# Sotiyo + Tatara stack (Amamake / Auner / Basgerin).
+RIG_XL_SHIP_MFG = RigFit(
+    "Standup XL-Set Ship Manufacturing Efficiency I",
+    37180,
+    JobClass.SHIP_MANUFACTURING,
+)
+RIG_XL_THUKKER = RigFit(
+    "Standup XL-Set Thukker Structure and Component Manufacturing Efficiency",
+    45548,
+    JobClass.COMPONENT_MANUFACTURING,
+)
+RIG_XL_LAB = RigFit(
+    "Standup XL-Set Laboratory Optimization I", 37183, None, aux="lab"
+)
+RIG_L_REACTOR_EFF = RigFit(
+    "Standup L-Set Reactor Efficiency II", 46497, JobClass.REACTION
+)
+RIG_L_REPROCESS_MONITOR = RigFit(
+    "Standup L-Set Reprocessing Monitor II", 46640, None, aux="reprocess"
+)
+
+# Azbel + twin Athanor stack (Gukarla / Resbroko "Hydra" freeports).
+RIG_L_CAP_SHIP_MFG = RigFit(
+    "Standup L-Set Capital Ship Manufacturing Efficiency I",
+    37173,
+    JobClass.SHIP_MANUFACTURING,
+)
+RIG_L_BASIC_CAP_COMPONENT = RigFit(
+    "Standup L-Set Basic Capital Component Manufacturing Efficiency I",
+    43718,
+    JobClass.COMPONENT_MANUFACTURING,
+)
+RIG_L_THUKKER_ADV_COMPONENT = RigFit(
+    "Standup L-Set Thukker Advanced Component Manufacturing Efficiency",
+    45641,
+    JobClass.COMPONENT_MANUFACTURING,
+)
+RIG_M_BIOCHEMICAL_REACTOR = RigFit(
+    "Standup M-Set Biochemical Reactor Material Efficiency I",
+    46494,
+    JobClass.REACTION,
+)
+RIG_M_COMPOSITE_REACTOR = RigFit(
+    "Standup M-Set Composite Reactor Material Efficiency I",
+    46486,
+    JobClass.REACTION,
+)
+RIG_M_HYBRID_REACTOR = RigFit(
+    "Standup M-Set Hybrid Reactor Material Efficiency I",
+    46490,
+    JobClass.REACTION,
+)
+RIG_M_ASTEROID_GRADING = RigFit(
+    "Standup M-Set Asteroid Ore Grading Processor I",
+    46633,
+    None,
+    aux="reprocess",
+)
+RIG_M_ICE_GRADING = RigFit(
+    "Standup M-Set Ice Grading Processor I", 46635, None, aux="reprocess"
+)
+RIG_M_MOON_GRADING = RigFit(
+    "Standup M-Set Moon Ore Grading Processor I", 46637, None, aux="reprocess"
+)
+
+
 # --- Rig base bonuses (before security multiplier) ---
 # Standup XL-Set Ship Manufacturing Efficiency I
 _SHIP_RIG_ME_BASE = 0.02
@@ -143,6 +249,34 @@ _REACTOR_RIG_TE_BASE = 0.24
 
 _LOWSEC_ENGINEERING_MULT = 1.9
 _LOWSEC_REACTOR_MULT = 1.0
+
+# --- Hydra (Azbel + Athanor) rig base bonuses ---
+# Standup L-Set Capital Ship Manufacturing Efficiency I (ESI attr 2593/2594).
+# NOTE: this rig only benefits *capital* ship builds; the planner applies it
+# uniformly to the SHIP_MANUFACTURING class (same limitation the Sotiyo XL ship
+# rig does not have — that one benefits all ships), so sub-capital estimates in
+# a Hydra Azbel are slightly optimistic. The Azbel is a capital yard in practice.
+_CAP_SHIP_RIG_ME_BASE = 0.02
+_CAP_SHIP_RIG_TE_BASE = 0.20
+
+# Standup L-Set Basic / Thukker capital component rigs (ESI attr 2593/2594).
+_CAP_COMPONENT_RIG_ME_BASE = 0.02
+_CAP_COMPONENT_RIG_TE_BASE = 0.20
+
+# Standup M-Set <type> Reactor Material Efficiency I (ESI attr 2714 = -2.0);
+# no time bonus. Lowsec reactor multiplier is 1.0 (as Reactor Efficiency II).
+_MSET_REACTOR_RIG_ME_BASE = 0.02
+
+# Azbel engineering-complex role bonuses (ESI attr 2600/2601/2602 = .99/.96/.80).
+_AZBEL_ROLE_ME = 0.01
+_AZBEL_ROLE_TE = 0.20
+_AZBEL_ISK_BONUS = 0.04
+
+# Athanor refinery running reactions: no reaction ME/time role bonus (only the
+# Tatara carries the -25% reaction-time role bonus).
+_ATHANOR_REACTION_ROLE_ME = 0.0
+_ATHANOR_REACTION_ROLE_TE = 0.0
+_ATHANOR_REACTION_ISK_BONUS = 0.0
 
 # Sotiyo manufacturing role bonuses
 _SOTIYO_ROLE_ME = 0.01
@@ -165,6 +299,15 @@ _TATARA_STRUCTURE_MODIFIER = 0.055
 _REPROCESS_MONITOR_II_RIG_MODIFIER = 3.0  # T2
 _LOWSEC_REPROCESS_SECURITY_MODIFIER = 0.06
 
+# Reprocessing: Athanor + Standup M-Set Ore Grading Processors (Gukarla / Resbroko).
+# Athanor structure modifier is 0.02 (vs Tatara 0.055). The grading-processor rig
+# modifier is derived on the same scale the Monitor II uses: ESI refiningYield
+# (attr 717) minus the 0.50 base, ×100 — Monitor II 0.53 → 3.0 calibrates it, so
+# the M-Set grading rig 0.51 → 1.0. The three grading rigs cover asteroid / ice /
+# moon ore respectively (full ore coverage), each contributing the same modifier.
+_ATHANOR_STRUCTURE_MODIFIER = 0.02
+_GRADING_PROCESSOR_RIG_MODIFIER = 1.0
+
 AMAMAKE_SYSTEM_ID = 30002537
 AMAMAKE_SYSTEM_NAME = "Amamake"
 # FW infrastructure hub level 5: -50% facility pricing (applies system-wide).
@@ -180,6 +323,16 @@ AUNER_SYSTEM_NAME = "Auner"
 _AUNER_FACILITY_TAX = 0.01
 _AUNER_REPROCESSING_TAX = 0.03
 
+GUKARLA_SYSTEM_ID = 30002102
+GUKARLA_SYSTEM_NAME = "Gukarla"
+
+RESBROKO_SYSTEM_ID = 30002056
+RESBROKO_SYSTEM_NAME = "Resbroko"
+
+# Both Hydra freeports sit in FW systems upgraded to -50% facility pricing,
+# and use the same corp taxes as Amamake / Basgerin.
+HYDRA_FW_SYSTEM_COST_BONUS = -0.50
+
 
 def _lowsec_tatara_reprocessing(
     tatara_name: str,
@@ -188,12 +341,35 @@ def _lowsec_tatara_reprocessing(
 ) -> ReprocessingProfile:
     return ReprocessingProfile(
         structure_name=tatara_name,
-        rig_name="Standup L-Set Reprocessing Monitor II",
+        rig_name=RIG_L_REPROCESS_MONITOR.name,
         base_yield_percent=50.0,
         rig_modifier=_REPROCESS_MONITOR_II_RIG_MODIFIER,
         security_modifier=_LOWSEC_REPROCESS_SECURITY_MODIFIER,
         structure_modifier=_TATARA_STRUCTURE_MODIFIER,
         facility_tax=facility_tax,
+        structure_kind="tatara",
+        structure_type_id=TATARA_TYPE_ID,
+        rig_type_id=RIG_L_REPROCESS_MONITOR.type_id,
+    )
+
+
+def _athanor_grading_reprocessing(
+    athanor_name: str,
+    *,
+    facility_tax: float = _FREEPORT_REPROCESSING_TAX,
+) -> ReprocessingProfile:
+    """Athanor + M-Set Ore Grading Processors (Gukarla / Resbroko)."""
+    return ReprocessingProfile(
+        structure_name=athanor_name,
+        rig_name="Standup M-Set Ore Grading Processors (Asteroid / Ice / Moon)",
+        base_yield_percent=50.0,
+        rig_modifier=_GRADING_PROCESSOR_RIG_MODIFIER,
+        security_modifier=_LOWSEC_REPROCESS_SECURITY_MODIFIER,
+        structure_modifier=_ATHANOR_STRUCTURE_MODIFIER,
+        facility_tax=facility_tax,
+        structure_kind="athanor",
+        structure_type_id=ATHANOR_TYPE_ID,
+        rig_type_id=RIG_M_ASTEROID_GRADING.type_id,
     )
 
 
@@ -222,6 +398,10 @@ def _lowsec_freeport_bonuses(
             structure_isk_bonus=_SOTIYO_ISK_BONUS,
             facility_tax=facility_tax,
             system_cost_bonus=system_cost_bonus,
+            structure_kind="sotiyo",
+            structure_type_id=SOTIYO_TYPE_ID,
+            rig_name=RIG_XL_SHIP_MFG.name,
+            rig_type_id=RIG_XL_SHIP_MFG.type_id,
         ),
         JobClass.COMPONENT_MANUFACTURING: FacilityBonuses(
             structure_name=sotiyo_name,
@@ -232,6 +412,10 @@ def _lowsec_freeport_bonuses(
             structure_isk_bonus=_SOTIYO_ISK_BONUS,
             facility_tax=facility_tax,
             system_cost_bonus=system_cost_bonus,
+            structure_kind="sotiyo",
+            structure_type_id=SOTIYO_TYPE_ID,
+            rig_name=RIG_XL_THUKKER.name,
+            rig_type_id=RIG_XL_THUKKER.type_id,
         ),
         JobClass.REACTION: FacilityBonuses(
             structure_name=tatara_name,
@@ -242,6 +426,70 @@ def _lowsec_freeport_bonuses(
             structure_isk_bonus=_TATARA_ISK_BONUS,
             facility_tax=facility_tax,
             system_cost_bonus=system_cost_bonus,
+            structure_kind="tatara",
+            structure_type_id=TATARA_TYPE_ID,
+            rig_name=RIG_L_REACTOR_EFF.name,
+            rig_type_id=RIG_L_REACTOR_EFF.type_id,
+        ),
+    }
+
+
+def _hydra_freeport_bonuses(
+    *,
+    azbel_name: str,
+    reactions_athanor_name: str,
+    system_cost_bonus: float = HYDRA_FW_SYSTEM_COST_BONUS,
+    facility_tax: float = _FREEPORT_FACILITY_TAX,
+) -> Dict[JobClass, FacilityBonuses]:
+    """Azbel manufacturing + Athanor reactions stack (Gukarla / Resbroko)."""
+    cap_ship_me = _CAP_SHIP_RIG_ME_BASE * _LOWSEC_ENGINEERING_MULT
+    cap_ship_te = _CAP_SHIP_RIG_TE_BASE * _LOWSEC_ENGINEERING_MULT
+    cap_comp_me = _CAP_COMPONENT_RIG_ME_BASE * _LOWSEC_ENGINEERING_MULT
+    cap_comp_te = _CAP_COMPONENT_RIG_TE_BASE * _LOWSEC_ENGINEERING_MULT
+    reactor_me = _MSET_REACTOR_RIG_ME_BASE * _LOWSEC_REACTOR_MULT
+
+    return {
+        JobClass.SHIP_MANUFACTURING: FacilityBonuses(
+            structure_name=azbel_name,
+            role_me=_AZBEL_ROLE_ME,
+            role_te=_AZBEL_ROLE_TE,
+            rig_me=cap_ship_me,
+            rig_te=cap_ship_te,
+            structure_isk_bonus=_AZBEL_ISK_BONUS,
+            facility_tax=facility_tax,
+            system_cost_bonus=system_cost_bonus,
+            structure_kind="azbel",
+            structure_type_id=AZBEL_TYPE_ID,
+            rig_name=RIG_L_CAP_SHIP_MFG.name,
+            rig_type_id=RIG_L_CAP_SHIP_MFG.type_id,
+        ),
+        JobClass.COMPONENT_MANUFACTURING: FacilityBonuses(
+            structure_name=azbel_name,
+            role_me=_AZBEL_ROLE_ME,
+            role_te=_AZBEL_ROLE_TE,
+            rig_me=cap_comp_me,
+            rig_te=cap_comp_te,
+            structure_isk_bonus=_AZBEL_ISK_BONUS,
+            facility_tax=facility_tax,
+            system_cost_bonus=system_cost_bonus,
+            structure_kind="azbel",
+            structure_type_id=AZBEL_TYPE_ID,
+            rig_name=RIG_L_THUKKER_ADV_COMPONENT.name,
+            rig_type_id=RIG_L_THUKKER_ADV_COMPONENT.type_id,
+        ),
+        JobClass.REACTION: FacilityBonuses(
+            structure_name=reactions_athanor_name,
+            role_me=_ATHANOR_REACTION_ROLE_ME,
+            role_te=_ATHANOR_REACTION_ROLE_TE,
+            rig_me=reactor_me,
+            rig_te=0.0,
+            structure_isk_bonus=_ATHANOR_REACTION_ISK_BONUS,
+            facility_tax=facility_tax,
+            system_cost_bonus=system_cost_bonus,
+            structure_kind="athanor",
+            structure_type_id=ATHANOR_TYPE_ID,
+            rig_name=RIG_M_BIOCHEMICAL_REACTOR.name,
+            rig_type_id=RIG_M_BIOCHEMICAL_REACTOR.type_id,
         ),
     }
 
@@ -273,10 +521,37 @@ def _auner_bonuses() -> Dict[JobClass, FacilityBonuses]:
     )
 
 
+# Hydra freeport structure names (shared between bonuses, reprocessing, and the
+# display registry so they line up).
+GUKARLA_AZBEL_NAME = "Gukarla – Hydra Manufacturing (Azbel)"
+GUKARLA_REACTIONS_NAME = "Gukarla – Hydra Reactions (Athanor)"
+GUKARLA_REPROCESSING_NAME = "Gukarla – Hydra Reprocessing (Athanor)"
+RESBROKO_AZBEL_NAME = "Resbroko – Hydra Manufacturing (Azbel)"
+RESBROKO_REACTIONS_NAME = "Resbroko – Hydra Reactions (Athanor)"
+RESBROKO_REPROCESSING_NAME = "Resbroko – Hydra Reprocessing (Athanor)"
+
+
+def _gukarla_bonuses() -> Dict[JobClass, FacilityBonuses]:
+    return _hydra_freeport_bonuses(
+        azbel_name=GUKARLA_AZBEL_NAME,
+        reactions_athanor_name=GUKARLA_REACTIONS_NAME,
+    )
+
+
+def _resbroko_bonuses() -> Dict[JobClass, FacilityBonuses]:
+    # Same fit as Gukarla (Digital Blink: "resbroko is the same setup").
+    return _hydra_freeport_bonuses(
+        azbel_name=RESBROKO_AZBEL_NAME,
+        reactions_athanor_name=RESBROKO_REACTIONS_NAME,
+    )
+
+
 FACILITY_PROFILES: Dict[str, Dict[JobClass, FacilityBonuses]] = {
     "amamake": _amamake_bonuses(),
     "auner": _auner_bonuses(),
     "basgerin": _basgerin_bonuses(),
+    "gukarla": _gukarla_bonuses(),
+    "resbroko": _resbroko_bonuses(),
 }
 
 FACILITY_REPROCESSING: Dict[str, ReprocessingProfile] = {
@@ -290,6 +565,8 @@ FACILITY_REPROCESSING: Dict[str, ReprocessingProfile] = {
     "basgerin": _lowsec_tatara_reprocessing(
         "Basgerin – Reactions & Reprocessing (Tatara)"
     ),
+    "gukarla": _athanor_grading_reprocessing(GUKARLA_REPROCESSING_NAME),
+    "resbroko": _athanor_grading_reprocessing(RESBROKO_REPROCESSING_NAME),
 }
 
 # Solar system used for live ESI industry cost indices per facility profile.
@@ -297,7 +574,107 @@ FACILITY_SYSTEM_IDS: Dict[str, int] = {
     "amamake": AMAMAKE_SYSTEM_ID,
     "auner": AUNER_SYSTEM_ID,
     "basgerin": BASGERIN_SYSTEM_ID,
+    "gukarla": GUKARLA_SYSTEM_ID,
+    "resbroko": RESBROKO_SYSTEM_ID,
 }
+
+
+def _sotiyo_tatara_structures(
+    sotiyo_name: str, tatara_name: str
+) -> List[StructureFit]:
+    """Display fit for the Amamake / Auner / Basgerin stack."""
+    return [
+        StructureFit(
+            role="ship",
+            name=sotiyo_name,
+            kind="sotiyo",
+            type_id=SOTIYO_TYPE_ID,
+            rigs=(RIG_XL_SHIP_MFG, RIG_XL_THUKKER, RIG_XL_LAB),
+        ),
+        StructureFit(
+            role="reaction",
+            name=tatara_name,
+            kind="tatara",
+            type_id=TATARA_TYPE_ID,
+            rigs=(RIG_L_REACTOR_EFF, RIG_L_REPROCESS_MONITOR),
+        ),
+    ]
+
+
+def _hydra_structures(
+    azbel_name: str, reactions_name: str, reprocessing_name: str
+) -> List[StructureFit]:
+    """Display fit for the Gukarla / Resbroko stack (Azbel + twin Athanors)."""
+    return [
+        StructureFit(
+            role="ship",
+            name=azbel_name,
+            kind="azbel",
+            type_id=AZBEL_TYPE_ID,
+            rigs=(
+                RIG_L_CAP_SHIP_MFG,
+                RIG_L_BASIC_CAP_COMPONENT,
+                RIG_L_THUKKER_ADV_COMPONENT,
+            ),
+        ),
+        StructureFit(
+            role="reaction",
+            name=reactions_name,
+            kind="athanor",
+            type_id=ATHANOR_TYPE_ID,
+            rigs=(
+                RIG_M_BIOCHEMICAL_REACTOR,
+                RIG_M_COMPOSITE_REACTOR,
+                RIG_M_HYBRID_REACTOR,
+            ),
+        ),
+        StructureFit(
+            role="reprocessing",
+            name=reprocessing_name,
+            kind="athanor",
+            type_id=ATHANOR_TYPE_ID,
+            rigs=(
+                RIG_M_ASTEROID_GRADING,
+                RIG_M_ICE_GRADING,
+                RIG_M_MOON_GRADING,
+            ),
+        ),
+    ]
+
+
+# Fitted structures + rigs per facility, for the planner facility card.
+FACILITY_STRUCTURES: Dict[str, List[StructureFit]] = {
+    "amamake": _sotiyo_tatara_structures(
+        "Amamake – Police Weapons Facility (Sotiyo)",
+        "Amamake – Reactions & Reprocessing (Tatara)",
+    ),
+    "auner": _sotiyo_tatara_structures(
+        "Auner – Guru Forge (Sotiyo)",
+        "Auner – Guru Foundry (Tatara)",
+    ),
+    "basgerin": _sotiyo_tatara_structures(
+        "Basgerin – The Forgery (Sotiyo)",
+        "Basgerin – Reactions & Reprocessing (Tatara)",
+    ),
+    "gukarla": _hydra_structures(
+        GUKARLA_AZBEL_NAME, GUKARLA_REACTIONS_NAME, GUKARLA_REPROCESSING_NAME
+    ),
+    "resbroko": _hydra_structures(
+        RESBROKO_AZBEL_NAME,
+        RESBROKO_REACTIONS_NAME,
+        RESBROKO_REPROCESSING_NAME,
+    ),
+}
+
+
+def get_facility_structures(name: str) -> List[StructureFit]:
+    """Fitted structure list for a facility profile (display / API)."""
+    key = name.lower().strip()
+    if key not in FACILITY_STRUCTURES:
+        known = ", ".join(sorted(FACILITY_STRUCTURES))
+        raise ValueError(f"Unknown facility profile {name!r}. Known: {known}")
+    return FACILITY_STRUCTURES[key]
+
 
 # Thukker enhanced capital-component ME (lowsec), for Advanced Capital Construction
 # Components. Not used for Typhoon T1 advanced components (group Construction Components).

--- a/backend/industry/tests/test_planner_endpoints.py
+++ b/backend/industry/tests/test_planner_endpoints.py
@@ -22,6 +22,8 @@ from industry.helpers.facility_profiles import (
     AMAMAKE_SYSTEM_ID,
     AUNER_SYSTEM_ID,
     BASGERIN_SYSTEM_ID,
+    GUKARLA_SYSTEM_ID,
+    RESBROKO_SYSTEM_ID,
 )
 from industry.helpers.reprocessing_skills import (
     SKILL_COHERENT_ORE_PROCESSING,
@@ -51,14 +53,20 @@ class PlannerFacilitiesEndpointTestCase(TestCase):
         response = self.client.get(f"{BASE}/facilities")
         self.assertEqual(response.status_code, 200)
         keys = {row["key"] for row in response.json()}
-        self.assertEqual(keys, {"amamake", "auner", "basgerin"})
+        self.assertEqual(
+            keys,
+            {"amamake", "auner", "basgerin", "gukarla", "resbroko"},
+        )
 
     def test_facilities_list_contains_amamake_and_basgerin(self):
         response = self.client.get(f"{BASE}/facilities", **self.auth)
         self.assertEqual(response.status_code, 200)
         data = response.json()
         keys = {row["key"] for row in data}
-        self.assertEqual(keys, {"amamake", "auner", "basgerin"})
+        self.assertEqual(
+            keys,
+            {"amamake", "auner", "basgerin", "gukarla", "resbroko"},
+        )
         amamake = next(r for r in data if r["key"] == "amamake")
         self.assertEqual(amamake["system_id"], AMAMAKE_SYSTEM_ID)
         self.assertEqual(amamake["system_cost_bonus"], -0.5)
@@ -107,6 +115,47 @@ class PlannerFacilitiesEndpointTestCase(TestCase):
         )
         self.assertAlmostEqual(auner["reprocessing"]["facility_tax"], 0.03)
         self.assertIn("Guru Forge", auner["structures"][0]["name"])
+
+    def test_hydra_freeports_gukarla_and_resbroko(self):
+        response = self.client.get(f"{BASE}/facilities", **self.auth)
+        self.assertEqual(response.status_code, 200)
+        data = {row["key"]: row for row in response.json()}
+
+        expected_systems = {
+            "gukarla": GUKARLA_SYSTEM_ID,
+            "resbroko": RESBROKO_SYSTEM_ID,
+        }
+        for key, system_id in expected_systems.items():
+            park = data[key]
+            self.assertEqual(park["system_id"], system_id)
+            # Both Hydra freeports are FW-upgraded (-50% facility pricing),
+            # with Amamake/Basgerin corp taxes.
+            self.assertEqual(park["system_cost_bonus"], -0.5)
+            self.assertAlmostEqual(park["facility_tax"], 0.0075)
+
+            # Azbel manufacturing + two Athanor refineries (reactions + reprocessing).
+            kinds = [s["kind"] for s in park["structures"]]
+            self.assertEqual(kinds, ["azbel", "athanor", "athanor"])
+            azbel = park["structures"][0]
+            self.assertEqual(azbel["type_id"], 35826)
+            azbel_rig_ids = {r["type_id"] for r in azbel["rigs"]}
+            self.assertEqual(azbel_rig_ids, {37173, 43718, 45641})
+
+            reactions = park["structures"][1]
+            self.assertEqual(reactions["type_id"], 35835)
+            self.assertEqual(
+                {r["type_id"] for r in reactions["rigs"]},
+                {46494, 46486, 46490},
+            )
+
+            # Athanor grading-processor reprocessing (weaker than the Tatara).
+            self.assertEqual(park["reprocessing"]["structure_type_id"], 35835)
+            self.assertEqual(park["reprocessing"]["rig_type_id"], 46633)
+            expected_refine = (51.0 * 1.06 * 1.02 / 100.0) * 1.15 * 1.10 * 1.10
+            self.assertAlmostEqual(
+                park["reprocessing"]["refine_rate"], expected_refine, places=6
+            )
+            self.assertAlmostEqual(park["reprocessing"]["facility_tax"], 0.025)
 
     @patch("industry.helpers.facility_api.fetch_system_cost_indices")
     def test_facility_detail_includes_live_indexes(self, fetch_indices):


### PR DESCRIPTION
Adds two new alliance freeport profiles — **Gukarla** and **Resbroko** (the "Hydra" freeports) — to the industry planner, modeled with faithful, ESI-derived bonuses.

## What's new

| | Gukarla (`30002102`) / Resbroko (`30002056`) |
|---|---|
| **Manufacturing** | **Azbel** — role ME 1% / TE 20% / cost −4%; L-Set Capital Ship (37173), Basic Capital Component (43718), Thukker Advanced Component (45641) rigs → rig ME +3.8% / TE +38% |
| **Reactions** | **Athanor** — M-Set Biochemical / Composite / Hybrid reactor ME rigs → ME +2%, no TE (Athanor has no reaction-time role bonus — only the Tatara does) |
| **Reprocessing** | **Athanor** — M-Set Asteroid / Ice / Moon grading processors → ~76.7% max-skills refine |
| **Taxes / FW** | 0.75% facility, 2.5% reprocessing; both FW −50% facility pricing (same as Amamake) |

All type/system IDs and bonus values were resolved and calibrated against ESI (`/universe/ids`, `/universe/types`).

### Why the reprocessing is lower than Amamake (~76.7% vs ~82.5%)
Two independent factors, both faithful to the posted fit:
- **Structure:** Athanor structure yield bonus is +2% vs the Tatara's +5.5%.
- **Rig tech level:** the fit lists Tech **I** grading processors; Amamake runs the Tech **II** Monitor. At equal tech the grading processor and monitor give the identical bonus (ESI `refiningYield` 0.51 for I, 0.53 for II) — rig *size* (M vs L) doesn't affect yield.

## Implementation

To support parks whose fits differ from the existing Sotiyo+Tatara stack, structure/rig identity now lives on the profile data:
- New `RigFit` / `StructureFit` types and a `FACILITY_STRUCTURES` registry in `facility_profiles.py`.
- `facility_api.py` response-shaping is now **data-driven per park** instead of hardcoding `sotiyo`/`tatara` globals.
- **Amamake / Auner / Basgerin output is byte-identical** (verified — the refactor is non-breaking).
- **No frontend change:** the planner renders structures/rigs from the API and already recognizes `azbel`/`athanor`.

## Known limitation
The planner applies each rig's ME/TE uniformly across its job class, so the Azbel's capital-only rigs slightly over-credit sub-capital builds. Capital builds (the Azbel's actual purpose) are priced correctly. Scoping rigs to the exact groups they affect is a follow-up (a group-scoped resolver in `build_planner`) — noted for a later PR.

## Testing
- Full `industry` suite: **440 tests pass** (`--settings=app.settings_test`).
- Added `test_hydra_freeports_gukarla_and_resbroko`; updated the facility key-set assertions.
- `black` + `flake8` clean (pre-commit + CI lint passed on push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)