### PR TITLE
Persist planner build-vs-buy choices when switching location

### DIFF
--- a/frontend/app/src/pages/industry/orders/planner.astro
+++ b/frontend/app/src/pages/industry/orders/planner.astro
@@ -349,10 +349,12 @@ const bucket_labels = JSON.stringify({
                                     refine_key !== this._loaded_refine_key
 
                                 if (facility_changed) {
-                                    this.withSuspendedWatch(() => {
-                                        this.subitem_catalog = []
-                                        this.build_toggles = {}
-                                    })
+                                    // Persist build-vs-buy choices across a
+                                    // location change: build_toggles and
+                                    // subitem_catalog are keyed by product_type_id
+                                    // and the build tree is facility-independent,
+                                    // so runPlan/syncSubitemsFromJobs reconcile them
+                                    // (refreshed runs, defaults only for new items).
                                     this._loaded_facility_key = this.facility_key
                                     await this.loadFacility()
                                     if (gen !== this._plan_generation)


### PR DESCRIPTION
## Problem
In the industry planner, changing the **facility/location** wiped every build-vs-buy choice the user had made. `applyPlannerInputs` reset `build_toggles = {}` and `subitem_catalog = []` on any facility change, so switching location forced you to re-toggle the whole BOM.

## Fix
Drop that reset. Both `build_toggles` and `subitem_catalog` are keyed by `product_type_id`, and the build tree is **facility-independent** (it comes from the product recipe, not the structure). `runPlan` → `syncSubitemsFromJobs` already reconciles them idempotently — it refreshes run counts for jobs in the new plan and only assigns a default toggle when one is `undefined` (i.e. a genuinely new sub-item). So the choices carry over cleanly.

Everything else on the form (ME/TE, quantity, compression, implants, stock paste, isk/LP) was already `x-model`-bound and persisted — only the build toggles were being discarded.

### Why keep `subitem_catalog` too (not just `build_toggles`)
`subitem_catalog` holds the toggleable rows, populated from the first unrestricted plan. If it were cleared while toggles were kept, "buy" items would be excluded from the next plan, never return as jobs, and disappear from the catalog — leaving the user unable to switch them back to "build". Keeping both is required.

## Scope
One-file change ([planner.astro](frontend/app/src/pages/industry/orders/planner.astro)); no API or schema change. `loadFacility()` and the facility cost/refine refresh still run on a location change as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)