### PR TITLE
Fix Sentry modal, planner, dialog, and offboard failures

### DIFF
--- a/backend/access_lists/migrations/0003_remove_stale_celery_beat_tasks.py
+++ b/backend/access_lists/migrations/0003_remove_stale_celery_beat_tasks.py
@@ -1,0 +1,25 @@
+# Beat still enqueues the deleted executor access-list sync task.
+
+from django.db import migrations
+
+STALE_TASKS = ("access_lists.tasks.sync_executor_access_lists_task",)
+
+
+def remove_stale_periodic_tasks(apps, schema_editor):
+    PeriodicTask = apps.get_model("django_celery_beat", "PeriodicTask")
+    PeriodicTask.objects.filter(task__in=STALE_TASKS).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("access_lists", "0002_delete_eveaccesslist_models"),
+        ("django_celery_beat", "0019_alter_periodictasks_options"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            remove_stale_periodic_tasks,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/backend/groups/migrations/0027_drop_legacy_mumble_access_table.py
+++ b/backend/groups/migrations/0027_drop_legacy_mumble_access_table.py
@@ -1,0 +1,30 @@
+# Drop leftover Mumble credential table after the mumble app was hard-deleted.
+
+from django.db import migrations
+
+LEGACY_TABLES = ("mumble_mumbleaccess",)
+
+
+def drop_legacy_mumble_tables(apps, schema_editor):
+    connection = schema_editor.connection
+    existing = set(connection.introspection.table_names())
+    with connection.cursor() as cursor:
+        for table in LEGACY_TABLES:
+            if table in existing:
+                cursor.execute(
+                    f"DROP TABLE IF EXISTS {connection.ops.quote_name(table)}"
+                )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("groups", "0026_remove_mumble_feature_and_tasks"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            drop_legacy_mumble_tables,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/backend/users/helpers.py
+++ b/backend/users/helpers.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 
 import requests
 from django.contrib.auth.models import Group, User, Permission
+from django.db import connection
 
 from discord.client import DiscordClient
 from discord.models import DiscordRole, DiscordUser
@@ -15,6 +16,25 @@ from .schemas import EveCharacterSchema, UserProfileSchema
 
 logger = logging.getLogger(__name__)
 
+# Left behind when the mumble Django app was hard-deleted. Production still has
+# the table with a non-cascading FK to auth_user, which blocks User.delete().
+LEGACY_MUMBLE_ACCESS_TABLE = "mumble_mumbleaccess"
+
+
+def _delete_legacy_mumble_access(user_id: int) -> None:
+    """Delete leftover MumbleAccess rows for this user, if the table exists."""
+    if (
+        LEGACY_MUMBLE_ACCESS_TABLE
+        not in connection.introspection.table_names()
+    ):
+        return
+    quoted = connection.ops.quote_name(LEGACY_MUMBLE_ACCESS_TABLE)
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"DELETE FROM {quoted} WHERE user_id = %s",
+            [user_id],
+        )
+
 
 def offboard_user(user_id: int):
     """
@@ -25,6 +45,7 @@ def offboard_user(user_id: int):
     """
     with disable_discord_group_sync():
         user = User.objects.get(id=user_id)
+        _delete_legacy_mumble_access(user_id)
         user.delete()
 
 

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch, MagicMock
 
 from django.conf import settings
+from django.db import connection
 from django.db.models import signals
 from django.test import Client
 from django.contrib.auth.models import User
@@ -14,6 +15,7 @@ from eveonline.helpers.characters import (
     set_primary_character,
     user_primary_character,
 )
+from users.helpers import LEGACY_MUMBLE_ACCESS_TABLE, offboard_user
 from users.router import callback
 
 # Create your tests here.
@@ -316,3 +318,46 @@ class UserRouterTestCase(TestCase):
             "mobile://auth/callback",
             self.client.session["authentication_redirect_url"],
         )
+
+
+class OffboardUserTestCase(TestCase):
+    """Offboard must succeed even with leftover mumble_mumbleaccess rows."""
+
+    def _create_legacy_mumble_table(self):
+        quoted = connection.ops.quote_name(LEGACY_MUMBLE_ACCESS_TABLE)
+        with connection.cursor() as cursor:
+            cursor.execute(f"""
+                CREATE TABLE {quoted} (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL,
+                    username VARCHAR(255) NOT NULL,
+                    password VARCHAR(255) NOT NULL,
+                    suspended BOOLEAN NOT NULL DEFAULT 0,
+                    FOREIGN KEY (user_id) REFERENCES auth_user (id)
+                )
+                """)
+
+    def _drop_legacy_mumble_table(self):
+        quoted = connection.ops.quote_name(LEGACY_MUMBLE_ACCESS_TABLE)
+        with connection.cursor() as cursor:
+            cursor.execute(f"DROP TABLE IF EXISTS {quoted}")
+
+    def tearDown(self):
+        self._drop_legacy_mumble_table()
+        super().tearDown()
+
+    def test_offboard_deletes_user_with_legacy_mumble_access_row(self):
+        self._create_legacy_mumble_table()
+        quoted = connection.ops.quote_name(LEGACY_MUMBLE_ACCESS_TABLE)
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"""
+                INSERT INTO {quoted} (user_id, username, password, suspended)
+                VALUES (%s, %s, %s, %s)
+                """,
+                [self.user.id, "Test Char", "secret", False],
+            )
+
+        offboard_user(self.user.id)
+
+        self.assertFalse(User.objects.filter(id=self.user.id).exists())

--- a/frontend/app/src/components/blocks/ButtonAddPrimary.astro
+++ b/frontend/app/src/components/blocks/ButtonAddPrimary.astro
@@ -33,15 +33,17 @@ import Button from '@components/blocks/Button.astro';
     narrow={narrow}
     x-data={`{
         add_primary_pilot(accepted) {
-            if (accepted) window.location.href = "${ADD_PRIMARY_CHARACTER_INIT_PARTIAL_URL}"
+            if (accepted) window.location.href = ${JSON.stringify(ADD_PRIMARY_CHARACTER_INIT_PARTIAL_URL)}
         },
         show_add_pilot_disclaimer() {
-            show_alert_dialog({
-                title: '${dialog_title}',
-                partial: '${translatePath('/partials/add_primary_pilot_dialog_disclaimer/')}?${query_string({
+            const root_data = Alpine.$data(document.body)
+            if (!root_data || !root_data.show_alert_dialog) return Promise.resolve(false)
+            return root_data.show_alert_dialog({
+                title: ${JSON.stringify(dialog_title)},
+                partial: ${JSON.stringify(`${translatePath('/partials/add_primary_pilot_dialog_disclaimer/')}?${query_string({
                     is_main: JSON.stringify(true),
-                })}',
-            }).then( (accepted) => this.add_primary_pilot(accepted) )
+                })}`)},
+            }).then((accepted) => this.add_primary_pilot(accepted))
         }
     }`}
     x-on:click="show_add_pilot_disclaimer"

--- a/frontend/app/src/components/blocks/GuestPilotList.astro
+++ b/frontend/app/src/components/blocks/GuestPilotList.astro
@@ -58,7 +58,7 @@ delete attributes.class
         },
         pilot_list_init() {
             ${removed_character !== false ? `stop_remove_animation(${removed_character})` : ''}
-            ${alert !== false ? `show_alert_dialog(${JSON.stringify(alert)})` : ''}
+            ${alert !== false ? `const root_data = Alpine.$data(document.body); if (root_data && root_data.show_alert_dialog) root_data.show_alert_dialog(${JSON.stringify(alert)})` : ''}
         }
     }`}
     x-init="pilot_list_init()"
@@ -81,10 +81,12 @@ delete attributes.class
                         type="button"
                         x-data={`{
                             show_add_pilot_disclaimer() {
-                                show_alert_dialog({
-                                    title: '${t('add_friend_pilot_dialog_title')}',
-                                    content: '${t('add_guest_pilot_dialog_text')}',
-                                }).then( (accepted) => add_pilot(accepted) )
+                                const root_data = Alpine.$data(document.body)
+                                if (!root_data || !root_data.show_alert_dialog) return Promise.resolve(false)
+                                return root_data.show_alert_dialog({
+                                    title: ${JSON.stringify(t('add_friend_pilot_dialog_title'))},
+                                    content: ${JSON.stringify(t('add_guest_pilot_dialog_text'))},
+                                }).then((accepted) => add_pilot(accepted))
                             }
                         }`}
                         x-on:click="show_add_pilot_disclaimer"
@@ -114,24 +116,26 @@ delete attributes.class
                         narrow={true}
                         x-data={`{
                             show_remove_character_dialog() {
-                                show_confirm_dialog({
-                                    title: '${t('remove_pilot_dialog_title')}',
-                                    partial: '${translatePath('/partials/dialog_with_character/')}?${query_string({
+                                const root_data = Alpine.$data(document.body)
+                                if (!root_data || !root_data.show_confirm_dialog) return Promise.resolve(false)
+                                return root_data.show_confirm_dialog({
+                                    title: ${JSON.stringify(t('remove_pilot_dialog_title'))},
+                                    partial: ${JSON.stringify(`${translatePath('/partials/dialog_with_character/')}?${query_string({
                                         id: pilot.character_id.toString(),
                                         character_name: pilot.character_name,
                                         message: t('remove_pilot_dialog_text'),
-                                    })}',
+                                    })}`)},
                                     return_on_accept: ${pilot.character_id},
                                     hx: {
                                         method: 'delete',
-                                        url: '${GUEST_PILOTS_LIST_PARTIAL_URL}?${query_string({
+                                        url: ${JSON.stringify(`${GUEST_PILOTS_LIST_PARTIAL_URL}?${query_string({
                                             id: pilot.character_id.toString(),
                                             character_name: pilot.character_name
-                                        })}',
+                                        })}`)},
                                         target: '#pilots-list',
                                         swap: 'outerHTML transition:true'
                                     }
-                                }).then( (character_id) => start_remove_animation(character_id) )
+                                }).then((character_id) => start_remove_animation(character_id))
                             }
                         }`}
                         x-on:click="show_remove_character_dialog()"

--- a/frontend/app/src/components/blocks/Modal.astro
+++ b/frontend/app/src/components/blocks/Modal.astro
@@ -45,32 +45,7 @@ interface Props {
             x-bind:hx-swap="modal_partial ? 'innerHTML transition:true' : false"
             hx-target="#modal-description"
             hx-indicator=".loader"
-            hx-on="htmx:afterSwap: (() => {
-                const swapped = event.target;
-                // Child swaps (e.g. skillset character portraits) must not re-process
-                // this node — that re-arms hx-get/intersect and reloads the original partial.
-                if (swapped !== this && this.contains(swapped)) {
-                    htmx.process(swapped);
-                    if (typeof Alpine !== 'undefined') Alpine.initTree(swapped);
-                    return;
-                }
-                if (swapped === this) {
-                    htmx.process(this);
-                    if (typeof Alpine !== 'undefined') Alpine.initTree(this);
-                    // Disarm after first fill so nested hx-get swaps stay put.
-                    this.removeAttribute('hx-get');
-                    this.removeAttribute('hx-post');
-                    this.removeAttribute('hx-trigger');
-                    this.removeAttribute('hx-vals');
-                    try {
-                        const scope = Alpine.$data(document.body);
-                        if (scope && 'modal_partial' in scope) {
-                            scope.modal_partial = '';
-                            scope.modal_partial_params = '';
-                        }
-                    } catch (e) {}
-                }
-            })()"
+            hx-on--after-swap="window.minmatar_modal_after_swap.call(this, event)"
         />
         <button modal-action="cancel"><TrashIcon /></button>
     </Dialog>
@@ -128,3 +103,29 @@ interface Props {
         transform: scale(1.5);
     }
 </style>
+
+<script is:inline>
+    window.minmatar_modal_after_swap = function (event) {
+        const swapped = event.target
+        if (swapped !== this && this.contains(swapped)) {
+            htmx.process(swapped)
+            if (typeof Alpine !== 'undefined') Alpine.initTree(swapped)
+            return
+        }
+        if (swapped === this) {
+            htmx.process(this)
+            if (typeof Alpine !== 'undefined') Alpine.initTree(this)
+            this.removeAttribute('hx-get')
+            this.removeAttribute('hx-post')
+            this.removeAttribute('hx-trigger')
+            this.removeAttribute('hx-vals')
+            try {
+                const scope = Alpine.$data(document.body)
+                if (scope && 'modal_partial' in scope) {
+                    scope.modal_partial = ''
+                    scope.modal_partial_params = ''
+                }
+            } catch (e) {}
+        }
+    }
+</script>

--- a/frontend/app/src/components/blocks/PilotsList.astro
+++ b/frontend/app/src/components/blocks/PilotsList.astro
@@ -68,7 +68,7 @@ delete attributes.class
         },
         pilot_list_init() {
             ${removed_character !== false ? `stop_remove_animation(${removed_character})` : ''}
-            ${alert !== false ? `show_alert_dialog(${JSON.stringify(alert)})` : ''}
+            ${alert !== false ? `const root_data = Alpine.$data(document.body); if (root_data && root_data.show_alert_dialog) root_data.show_alert_dialog(${JSON.stringify(alert)})` : ''}
         }
     }`}
     x-init="pilot_list_init()"
@@ -102,21 +102,22 @@ delete attributes.class
                         color='green'
                         x-data={`{
                             show_add_pilot_disclaimer() {
+                                const root_data = Alpine.$data(document.body)
+                                if (!root_data || !root_data.show_alert_dialog) return Promise.resolve(false)
                                 if (pilots.length == 0) {
-                                    show_alert_dialog({
-                                        title: '${t('add_primary_pilot_dialog_title')}',
-                                        partial: '${translatePath('/partials/add_pilot_dialog/')}?${query_string({
+                                    return root_data.show_alert_dialog({
+                                        title: ${JSON.stringify(t('add_primary_pilot_dialog_title'))},
+                                        partial: ${JSON.stringify(`${translatePath('/partials/add_pilot_dialog/')}?${query_string({
                                             is_main: JSON.stringify(true),
-                                        })}',
-                                    }).then( (accepted) => add_pilot(accepted) )
-                                } else {
-                                    show_alert_dialog({
-                                        title: '${t('add_pilot_dialog_title')}',
-                                        partial: '${translatePath('/partials/add_pilot_dialog/')}?${query_string({
-                                            is_main: JSON.stringify(false),
-                                        })}',
-                                    }).then( (accepted) => add_pilot(accepted) )
+                                        })}`)},
+                                    }).then((accepted) => add_pilot(accepted))
                                 }
+                                return root_data.show_alert_dialog({
+                                    title: ${JSON.stringify(t('add_pilot_dialog_title'))},
+                                    partial: ${JSON.stringify(`${translatePath('/partials/add_pilot_dialog/')}?${query_string({
+                                        is_main: JSON.stringify(false),
+                                    })}`)},
+                                }).then((accepted) => add_pilot(accepted))
                             }
                         }`}
                         x-on:click="show_add_pilot_disclaimer"
@@ -193,19 +194,21 @@ delete attributes.class
                                     type="button"
                                     x-data={`{
                                         show_set_main_dialog() {
-                                            show_confirm_dialog({
-                                                title: '${t('set_main_character_dialog_title')}',
-                                                partial: '${translatePath('/partials/dialog_with_character/')}?${query_string({
+                                            const root_data = Alpine.$data(document.body)
+                                            if (!root_data || !root_data.show_confirm_dialog) return Promise.resolve(false)
+                                            return root_data.show_confirm_dialog({
+                                                title: ${JSON.stringify(t('set_main_character_dialog_title'))},
+                                                partial: ${JSON.stringify(`${translatePath('/partials/dialog_with_character/')}?${query_string({
                                                     id: pilot.character_id,
                                                     character_name: pilot.character_name,
-                                                    message: t('set_main_character_dialog_text')    
-                                                })}',
+                                                    message: t('set_main_character_dialog_text')
+                                                })}`)},
                                                 hx: {
                                                     method: 'post',
-                                                    url: '${SET_MAIN_CHARACTER_PARTIAL_URL}?${query_string({
+                                                    url: ${JSON.stringify(`${SET_MAIN_CHARACTER_PARTIAL_URL}?${query_string({
                                                         id: pilot.character_id,
                                                         character_name: pilot.character_name,
-                                                    })}',
+                                                    })}`)},
                                                     target: '#pilots-list',
                                                     swap: 'outerHTML transition:true'
                                                 }
@@ -230,24 +233,26 @@ delete attributes.class
                                     narrow={true}
                                     x-data={`{
                                         show_remove_character_dialog() {
-                                            show_confirm_dialog({
-                                                title: '${t('remove_pilot_dialog_title')}',
-                                                partial: '${translatePath('/partials/dialog_with_character/')}?${query_string({
+                                            const root_data = Alpine.$data(document.body)
+                                            if (!root_data || !root_data.show_confirm_dialog) return Promise.resolve(false)
+                                            return root_data.show_confirm_dialog({
+                                                title: ${JSON.stringify(t('remove_pilot_dialog_title'))},
+                                                partial: ${JSON.stringify(`${translatePath('/partials/dialog_with_character/')}?${query_string({
                                                     id: pilot.character_id.toString(),
                                                     character_name: pilot.character_name,
                                                     message: t('remove_pilot_dialog_text'),
-                                                })}',
+                                                })}`)},
                                                 return_on_accept: ${pilot.character_id},
                                                 hx: {
                                                     method: 'delete',
-                                                    url: '${PILOTS_LIST_PARTIAL_URL}?${query_string({
+                                                    url: ${JSON.stringify(`${PILOTS_LIST_PARTIAL_URL}?${query_string({
                                                         id: pilot.character_id.toString(),
                                                         character_name: pilot.character_name
-                                                    })}',
+                                                    })}`)},
                                                     target: '#pilots-list',
                                                     swap: 'outerHTML transition:true'
                                                 }
-                                            }).then( (character_id) => start_remove_animation(character_id) )
+                                            }).then((character_id) => start_remove_animation(character_id))
                                         }
                                     }`}
                                     x-on:click="show_remove_character_dialog()"

--- a/frontend/app/src/pages/industry/orders/planner.astro
+++ b/frontend/app/src/pages/industry/orders/planner.astro
@@ -175,6 +175,25 @@ const bucket_labels = JSON.stringify({
     second_stage_reactions: t('industry.orders.planner.bucket.second_stage_reactions'),
     other: t('industry.orders.planner.bucket.other'),
 })
+const planner_copy = JSON.stringify({
+    implant_off: t('industry.orders.planner.implant_off'),
+    stock_applied: t('industry.orders.planner.stock_applied'),
+    stock_unresolved: t('industry.orders.planner.stock_unresolved'),
+    per_unit_cost_tip: t('industry.orders.planner.per_unit_cost_tip'),
+    total_cost_tip: t('industry.orders.planner.total_cost_tip'),
+    freight_volume: t('industry.orders.planner.freight_volume'),
+    freight_none: t('industry.orders.planner.freight_none'),
+    per_unit_cost: t('industry.orders.planner.per_unit_cost'),
+    per_unit_equals_total: t('industry.orders.planner.per_unit_equals_total'),
+    total_cost: t('industry.orders.planner.total_cost'),
+    implant_assumed_max: t('industry.orders.planner.implant_assumed_max'),
+    implant_fitted: t('industry.orders.planner.implant_fitted'),
+    effective_refine_tip: t('industry.orders.planner.effective_refine_tip'),
+    refine_core: t('industry.orders.planner.refine_core'),
+    refine_per_ore: t('industry.orders.planner.refine_per_ore'),
+    error: t('industry.orders.planner.error'),
+    subitem_import: t('industry.orders.planner.subitem_import').trim(),
+})
 ---
 
 <Viewport
@@ -253,7 +272,7 @@ const bucket_labels = JSON.stringify({
                             effective_refine: ${default_refine},
                             refine_source: 'facility_default',
                             skill_summary: '',
-                            implant_status: '${t('industry.orders.planner.implant_off')}',
+                            implant_status: '',
                             ore_yields: [],
                             character_skills: null,
                             facility_detail: null,
@@ -268,6 +287,7 @@ const bucket_labels = JSON.stringify({
                             _loaded_facility_key: '',
                             _loaded_refine_key: '',
                             bucket_labels: ${bucket_labels},
+                            copy: ${planner_copy},
                             // Auto-replan watches plannerInputSnapshot() only (user inputs).
                             // To add a new control: x-model it onto this component and include
                             // that field in plannerInputSnapshot() — no per-control @change.
@@ -295,7 +315,7 @@ const bucket_labels = JSON.stringify({
                                 const parts = []
                                 if (this.stock_applied_count > 0) {
                                     parts.push(
-                                        '${t('industry.orders.planner.stock_applied')}'.replace(
+                                        this.copy.stock_applied.replace(
                                             '{n}',
                                             String(this.stock_applied_count)
                                         )
@@ -303,7 +323,7 @@ const bucket_labels = JSON.stringify({
                                 }
                                 if (this.stock_unresolved_count > 0) {
                                     parts.push(
-                                        '${t('industry.orders.planner.stock_unresolved')}'.replace(
+                                        this.copy.stock_unresolved.replace(
                                             '{n}',
                                             String(this.stock_unresolved_count)
                                         )
@@ -312,6 +332,7 @@ const bucket_labels = JSON.stringify({
                                 return parts.join(' · ')
                             },
                             initPlannerAutoReplan() {
+                                this.implant_status = this.copy.implant_off
                                 this.$watch(
                                     () => this.plannerInputSnapshot(),
                                     () => this.scheduleReplan()
@@ -408,8 +429,8 @@ const bucket_labels = JSON.stringify({
                                 const perUnit = mode === 'per_unit'
                                 const lines = [
                                     perUnit
-                                        ? '${t('industry.orders.planner.per_unit_cost_tip')}'
-                                        : '${t('industry.orders.planner.total_cost_tip')}',
+                                        ? this.copy.per_unit_cost_tip
+                                        : this.copy.total_cost_tip,
                                     '',
                                 ]
                                 // Show every backend line (incl. reprocessing tax
@@ -428,7 +449,7 @@ const bucket_labels = JSON.stringify({
                                 }
                                 if (Number(breakdown.freight_volume_m3) > 0) {
                                     lines.push(
-                                        '${t('industry.orders.planner.freight_volume')}: '
+                                        this.copy.freight_volume + ': '
                                         + Number(breakdown.freight_volume_m3).toLocaleString(
                                             undefined,
                                             { maximumFractionDigits: 2 }
@@ -441,24 +462,24 @@ const bucket_labels = JSON.stringify({
                                     && Number(breakdown.freight_volume_m3) > 0
                                 ) {
                                     lines.push(
-                                        '${t('industry.orders.planner.freight_none')}'
+                                        this.copy.freight_none
                                     )
                                 }
                                 if (perUnit) {
                                     lines.push(
-                                        '<strong>${t('industry.orders.planner.per_unit_cost')}: '
+                                        '<strong>' + this.copy.per_unit_cost + ': '
                                         + this.formatIsk(
                                             Math.round(breakdown.per_unit_isk)
                                         )
                                         + ' ISK</strong>'
                                     )
                                     lines.push(
-                                        '${t('industry.orders.planner.per_unit_equals_total')}'
+                                        this.copy.per_unit_equals_total
                                             .replace('{n}', String(qty))
                                     )
                                 } else {
                                     lines.push(
-                                        '<strong>${t('industry.orders.planner.total_cost')}: '
+                                        '<strong>' + this.copy.total_cost + ': '
                                         + this.formatIsk(
                                             breakdown.grand_total_isk
                                         )
@@ -634,14 +655,14 @@ const bucket_labels = JSON.stringify({
                                             '/RE' + s.reprocessing_efficiency_level +
                                             '/Ore' + s.ore_processing_level)
                                         : ''
-                                    this.implant_status = '${t('industry.orders.planner.implant_off')}'
+                                    this.implant_status = this.copy.implant_off
                                     this.bindRefineTooltip()
                                     return
                                 }
                                 if (!s) {
                                     this.skill_summary = ''
                                     this.implant_status = (!this.character_id)
-                                        ? '${t('industry.orders.planner.implant_assumed_max')}'
+                                        ? this.copy.implant_assumed_max
                                         : ''
                                     this.bindRefineTooltip()
                                     return
@@ -654,20 +675,20 @@ const bucket_labels = JSON.stringify({
                                     const name = s.implant_name || ('type ' + s.implant_type_id)
                                     const pct = (s.implant_bonus * 100).toFixed(0) + '%'
                                     this.implant_status =
-                                        '${t('industry.orders.planner.implant_fitted')}: ' +
+                                        this.copy.implant_fitted + ': ' +
                                         name + ' (+' + pct + ')'
                                 } else {
                                     // Toggle ON with no RX found → backend assumes RX-804.
                                     this.implant_status =
-                                        '${t('industry.orders.planner.implant_assumed_max')}'
+                                        this.copy.implant_assumed_max
                                 }
                                 this.bindRefineTooltip()
                             },
                             refineYieldTipHtml() {
                                 const lines = [
-                                    '${t('industry.orders.planner.effective_refine_tip')}',
+                                    this.copy.effective_refine_tip,
                                     '',
-                                    '<strong>${t('industry.orders.planner.refine_core')}</strong>',
+                                    '<strong>' + this.copy.refine_core + '</strong>',
                                 ]
                                 const s = this.character_skills
                                 const rep = s ? s.reprocessing_level : 5
@@ -684,7 +705,7 @@ const bucket_labels = JSON.stringify({
                                 if (yields.length) {
                                     lines.push('')
                                     lines.push(
-                                        '<strong>${t('industry.orders.planner.refine_per_ore')}</strong>'
+                                        '<strong>' + this.copy.refine_per_ore + '</strong>'
                                     )
                                     for (const row of yields) {
                                         const pct = (
@@ -767,7 +788,7 @@ const bucket_labels = JSON.stringify({
                                     if (gen !== this._plan_generation)
                                         return
                                     if (!response.ok) {
-                                        let detail = '${t('industry.orders.planner.error')}'
+                                        let detail = this.copy.error
                                         try {
                                             const err = await response.json()
                                             if (err.detail) detail = err.detail
@@ -799,7 +820,7 @@ const bucket_labels = JSON.stringify({
                                 } catch (e) {
                                     if (gen !== this._plan_generation)
                                         return
-                                    this.error = e.message || '${t('industry.orders.planner.error')}'
+                                    this.error = e.message || this.copy.error
                                     this.materials_tsv = ''
                                     this.cost_breakdown = null
                                     this.stock_applied_count = 0
@@ -1214,7 +1235,7 @@ const bucket_labels = JSON.stringify({
                                                         class="[ text-gray ]"
                                                         x-text="build_toggles[String(job.product_type_id)]
                                                             ? ((job.runs || '?') + ' runs')
-                                                            : '${t('industry.orders.planner.subitem_import').trim()}'"
+                                                            : copy.subitem_import"
                                                     ></small>
                                                 </label>
                                             </template>

--- a/frontend/app/testing/components/blocks/Modal.test.ts
+++ b/frontend/app/testing/components/blocks/Modal.test.ts
@@ -1,0 +1,13 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { expect, test } from "vitest";
+import Modal from "@components/blocks/Modal.astro";
+
+test("Modal afterSwap handler is a named function, not inline hx-on JS", async () => {
+  const container = await AstroContainer.create();
+  const result = await container.renderToString(Modal, {});
+
+  expect(result).toContain('hx-on--after-swap="window.minmatar_modal_after_swap.call(this, event)"');
+  expect(result).toContain("window.minmatar_modal_after_swap = function (event)");
+  expect(result).not.toMatch(/hx-on=["']htmx:afterSwap:/);
+  expect(result).not.toMatch(/hx-on--after-swap=["'][^"']*\/\//);
+});

--- a/frontend/app/testing/components/blocks/PilotsList.test.ts
+++ b/frontend/app/testing/components/blocks/PilotsList.test.ts
@@ -1,15 +1,13 @@
 import { experimental_AstroContainer as AstroContainer } from "astro/container";
 import { expect, test } from "vitest";
-import ButtonAddPrimary from "@components/blocks/ButtonAddPrimary.astro";
+import PilotsList from "@components/blocks/PilotsList.astro";
 
-test("ButtonAddPrimary looks up show_alert_dialog on body", async () => {
+test("PilotsList add-pilot looks up show_alert_dialog on body", async () => {
   const container = await AstroContainer.create();
-  const result = await container.renderToString(ButtonAddPrimary, {
+  const result = await container.renderToString(PilotsList, {
     props: {
-      dialog_title: "Add a main character",
-    },
-    slots: {
-      default: "Add main",
+      readonly: false,
+      pilots: [],
     },
   });
 


### PR DESCRIPTION
## Summary
- Move modal `htmx:afterSwap` off inline `hx-on` (H8 SyntaxError from `//` comments flattening to one line)
- Look up `show_alert_dialog` / `show_confirm_dialog` on the body Alpine scope (F8) in add/remove pilot buttons
- Put planner i18n into `x-data` via `JSON.stringify` so Alpine never evaluates `industry.orders…` (DC)
- Delete leftover `mumble_mumbleaccess` rows on offboard and drop the table (KF/KG); remove the stale `sync_executor_access_lists_task` beat row (FR)

## Test plan
- [ ] Open combat log (or any modal with nested htmx swaps) in Firefox and Chromium — no `missing ) in parenthetical`
- [ ] Account page: add primary / guest / remove pilot dialogs open without `show_alert_dialog is not defined`
- [ ] Industry orders planner loads; subitem import / refine tooltip copy renders; no `Unexpected identifier 'industry'`
- [ ] Offboard a user that still has a leftover Mumble row (or run the users test)
- [ ] After migrate, celery no longer enqueues `access_lists.tasks.sync_executor_access_lists_task`
- [ ] Backend: `pipenv run python manage.py test users --settings=app.settings_test`
- [ ] Frontend: `npm run check` and `npm run test -- testing/components/blocks/ButtonAddPrimary.test.ts testing/components/blocks/Modal.test.ts testing/components/blocks/PilotsList.test.ts`


Made with [Cursor](https://cursor.com)