### PR TITLE
Score sell-order viability from the cheapest ask

### DIFF
--- a/backend/market/helpers/sell_order_health.py
+++ b/backend/market/helpers/sell_order_health.py
@@ -79,6 +79,7 @@ def build_sell_order_health(  # noqa: C901
     baseline_by_type = forge_baseline_by_type(target_type_ids)
     stock_by_loc_item: dict[tuple[int, int], int] = {}
     viable_by_loc_item: dict[tuple[int, int], int] = {}
+    min_price_by_loc_item: dict[tuple[int, int], int] = {}
     listed_value_by_loc_item: dict[tuple[int, int], float] = {}
     for order in EveMarketItemOrder.objects.filter(
         location_id__in=location_pks,
@@ -87,14 +88,15 @@ def build_sell_order_health(  # noqa: C901
     ).values("location_id", "item_id", "price", "quantity"):
         key = (order["location_id"], order["item_id"])
         quantity = order["quantity"] or 0
+        price = int(order["price"])
         stock_by_loc_item[key] = stock_by_loc_item.get(key, 0) + quantity
         listed_value_by_loc_item[key] = (
-            listed_value_by_loc_item.get(key, 0.0)
-            + float(order["price"]) * quantity
+            listed_value_by_loc_item.get(key, 0.0) + float(price) * quantity
         )
-        if is_price_viable(
-            order["price"], baseline_by_type.get(order["item_id"])
-        ):
+        prev_min = min_price_by_loc_item.get(key)
+        if prev_min is None or price < prev_min:
+            min_price_by_loc_item[key] = price
+        if is_price_viable(price, baseline_by_type.get(order["item_id"])):
             viable_by_loc_item[key] = viable_by_loc_item.get(key, 0) + quantity
 
     classified_by_id = classify_items(target_type_ids)
@@ -158,24 +160,28 @@ def build_sell_order_health(  # noqa: C901
                 continue
             current = stock_by_loc_item.get((loc_pk, eve_type.id), 0)
             viable = viable_by_loc_item.get((loc_pk, eve_type.id), 0)
+            min_price = min_price_by_loc_item.get((loc_pk, eve_type.id))
+            cheapest_viable = min_price is not None and is_price_viable(
+                min_price, baseline_by_type.get(eve_type.id)
+            )
             sell_targets_by_loc[loc_pk] += 1
             sell_ratio = min(1.0, current / desired)
             sell_fill_ratios_by_loc[loc_pk].append(sell_ratio)
             if current >= desired:
                 sell_fulfilled_by_loc[loc_pk] += 1
-            # Viability = price quality of what is listed, not empty shelves.
+            # Viability = cheapest ask vs baseline, not leftover overpriced
+            # depth. Empty shelves drag coverage, not viability.
             if current > 0:
-                sell_viable_ratio = min(1.0, viable / current)
                 sell_viable_fill_ratios_by_loc[loc_pk].append(
-                    sell_viable_ratio
+                    1.0 if cheapest_viable else 0.0
                 )
                 sell_listed_by_loc[loc_pk] += 1
-                if viable >= current:
+                if cheapest_viable:
                     sell_viable_fulfilled_by_loc[loc_pk] += 1
             # Presence: coverage gap = empty shelf; viability = listed but
-            # nothing within-reason priced.
+            # the cheapest ask is above the within-reason cap.
             coverage_gap = current == 0
-            viability_gap = current > 0 and viable == 0
+            viability_gap = current > 0 and not cheapest_viable
             avg_markup_pct = None
             if current > 0:
                 baseline = baseline_by_type.get(eve_type.id)

--- a/backend/market/tests/test_staging_supply.py
+++ b/backend/market/tests/test_staging_supply.py
@@ -1109,14 +1109,15 @@ class MarketHealthApiTestCase(TestCase):
         # Presence desired=1; shortfall uses viable vs desired.
         self.assertEqual(gap["shortfall"], 0)
         self.assertFalse(gap["coverage_gap"])
-        # Some viable stock remains → not a viability gap.
+        # Cheapest ask is within 20% of baseline → type is viable even
+        # when most listed quantity sits above that.
         self.assertFalse(gap["viability_gap"])
         self.assertEqual(gap["item_type"], "consumable")
         self.assertEqual(sells["summary"]["targets"], 1)
         self.assertEqual(sells["summary"]["fulfilled"], 1)
-        self.assertEqual(sells["summary"]["viable_fulfilled"], 0)
+        self.assertEqual(sells["summary"]["viable_fulfilled"], 1)
         self.assertEqual(sells["summary"]["health_pct"], 100.0)
-        self.assertEqual(sells["summary"]["viability_pct"], 11.0)
+        self.assertEqual(sells["summary"]["viability_pct"], 100.0)
         self.assertEqual(
             sum(
                 1
@@ -1127,6 +1128,63 @@ class MarketHealthApiTestCase(TestCase):
         )
         self.assertEqual(gap["flags"], ["in_stock", "overpriced"])
         self.assertIsNone(gap["days_of_stock"])
+
+    def test_viability_uses_cheapest_ask_not_listed_mix(self):
+        charge_cat, _ = EveCategory.objects.get_or_create(
+            id=8, defaults={"name": "Charge", "published": True}
+        )
+        charge_grp, _ = EveGroup.objects.get_or_create(
+            id=801,
+            defaults={
+                "name": "Hybrid Charge",
+                "published": True,
+                "eve_category": charge_cat,
+            },
+        )
+        item, _ = EveType.objects.update_or_create(
+            id=91024,
+            defaults={
+                "name": "Cheapest Ask Ammo",
+                "published": True,
+                "eve_group": charge_grp,
+            },
+        )
+        EveMarketItemExpectation.objects.create(
+            item=item,
+            location=self.loc,
+            quantity=100,
+        )
+        # Expensive majority first so aggregation cannot rely on insert order.
+        EveMarketItemOrder.objects.create(
+            location=self.loc,
+            item=item,
+            quantity=90,
+            price=4_000_000,
+            is_buy_order=False,
+        )
+        EveMarketItemOrder.objects.create(
+            location=self.loc,
+            item=item,
+            quantity=1,
+            price=2_000_000,
+            is_buy_order=False,
+        )
+
+        with patch(
+            "market.helpers.health_common.get_prices_by_type_id",
+            return_value={item.pk: 2_000_000},
+        ):
+            sells = _sell_at(self.loc.location_id)
+
+        gap = next(
+            row
+            for row in sells["rows"]
+            if row["item_name"] == "Cheapest Ask Ammo"
+        )
+        self.assertEqual(gap["viable_quantity"], 1)
+        self.assertFalse(gap["viability_gap"])
+        self.assertEqual(sells["summary"]["viability_pct"], 100.0)
+        self.assertEqual(sells["summary"]["viable_fulfilled"], 1)
 
     def test_boundary_price_counts_as_viable(self):
         charge_cat, _ = EveCategory.objects.get_or_create(

--- a/frontend/app/src/i18n/ui.ts
+++ b/frontend/app/src/i18n/ui.ts
@@ -573,7 +573,7 @@ export const ui = {
         'ops_health_coverage_hint': 'Of configured targets, share of target quantity currently listed, regardless of price.',
         'ops_health_contracts_target_hint': 'Of configured targets, share of target contract quantity currently outstanding, regardless of price.',
         'ops_health_contracts_viability_hint': 'Of listed doctrine fits only, share priced within 20% of the Forge baseline for their actual contents (empty targets ignored; fits under 250k ISK always count).',
-        'ops_health_viability_hint': 'Of listed items only, share priced within 20% of baseline (empty targets ignored; items under 1M ISK always count).',
+        'ops_health_viability_hint': 'Of listed items only, share whose cheapest ask is within 20% of the 7-day Forge baseline (empty targets ignored; items under 250k ISK always count).',
         'ops_history_chart_title': 'Market Health',
         'ops_history_contracts_chart_title': 'Contracts Health',
         'ops_history_sell_orders_chart_title': 'Sell Orders Health',


### PR DESCRIPTION
## Summary
- Sell-order viability is now whether the **cheapest ask** is within 20% of the 7-day Forge baseline, not the mix of all listed quantity.
- Overpriced leftover no longer tanks the health % when a fair buy exists. Quantity-weighted markup (and the overpriced flag) still reflects the rest of the book.
- Ops hint copy matches this (and the 250k cheap-item floor).

## Test plan
- [ ] `pipenv run python manage.py test market.tests.test_staging_supply --settings=app.settings_test`
- [ ] On Market Ops sell orders, a type with one fair ask and a pile of expensive remainder shows **viable**, not a viability gap
- [ ] Types whose cheapest ask is still >20% over Jita remain overpriced / non-viable
- [ ] Coverage is unchanged (empty shelves still only hit coverage)


Made with [Cursor](https://cursor.com)