### PR TITLE
Fix planner reaction expansion and skillset copy format

### DIFF
--- a/backend/industry/helpers/build_planner.py
+++ b/backend/industry/helpers/build_planner.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum
 from math import ceil
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple
 
 from eveuniverse.models import (
     EveIndustryActivityDuration,
@@ -484,6 +484,106 @@ def _collect_leaf_materials(
     return leaf_materials
 
 
+def _cached_recipe(
+    type_id: int, cache: Dict[int, Optional[Recipe]]
+) -> Optional[Recipe]:
+    if type_id not in cache:
+        cache[type_id] = _get_recipe(type_id)
+    return cache[type_id]
+
+
+def _skips_intermediate_fuel(
+    type_id: int,
+    *,
+    build_fuel_blocks: bool,
+    fuel_type_ids: Set[int],
+    root_id: int,
+) -> bool:
+    # Always manufacture the root (e.g. fuel-block industry orders).
+    # build_fuel_blocks=False only skips intermediate fuel-block inputs.
+    return (
+        not build_fuel_blocks
+        and type_id in fuel_type_ids
+        and type_id != root_id
+    )
+
+
+def _has_wanted_descendant(
+    type_id: int,
+    *,
+    recipe_for: Callable[[int], Optional[Recipe]],
+    excluded: Set[int],
+    fuel_type_ids: Set[int],
+    root_id: int,
+    build_fuel_blocks: bool,
+    cache: Dict[int, bool],
+) -> bool:
+    """True if some non-excluded, non-fuel recipe sits under this type."""
+    if type_id in cache:
+        return cache[type_id]
+    visiting: Set[int] = set()
+
+    def walk(tid: int) -> bool:
+        if tid in visiting:
+            return False
+        visiting.add(tid)
+        recipe = recipe_for(tid)
+        if recipe is None:
+            return False
+        for mid, _, _ in recipe.materials:
+            if _skips_intermediate_fuel(
+                mid,
+                build_fuel_blocks=build_fuel_blocks,
+                fuel_type_ids=fuel_type_ids,
+                root_id=root_id,
+            ):
+                continue
+            child = recipe_for(mid)
+            if child is None:
+                continue
+            if mid not in excluded:
+                return True
+            if walk(mid):
+                return True
+        return False
+
+    result = walk(type_id)
+    cache[type_id] = result
+    return result
+
+
+def _is_job_buildable(
+    type_id: int,
+    *,
+    recipe_for: Callable[[int], Optional[Recipe]],
+    excluded: Set[int],
+    fuel_type_ids: Set[int],
+    root_id: int,
+    build_fuel_blocks: bool,
+    wanted_cache: Dict[int, bool],
+) -> bool:
+    if _skips_intermediate_fuel(
+        type_id,
+        build_fuel_blocks=build_fuel_blocks,
+        fuel_type_ids=fuel_type_ids,
+        root_id=root_id,
+    ):
+        return False
+    if recipe_for(type_id) is None:
+        return False
+    if type_id in excluded:
+        return _has_wanted_descendant(
+            type_id,
+            recipe_for=recipe_for,
+            excluded=excluded,
+            fuel_type_ids=fuel_type_ids,
+            root_id=root_id,
+            build_fuel_blocks=build_fuel_blocks,
+            cache=wanted_cache,
+        )
+    return True
+
+
 def plan_build(
     product: EveType | str | int,
     quantity: int = 1,
@@ -509,7 +609,9 @@ def plan_build(
 
     Types in ``exclude_type_ids`` are treated as imported leaves (subtree not
     expanded), matching ``build_fuel_blocks=False`` for intermediate fuel-block
-    groups. The root product is always expanded when it has a recipe — including
+    groups. If a descendant of an excluded type is *not* excluded (the user
+    wants to build it), ancestors are still expanded so that job stays in the
+    plan. The root product is always expanded when it has a recipe — including
     when the order itself is a fuel block.
     """
     if quantity <= 0:
@@ -540,24 +642,21 @@ def plan_build(
     root_id = int(root.id)
 
     recipe_cache: Dict[int, Optional[Recipe]] = {}
+    wanted_descendant_cache: Dict[int, bool] = {}
 
     def recipe_for(type_id: int) -> Optional[Recipe]:
-        if type_id not in recipe_cache:
-            recipe_cache[type_id] = _get_recipe(type_id)
-        return recipe_cache[type_id]
+        return _cached_recipe(type_id, recipe_cache)
 
     def is_buildable(type_id: int) -> bool:
-        if type_id in excluded:
-            return False
-        # Always manufacture the root (e.g. fuel-block industry orders).
-        # build_fuel_blocks=False only skips intermediate fuel-block inputs.
-        if (
-            not build_fuel_blocks
-            and type_id in fuel_type_ids
-            and type_id != root_id
-        ):
-            return False
-        return recipe_for(type_id) is not None
+        return _is_job_buildable(
+            type_id,
+            recipe_for=recipe_for,
+            excluded=excluded,
+            fuel_type_ids=fuel_type_ids,
+            root_id=root_id,
+            build_fuel_blocks=build_fuel_blocks,
+            wanted_cache=wanted_descendant_cache,
+        )
 
     demand, jobs_meta = _stabilize_demand(
         root_id=root.id,

--- a/backend/industry/tests/test_build_planner.py
+++ b/backend/industry/tests/test_build_planner.py
@@ -581,7 +581,7 @@ class BuildPlannerFixtureTestCase(TestCase):
             facility="amamake",
             manufacturing_index=0.05,
             reaction_index=0.04,
-            exclude_type_ids=[self.adv.id],
+            exclude_type_ids=[self.adv.id, self.composite.id],
         )
         self.assertFalse(
             any(j.product_type_id == self.adv.id for j in trimmed.jobs)
@@ -592,6 +592,25 @@ class BuildPlannerFixtureTestCase(TestCase):
         self.assertIn(self.adv.id, trimmed.leaf_materials)
         self.assertNotIn(self.composite.id, trimmed.leaf_materials)
         self.assertLess(trimmed.total_job_cost_isk, full.total_job_cost_isk)
+
+    def test_exclude_parent_still_builds_requested_descendant(self):
+        """Buy the component but build its reaction: expand the parent too."""
+        plan = plan_build(
+            self.hull,
+            quantity=1,
+            blueprint_me=0.0,
+            blueprint_te=0.0,
+            facility="amamake",
+            manufacturing_index=0.05,
+            reaction_index=0.04,
+            exclude_type_ids=[self.adv.id],
+        )
+        job_ids = {j.product_type_id for j in plan.jobs}
+        self.assertIn(self.adv.id, job_ids)
+        self.assertIn(self.composite.id, job_ids)
+        self.assertNotIn(self.adv.id, plan.leaf_materials)
+        self.assertNotIn(self.composite.id, plan.leaf_materials)
+        self.assertIn(self.trit.id, plan.leaf_materials)
 
     def test_me_reduces_component_materials(self):
         plan0 = plan_build(

--- a/frontend/app/src/components/blocks/SkillsetMissingSkills.astro
+++ b/frontend/app/src/components/blocks/SkillsetMissingSkills.astro
@@ -38,10 +38,9 @@ missing_skills.forEach((skill) => {
     )
 })
 
-const skills_names: string[] = missing_skills.map(
-    (skill) => `${skill.skill_name} ${skill.skill_name}\n`,
-)
-const clipboard_text: string = skills_names.join('')
+const clipboard_text: string = missing_skills
+    .map((skill) => `${skill.skill_name} ${skill.skill_level}`)
+    .join('\n')
 
 const show_character_select = characters.length > 1 && Boolean(partial_url)
 const selected_character_id = skillset_missing_skills.character.character_id

--- a/frontend/app/src/i18n/ui.ts
+++ b/frontend/app/src/i18n/ui.ts
@@ -1291,7 +1291,7 @@ export const ui = {
         'industry.orders.planner.reprocessing_tax': 'Reprocessing tax',
         'industry.orders.planner.reprocessing_tax_tip': 'Tax taken when you reprocess (refine) ore at this location.',
         'industry.orders.planner.subitems': 'Build vs buy',
-        'industry.orders.planner.subitems_hint': 'Checked items are manufactured or reacted here. Uncheck anything you will buy or import instead.',
+        'industry.orders.planner.subitems_hint': 'Checked items are manufactured or reacted here. Building a reaction also builds the components that use it. Uncheck anything you will buy or import instead.',
         'industry.orders.planner.select_all': 'Build all',
         'industry.orders.planner.deselect_all': 'Buy all',
         'industry.orders.planner.other_hint': 'Fuel blocks and similar items default to buy. Check them only if you will manufacture them yourself.',

--- a/frontend/app/src/pages/industry/orders/planner.astro
+++ b/frontend/app/src/pages/industry/orders/planner.astro
@@ -286,11 +286,23 @@ const planner_copy = JSON.stringify({
                             _plan_generation: 0,
                             _loaded_facility_key: '',
                             _loaded_refine_key: '',
+                            _job_materials: {},
+                            _job_consumers: {},
+                            _downstream_buckets: {
+                                advanced_components: [
+                                    'second_stage_reactions',
+                                    'first_stage_reactions',
+                                ],
+                                second_stage_reactions: [
+                                    'first_stage_reactions',
+                                ],
+                            },
                             bucket_labels: ${bucket_labels},
                             copy: ${planner_copy},
                             // Auto-replan watches plannerInputSnapshot() only (user inputs).
                             // To add a new control: x-model it onto this component and include
-                            // that field in plannerInputSnapshot() — no per-control @change.
+                            // that field in plannerInputSnapshot() — no per-control @change
+                            // except onSubitemToggle, which cascades ancestor build flags.
                             // Do not put plan response fields (jobs, materials_tsv, etc.) here.
                             plannerInputSnapshot() {
                                 const toggles = this.build_toggles
@@ -533,7 +545,46 @@ const planner_copy = JSON.stringify({
                                     .filter(([, on]) => !on)
                                     .map(([id]) => parseInt(id))
                             },
+                            rememberJobGraph(jobs) {
+                                // Union into a persistent graph from the first
+                                // full expansion so later buy-all plans that
+                                // drop nested jobs still know parent/child.
+                                for (const job of jobs || []) {
+                                    const pid = job.product_type_id
+                                    if (!this._job_materials[pid])
+                                        this._job_materials[pid] = []
+                                    const known = {}
+                                    for (const mid of this._job_materials[pid])
+                                        known[mid] = true
+                                    for (const mat of job.materials || []) {
+                                        const mid = mat.type_id
+                                        if (!known[mid]) {
+                                            this._job_materials[pid].push(mid)
+                                            known[mid] = true
+                                        }
+                                        if (!this._job_consumers[mid])
+                                            this._job_consumers[mid] = []
+                                        if (!this._job_consumers[mid].includes(pid))
+                                            this._job_consumers[mid].push(pid)
+                                    }
+                                }
+                            },
+                            enableAncestorBuilds(type_id) {
+                                const seen = {}
+                                const walk = (id) => {
+                                    for (const cid of (this._job_consumers[id] || [])) {
+                                        if (seen[cid]) continue
+                                        seen[cid] = true
+                                        if (cid === this.product_type_id)
+                                            continue
+                                        this.build_toggles[String(cid)] = true
+                                        walk(cid)
+                                    }
+                                }
+                                walk(type_id)
+                            },
                             syncSubitemsFromJobs(jobs) {
+                                this.rememberJobGraph(jobs)
                                 let needs_replan = false
                                 // Suspend watch so buy-all default toggles do not
                                 // schedule a second debounced replan; runPlan re-runs
@@ -840,9 +891,19 @@ const planner_copy = JSON.stringify({
                             },
                             selectBucketSubitems(bucket) {
                                 this.setBucketSubitemToggles(bucket, true)
+                                for (const row of this.subitem_catalog) {
+                                    if ((row.bucket || 'other') === bucket)
+                                        this.enableAncestorBuilds(row.product_type_id)
+                                }
                             },
                             deselectBucketSubitems(bucket) {
                                 this.setBucketSubitemToggles(bucket, false)
+                                for (const child of (this._downstream_buckets[bucket] || []))
+                                    this.setBucketSubitemToggles(child, false)
+                            },
+                            onSubitemToggle(type_id, on) {
+                                if (on)
+                                    this.enableAncestorBuilds(type_id)
                             },
                         }`}
                         x-init="initPlannerAutoReplan()"
@@ -1221,6 +1282,7 @@ const planner_copy = JSON.stringify({
                                                     <input
                                                         type="checkbox"
                                                         x-model="build_toggles[String(job.product_type_id)]"
+                                                        x-on:change="onSubitemToggle(job.product_type_id, $event.target.checked)"
                                                     />
                                                     <img
                                                         class="[ planner-subitem-icon ]"

--- a/frontend/app/testing/components/blocks/SkillsetMissingSkills.test.ts
+++ b/frontend/app/testing/components/blocks/SkillsetMissingSkills.test.ts
@@ -1,0 +1,32 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container'
+import { expect, test } from 'vitest'
+import SkillsetMissingSkills from '@components/blocks/SkillsetMissingSkills.astro'
+import type { SkillsetMissingSkillUI } from '@dtypes/layout_components'
+
+const skillset_missing_skills: SkillsetMissingSkillUI = {
+    skillsets: {
+        name: 'Armor Logistics Cruisers',
+        progress: 40,
+        missing_skills: [
+            { skill_name: 'Remote Armor Repair Systems', skill_level: 4 },
+            { skill_name: 'Remote Armor Repair Systems', skill_level: 5 },
+            { skill_name: 'Logistics Cruisers', skill_level: 5 },
+        ],
+    },
+    character: {
+        character_id: 1,
+        character_name: 'Test Pilot',
+    },
+}
+
+test('Copy clipboard uses skill name plus numeric level so EVE can import the plan', async () => {
+    const container = await AstroContainer.create()
+    const result = await container.renderToString(SkillsetMissingSkills, {
+        props: { skillset_missing_skills },
+    })
+
+    expect(result).toContain('Remote Armor Repair Systems 4')
+    expect(result).toContain('Remote Armor Repair Systems 5')
+    expect(result).toContain('Logistics Cruisers 5')
+    expect(result).not.toContain('Remote Armor Repair Systems Remote Armor Repair Systems')
+})


### PR DESCRIPTION
## Summary
- Planner: checking second-stage reactions also builds the parent capital components, so Revelation-style plans expand into reaction materials instead of only hull parts
- Skillsets: copy clipboard uses `Skill Name 5` instead of duplicating the name, so EVE can import the plan

## Test plan
- [ ] Revelation planner: Build all second-stage reactions → shopping list includes reaction inputs, not only hull components
- [ ] Uncheck a capital component after a reaction is checked → parent stays built; unchecking a reaction bucket also unchecks downstream reactions
- [ ] Copy Armor Logistics Cruisers missing skills → paste into EVE as `Remote Armor Repair Systems 4` etc.


Made with [Cursor](https://cursor.com)