### PR TITLE
Use Roman numerals in skillset copy for EVE import

### DIFF
--- a/frontend/app/src/components/blocks/SkillItem.astro
+++ b/frontend/app/src/components/blocks/SkillItem.astro
@@ -1,5 +1,6 @@
 ---
 import type { SkillsUI } from '@dtypes/layout_components'
+import { SKILL_LEVEL_ROMAN } from '@helpers/skill_plan'
 
 interface Props {
     skill:              SkillsUI;
@@ -16,13 +17,6 @@ import FixedFluid from '@components/compositions/FixedFluid.astro';
 import SkillSquare from '@components/blocks/SkillSquare.astro';
 import FlexInline from '@components/compositions/FlexInline.astro';
 
-const SKILL_NUMBER = {
-    1: 'I',
-    2: 'II',
-    3: 'III',
-    4: 'IV',
-    5: 'V',
-}
 const PIXEL_GAP = 1
 const SKILL_SQUARE_WIDTH = 10
 ---
@@ -46,7 +40,7 @@ const SKILL_SQUARE_WIDTH = 10
             <SkillSquare status={ current_skill_level > 5 ? 'learned' : 'unlearned' } />
         }
     </FlexInline>
-    <span>{skill.skill_name} {SKILL_NUMBER[skill.skill_level]}</span>
+    <span>{skill.skill_name} {SKILL_LEVEL_ROMAN[skill.skill_level]}</span>
 </FixedFluid>
 
 <style lang="scss">

--- a/frontend/app/src/components/blocks/SkillsetMissingSkills.astro
+++ b/frontend/app/src/components/blocks/SkillsetMissingSkills.astro
@@ -28,6 +28,7 @@ import Wrapper from '@components/compositions/Wrapper.astro'
 import SkillItem from '@components/blocks/SkillItem.astro'
 import ClipboardButton from '@components/blocks/ClipboardButton.astro'
 import CharacterPicture from '@components/blocks/CharacterPicture.astro'
+import { format_skill_plan } from '@helpers/skill_plan'
 
 const missing_skills = skillset_missing_skills.skillsets.missing_skills
 const CURRENT_SKILL_LEVEL: Record<string, number> = {}
@@ -38,9 +39,7 @@ missing_skills.forEach((skill) => {
     )
 })
 
-const clipboard_text: string = missing_skills
-    .map((skill) => `${skill.skill_name} ${skill.skill_level}`)
-    .join('\n')
+const clipboard_text: string = format_skill_plan(missing_skills)
 
 const show_character_select = characters.length > 1 && Boolean(partial_url)
 const selected_character_id = skillset_missing_skills.character.character_id

--- a/frontend/app/src/helpers/skill_plan.ts
+++ b/frontend/app/src/helpers/skill_plan.ts
@@ -1,0 +1,19 @@
+import type { SkillsUI } from '@dtypes/layout_components'
+
+export const SKILL_LEVEL_ROMAN: Record<number, string> = {
+    1: 'I',
+    2: 'II',
+    3: 'III',
+    4: 'IV',
+    5: 'V',
+}
+
+export function format_skill_plan_line(skill_name: string, skill_level: number): string {
+    return `${skill_name} ${SKILL_LEVEL_ROMAN[skill_level] ?? skill_level}`
+}
+
+export function format_skill_plan(skills: SkillsUI[]): string {
+    return skills
+        .map((skill) => format_skill_plan_line(skill.skill_name, skill.skill_level))
+        .join('\n')
+}

--- a/frontend/app/testing/components/blocks/SkillsetMissingSkills.test.ts
+++ b/frontend/app/testing/components/blocks/SkillsetMissingSkills.test.ts
@@ -19,14 +19,15 @@ const skillset_missing_skills: SkillsetMissingSkillUI = {
     },
 }
 
-test('Copy clipboard uses skill name plus numeric level so EVE can import the plan', async () => {
+test('Copy clipboard uses skill name plus Roman level so EVE can import the plan', async () => {
     const container = await AstroContainer.create()
     const result = await container.renderToString(SkillsetMissingSkills, {
         props: { skillset_missing_skills },
     })
 
-    expect(result).toContain('Remote Armor Repair Systems 4')
-    expect(result).toContain('Remote Armor Repair Systems 5')
-    expect(result).toContain('Logistics Cruisers 5')
+    expect(result).toContain('Remote Armor Repair Systems IV')
+    expect(result).toContain('Remote Armor Repair Systems V')
+    expect(result).toContain('Logistics Cruisers V')
+    expect(result).not.toContain('Remote Armor Repair Systems 4')
     expect(result).not.toContain('Remote Armor Repair Systems Remote Armor Repair Systems')
 })

--- a/frontend/app/testing/helpers/skill_plan.test.ts
+++ b/frontend/app/testing/helpers/skill_plan.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { format_skill_plan, format_skill_plan_line } from '@helpers/skill_plan'
+
+describe('format_skill_plan', () => {
+    it('uses EVE Roman numerals, one line per missing level', () => {
+        expect(format_skill_plan_line('EDENCOM Frigate', 1)).toBe('EDENCOM Frigate I')
+        expect(format_skill_plan_line('Weapon Upgrades', 3)).toBe('Weapon Upgrades III')
+        expect(format_skill_plan_line('Medium Vorton Projector', 5)).toBe('Medium Vorton Projector V')
+
+        expect(
+            format_skill_plan([
+                { skill_name: 'EDENCOM Frigate', skill_level: 1 },
+                { skill_name: 'EDENCOM Frigate', skill_level: 2 },
+                { skill_name: 'EDENCOM Frigate', skill_level: 3 },
+                { skill_name: 'Weapon Upgrades', skill_level: 3 },
+                { skill_name: 'Weapon Upgrades', skill_level: 4 },
+            ]),
+        ).toBe(
+            [
+                'EDENCOM Frigate I',
+                'EDENCOM Frigate II',
+                'EDENCOM Frigate III',
+                'Weapon Upgrades III',
+                'Weapon Upgrades IV',
+            ].join('\n'),
+        )
+    })
+})


### PR DESCRIPTION
## Summary
- Skillset copy now pastes as `Skill Name I`–`V` (one line per missing level), matching the in-game skill plan format.
- Shared the Roman mapping so the missing-skills list and clipboard stay in sync.

## Test plan
- [ ] Open a skillset with missing skills and copy the plan
- [ ] Confirm clipboard text looks like `EDENCOM Frigate I` / `Weapon Upgrades III`, not `EDENCOM Frigate 1`
- [ ] Paste into EVE and confirm the skill plan imports
- [ ] `npm run test -- --run testing/helpers/skill_plan.test.ts testing/components/blocks/SkillsetMissingSkills.test.ts` (already passing)


Made with [Cursor](https://cursor.com)