### PR TITLE
Fix Set Character Roles Update after Account navigation

### DIFF
--- a/frontend/app/src/components/partials/FooterScripts.astro
+++ b/frontend/app/src/components/partials/FooterScripts.astro
@@ -93,10 +93,13 @@ const DISABLED_CCPWGL = is_disabled_ccpwgl()
         document.addEventListener('astro:after-swap', () => {
             tippy('[data-tippy-content]', window.tippy_options)
             document.querySelectorAll('.loader').forEach(e => e.classList.remove('active'))
-            const content = document.getElementById('content')
-                || document.querySelector('.viewport-layout-inner')
-            if (content)
-                htmx.process(content)
+            // Process the layout root, not only #content. Pages like account
+            // tags wrap <main id="content"> in a form with hx-post; processing
+            // #content alone never binds that form after ClientRouter nav.
+            const root = document.querySelector('.viewport-layout-inner')
+                || document.getElementById('content')
+            if (root)
+                htmx.process(root)
             // Init from body so page bindings see Viewport x-data
             // (color_blind_mode, ui_scaling, show_modal, get_*_icon, …).
             // initTree(content) alone orphans those expressions after soft nav.

--- a/frontend/app/src/components/partials/GuestsFooterScripts.astro
+++ b/frontend/app/src/components/partials/GuestsFooterScripts.astro
@@ -32,10 +32,10 @@
 
         document.addEventListener('astro:after-swap', () => {
             tippy('[data-tippy-content]', window.tippy_options)
-            const content = document.getElementById('content')
-                || document.querySelector('.viewport-layout-inner')
-            if (content)
-                htmx.process(content)
+            const root = document.querySelector('.viewport-layout-inner')
+                || document.getElementById('content')
+            if (root)
+                htmx.process(root)
             if (typeof Alpine !== 'undefined')
                 Alpine.initTree(document.body)
         })

--- a/frontend/app/src/helpers/character_tags_form.ts
+++ b/frontend/app/src/helpers/character_tags_form.ts
@@ -1,0 +1,5 @@
+export function tag_ids_from_form_data(form_data: FormData): number[] {
+    return (form_data.getAll('tag') as string[])
+        .map((tag) => parseInt(tag, 10))
+        .filter((id) => !Number.isNaN(id))
+}

--- a/frontend/app/src/pages/account/tags/[character_id].astro
+++ b/frontend/app/src/pages/account/tags/[character_id].astro
@@ -10,16 +10,37 @@ const user:User | false = auth_token ? jose.decodeJwt(auth_token) as User : fals
 
 if (!user) return Astro.redirect(`${translatePath('/redirects/auth_init')}?redirect_url=${Astro.url}`)
 
-import { get_tags } from '@helpers/api.minmatar.org/characters'
+import { get_tags, set_character_tags } from '@helpers/api.minmatar.org/characters'
+import { tag_ids_from_form_data } from '@helpers/character_tags_form'
 import { get_tags_summary } from '@helpers/fetching/characters'
 import type { CharacterTag } from '@dtypes/api.minmatar.org'
-import type { CharacterTagSummary } from '@dtypes/layout_components'
+import type { CharacterTagSummary, Alert } from '@dtypes/layout_components'
  
 const active_character = parseInt(Astro.params.character_id ? Astro.params.character_id : '0');
 
 let tags_summary:CharacterTagSummary[] = []
 let tags:CharacterTag[] = []
 let get_tags_error: Error | false = false
+let alert:Alert | false = false
+
+if (Astro.request.method === "POST") {
+    try {
+        if (isNaN(active_character) || active_character === 0)
+            throw new Error('invalid_character_id')
+
+        const form_data = await Astro.request.formData()
+        await set_character_tags(
+            auth_token as string,
+            active_character,
+            tag_ids_from_form_data(form_data),
+        )
+    } catch (error) {
+        alert = {
+            title: t('setting_roles'),
+            content: error.message as string,
+        }
+    }
+}
 
 try {
     tags_summary = await get_tags_summary(auth_token as string)
@@ -46,6 +67,7 @@ import FlexInline from '@components/compositions/FlexInline.astro';
 import Button from '@components/blocks/Button.astro';
 import ErrorRefetch from '@components/blocks/ErrorRefetch.astro';
 import CharactersTagList from '@components/blocks/CharactersTagList.astro'
+import ShowAlert from '@components/blocks/ShowAlert.astro'
 
 const page_title = t('account.tags.page_title');
 ---
@@ -58,7 +80,10 @@ const page_title = t('account.tags.page_title');
         modal: true
     }}
 >
+    {alert && <ShowAlert alert={alert} /> }
     <form
+        method="post"
+        action={translatePath(`/account/tags/${active_character}`)}
         hx-post={CHARACTER_TAG_LIST_PARTIAL_URL}
         hx-trigger="submit"
         hx-target="#character-tag-list"
@@ -121,6 +146,7 @@ const page_title = t('account.tags.page_title');
                 event.returnValue = ''
             },
             init() {
+                if (typeof htmx !== 'undefined') htmx.process(this.$el)
                 this._on_before_preparation = (event) => this.on_before_preparation(event)
                 this._on_before_unload = (event) => this.on_before_unload(event)
                 document.addEventListener('astro:before-preparation', this._on_before_preparation)

--- a/frontend/app/src/pages/partials/character_tag_list_component.astro
+++ b/frontend/app/src/pages/partials/character_tag_list_component.astro
@@ -11,6 +11,7 @@ const user:User | false = auth_token ? jose.decodeJwt(auth_token) as User : fals
 if (!user) return Astro.redirect(`${translatePath('/redirects/auth_init')}?redirect_url=${Astro.url}`)
 
 import { get_tags, set_character_tags } from '@helpers/api.minmatar.org/characters'
+import { tag_ids_from_form_data } from '@helpers/character_tags_form'
 import { get_tags_summary } from '@helpers/fetching/characters'
 import type { CharacterTag } from '@dtypes/api.minmatar.org'
 import type { CharacterTagSummary, Alert } from '@dtypes/layout_components'
@@ -25,12 +26,12 @@ let active_character:number = parseInt(Astro.url.searchParams.get('character_id'
 if (Astro.request.method === "POST") {
     try {
         const form_data = await Astro.request.formData()
-        const tags = (form_data.getAll('tag') as string[]).map(tag => parseInt(tag))
+        const selected_tags = tag_ids_from_form_data(form_data)
 
         if (isNaN(active_character))
             throw new Error('invalid_character_id')
 
-        await set_character_tags(auth_token as string, active_character, tags)
+        await set_character_tags(auth_token as string, active_character, selected_tags)
     } catch (error) {
         const set_character_tags_error = error.message
 

--- a/frontend/app/testing/helpers/character_tags_form.test.ts
+++ b/frontend/app/testing/helpers/character_tags_form.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "vitest";
+import { tag_ids_from_form_data } from "@helpers/character_tags_form";
+
+test("tag_ids_from_form_data reads checked role ids", () => {
+  const form_data = new FormData();
+  form_data.append("tag", "1");
+  form_data.append("tag", "7");
+  expect(tag_ids_from_form_data(form_data)).toEqual([1, 7]);
+});
+
+test("tag_ids_from_form_data ignores empty and invalid values", () => {
+  const form_data = new FormData();
+  form_data.append("tag", "2");
+  form_data.append("tag", "");
+  form_data.append("tag", "nope");
+  expect(tag_ids_from_form_data(form_data)).toEqual([2]);
+});
+
+test("tag_ids_from_form_data is empty when no roles are selected", () => {
+  expect(tag_ids_from_form_data(new FormData())).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- Set Character Roles → Update did not save when the page was opened from Account (ClientRouter soft nav). After swap we only ran `htmx.process` on `#content`, so the wrapping `hx-post` form never bound and submit became a no-op GET.
- Process `.viewport-layout-inner` after swap, re-process the roles form on Alpine init, and accept a native POST on the tags page so Update still saves if htmx is not bound.
- Shared helper parses checked role ids (skips invalid values) with unit tests.

## Test plan
- [ ] From Account, click **Set character roles** on an untagged alt (do not refresh). Select a role, press **Update**. Count should change from “0 roles selected” and Account should drop that NO_TAGS prompt.
- [ ] Hard-refresh the roles page, change roles, Update — still saves (htmx partial swap).
- [ ] Switch pilots on the roles reel with unsaved selections — leave confirm still appears.
- [ ] `cd frontend/app && npm test -- testing/helpers/character_tags_form.test.ts`


Made with [Cursor](https://cursor.com)