### PR TITLE
Wrap tribe group status markup in fragments so the frontend image can build.

### DIFF
--- a/frontend/app/src/pages/partials/tribe_group_status_component.astro
+++ b/frontend/app/src/pages/partials/tribe_group_status_component.astro
@@ -184,55 +184,58 @@ import DebugTag from '@components/blocks/DebugTag.astro'
             delay: delay,
         }}
     /> :
-    tribe_group ?
-        <small
-            id={`membership-${tribe_group.tribe_id}-${tribe_group.id}`}
-            class:list={[ 'text-highlight', { hidden: !is_member && !is_pending }, { 'animate-rubber-band': is_pending } ]}
-            hx-swap-oob="true"
-        >
-            {is_member ? t('member_of_tribe_group') : is_pending ? t('tribes.detail.apply_confirm_text') : ''}
-        </small>
+    <>{tribe_group ?
+        <>
+            <small
+                id={`membership-${tribe_group.tribe_id}-${tribe_group.id}`}
+                class:list={[ 'text-highlight', { hidden: !is_member && !is_pending }, { 'animate-rubber-band': is_pending } ]}
+                hx-swap-oob="true"
+            >
+                {is_member ? t('member_of_tribe_group') : is_pending ? t('tribes.detail.apply_confirm_text') : ''}
+            </small>
 
-        {actions_ui &&
-            <TribeGroupApplyHint
-                oob={true}
-                group={tribe_group}
-                tribe_id={tribe_group.tribe_id}
-                group_id={tribe_group.id}
-                is_auth={!!user}
-                is_leader={is_leader}
-                user_on_trial={user_on_trial}
-                user_characters={user_characters}
-                available_characters={available_characters}
-                membership_by_group={membership_by_group}
-            />
-        }
+            {actions_ui &&
+                <TribeGroupApplyHint
+                    oob={true}
+                    group={tribe_group}
+                    tribe_id={tribe_group.tribe_id}
+                    group_id={tribe_group.id}
+                    is_auth={!!user}
+                    is_leader={is_leader}
+                    user_on_trial={user_on_trial}
+                    user_characters={user_characters}
+                    available_characters={available_characters}
+                    membership_by_group={membership_by_group}
+                />
+            }
 
-        {actions_ui ?
-            <TribeGroupActions
-                group={tribe_group}
-                tribe_id={tribe_group.tribe_id}
-                group_id={tribe_group.id}
-                is_auth={!!user}
-                is_leader={is_leader}
-                is_superuser={is_superuser}
-                user_on_trial={user_on_trial}
-                user_characters={user_characters}
-                available_characters={available_characters}
-                membership_by_group={membership_by_group}
-            />
-            :
-            <TribeStatus
-                group={tribe_group}
-                tribe_id={tribe_group.tribe_id}
-                group_id={tribe_group.id}
-                user_characters={user_characters}
-                available_characters={available_characters}
-                is_auth={!!user}
-                user_on_trial={user_on_trial}
-                membership_by_group={membership_by_group}
-            />
-        }
+            {actions_ui ?
+                <TribeGroupActions
+                    group={tribe_group}
+                    tribe_id={tribe_group.tribe_id}
+                    group_id={tribe_group.id}
+                    is_auth={!!user}
+                    is_leader={is_leader}
+                    is_superuser={is_superuser}
+                    user_on_trial={user_on_trial}
+                    user_characters={user_characters}
+                    available_characters={available_characters}
+                    membership_by_group={membership_by_group}
+                />
+                :
+                <TribeStatus
+                    group={tribe_group}
+                    tribe_id={tribe_group.tribe_id}
+                    group_id={tribe_group.id}
+                    user_characters={user_characters}
+                    available_characters={available_characters}
+                    is_auth={!!user}
+                    user_on_trial={user_on_trial}
+                    membership_by_group={membership_by_group}
+                />
+            }
+        </>
         :
         <DebugTag set:html={t('no_tribe_group_unexpected_error')} />
+    }</>
 }


### PR DESCRIPTION
## Summary
- Production deploy failed in `npm run prodbuild` because Vite/esbuild could not parse sibling nodes in a nested ternary in `tribe_group_status_component.astro` (`Expected ":" but found "{"`).
- Wrap the `tribe_group` branch in fragments so it is a single expression, matching other partials.

Fixes the failed production deploy: https://github.com/minmatarfleet/minmatar.org/actions/runs/33394913500/job/99497022712

## Test plan
- [x] `npm run check` from `frontend/app/`
- [x] `npm run prodbuild` from `frontend/app/` (the command that failed in Docker)
- [x] `docker build -f frontend/Dockerfile frontend/` succeeds through the `build` stage
- [ ] Merge and confirm production deploy rebuilds the frontend image

Made with [Cursor](https://cursor.com)