### PR TITLE
Fix industry order Revert Delivery confirm no-op

### DIFF
--- a/frontend/app/src/components/blocks/Dropdown.astro
+++ b/frontend/app/src/components/blocks/Dropdown.astro
@@ -65,6 +65,7 @@ import CollapsableButton from "@components/blocks/CollapsableButton.astro";
             x-bind:style="expanded ? { '--button-dropdown-min-width': `${$refs.trigger?.offsetWidth || 0}px` } : {}"
             @mousedown.outside="expanded && close_if_outside($event)"
             @keydown.escape.prevent.stop="close()"
+            x-init="if (typeof htmx !== 'undefined') htmx.process($el); $watch('expanded', v => { if (v && typeof htmx !== 'undefined') htmx.process($el) })"
             style="display: none"
         >
             <slot />

--- a/frontend/app/src/components/blocks/OrderBreakdown.astro
+++ b/frontend/app/src/components/blocks/OrderBreakdown.astro
@@ -70,6 +70,7 @@ import AddIcon from '@components/icons/buttons/AddIcon.astro';
 
 <Flexblock
     id={id}
+    hx-on--after-swap="window.minmatar_after_outer_html_swap?.call(this)"
     x-init={alert ? `show_alert_dialog(${JSON.stringify(alert)})` : undefined}
 >
     <hr class="border-bottom">

--- a/frontend/app/src/components/partials/FooterScripts.astro
+++ b/frontend/app/src/components/partials/FooterScripts.astro
@@ -78,6 +78,16 @@ const DISABLED_CCPWGL = is_disabled_ccpwgl()
 <script is:inline>
     window.ccpwgl_context = window.ccpwgl_context ?? null
 
+    // After an outerHTML htmx swap the old target is detached, so body
+    // afterSwap listeners never see it. The dying node calls this; look up
+    // the replacement by id and re-bind htmx/Alpine (dropdown teleport, etc.).
+    window.minmatar_after_outer_html_swap = function () {
+        const next = this && this.id ? document.getElementById(this.id) : null
+        if (!next) return
+        if (typeof htmx !== 'undefined') htmx.process(next)
+        if (typeof Alpine !== 'undefined') Alpine.initTree(next)
+    }
+
     if (!window.__footer_scripts_bound) {
         window.__footer_scripts_bound = true
 

--- a/frontend/app/testing/components/blocks/Dropdown.test.ts
+++ b/frontend/app/testing/components/blocks/Dropdown.test.ts
@@ -1,0 +1,18 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { expect, test } from "vitest";
+import Dropdown from "@components/blocks/Dropdown.astro";
+
+test("teleported dropdown panel processes htmx after Alpine mounts it", async () => {
+  const container = await AstroContainer.create();
+  const result = await container.renderToString(Dropdown, {
+    slots: {
+      button: "Actions",
+      default: '<button hx-patch="/partials/example" type="button">Confirm</button>',
+    },
+  });
+
+  expect(result).toContain('x-teleport="body"');
+  expect(result).toContain("htmx.process($el)");
+  expect(result).toContain("$watch('expanded'");
+  expect(result).toContain('hx-patch="/partials/example"');
+});

--- a/frontend/app/testing/components/blocks/OrderBreakdown.test.ts
+++ b/frontend/app/testing/components/blocks/OrderBreakdown.test.ts
@@ -1,0 +1,49 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { expect, test } from "vitest";
+import OrderBreakdown from "@components/blocks/OrderBreakdown.astro";
+
+test("order breakdown rebinds Alpine after outerHTML delivery swaps", async () => {
+  const container = await AstroContainer.create();
+  const result = await container.renderToString(OrderBreakdown, {
+    props: {
+      order_id: 46,
+      primary_character_id: 95434311,
+      order_breakdown: [
+        {
+          id: 141,
+          eve_type_id: 17703,
+          eve_type_name: "Tempest Fleet Issue",
+          quantity: 50,
+          unassigned_quantity: 0,
+          self_assign_maximum: null,
+          self_assign_window_ends_at: new Date("2026-08-31T15:15:35.283Z"),
+          target_unit_price: null,
+          target_estimated_margin: null,
+          assignments: [
+            {
+              id: 286,
+              character_id: 95434311,
+              character_name: "Jyll Ataru",
+              quantity: 10,
+              target_unit_price: null,
+              target_estimated_margin: null,
+              delivered_quantity: 10,
+              delivered_at: new Date("2026-08-30T00:31:56.451Z"),
+              has_blueprints: false,
+            },
+          ],
+        },
+      ],
+      location_name: undefined,
+      swap_target_id: "order-breakdown-46-inner",
+      claim_render: "breakdown",
+    },
+  });
+
+  expect(result).toContain('id="order-breakdown-46-inner"');
+  expect(result).toContain(
+    'hx-on--after-swap="window.minmatar_after_outer_html_swap?.call(this)"',
+  );
+  expect(result).toContain("delivery=false");
+  expect(result).not.toMatch(/hx-on=["']htmx:afterSwap:/);
+});


### PR DESCRIPTION
## Summary
- Confirm in **Actions → Revert delivery** never fired: Alpine teleports the dropdown panel to `body`, and htmx did not bind `hx-patch` on that panel.
- Process the teleported panel on mount/open, and re-init Alpine/htmx after the breakdown `outerHTML` swap so Actions still works afterward.
- Reported in [pulse-technology-toby1492](https://discord.com/channels/1041384161505722368/1544022971830632479) (order 46). Production TFI assignment 286 is still marked delivered.

## Test plan
- [ ] Open `/industry/orders/46/` (or any order with a delivered assignment), **Actions → Revert delivery → Confirm**. Delivery should clear and **Create delivery contract** should appear.
- [ ] After revert, Actions still opens (claim / planner / find blueprint).
- [ ] `npm run test -- --run testing/components/blocks/Dropdown.test.ts testing/components/blocks/OrderBreakdown.test.ts` from `frontend/app/`
- [ ] `npm run check` from `frontend/app/`


Made with [Cursor](https://cursor.com)