### PR TITLE
Fix Schedule fleet Internal server error

### DIFF
--- a/frontend/app/src/components/blocks/FleetForm.astro
+++ b/frontend/app/src/components/blocks/FleetForm.astro
@@ -21,15 +21,19 @@ interface Props {
 
 const {
     fleet = null,
-    audiences,
-    locations,
-    doctrines,
+    audiences: audiences_prop,
+    locations: locations_prop,
+    doctrines: doctrines_prop,
     fleet_commander,
     eve_date,
     eve_time,
     disable_motd,
     lang,
 } = Astro.props
+
+const audiences = Array.isArray(audiences_prop) ? audiences_prop : []
+const locations = Array.isArray(locations_prop) ? locations_prop : []
+const doctrines = Array.isArray(doctrines_prop) ? doctrines_prop : []
 
 const no_doctrine_option = {
     label: t('no_doctrine'),
@@ -45,8 +49,6 @@ const fleet_types_select_options = fleet_types.map( (i):SelectOptions => {
     FLEET_TYPES_LABELS[i] = t(i as any) ?? i
     return {value: i, label: t(i as any) ?? i}
 } )
-
-// Form-up location is selected explicitly; default is the active staging location.
 
 const no_location_option = {
     label: t('select_location'),
@@ -131,6 +133,7 @@ import DoctrineBadge from '@components/blocks/DoctrineBadge.astro'
 import PilotBadge from '@components/blocks/PilotBadge.astro'
 
 import FlagIcon from '@components/icons/FlagIcon.astro';
+import TimerIcon from '@components/icons/buttons/TimerIcon.astro';
 ---
 
 <div>
@@ -176,7 +179,7 @@ import FlagIcon from '@components/icons/FlagIcon.astro';
                 const date_time = this.eve_date+' '+this.eve_time
                 const date_string = new Date(date_time+(utc ? ' UTC' : '')).toLocaleDateString(
                     ${JSON.stringify(lang)},
-                    ${import.meta.env.DATETIME_FORMAT}
+                    ${import.meta.env.DATETIME_FORMAT || '{}'}
                 )
 
                 return (date_string != 'Invalid Date' ? date_string : ${JSON.stringify(t('waiting_fleet_time'))})

--- a/frontend/app/src/helpers/api.minmatar.org/fleets.ts
+++ b/frontend/app/src/helpers/api.minmatar.org/fleets.ts
@@ -64,17 +64,14 @@ export async function get_locations(access_token:string) {
         // console.log(response)
 
         if (!response.ok) {
-            throw new Error(get_error_message(
-                response.status,
-                `GET ${ENDPOINT}`
-            ), {
+            throw new Error(await parse_response_error(response, `GET ${ENDPOINT}`), {
                 cause: response.status
             });
         }
 
         return await response.json() as Location[];
     } catch (error) {
-        throw new Error(`Error fetching fleet types: ${error.message}`, { cause: error.cause });
+        throw new Error(`Error fetching fleet locations: ${error.message}`, { cause: error.cause });
     }
 }
 
@@ -96,17 +93,14 @@ export async function get_audiences(access_token:string) {
         // console.log(response)
 
         if (!response.ok) {
-            throw new Error(get_error_message(
-                response.status,
-                `GET ${ENDPOINT}`
-            ), {
+            throw new Error(await parse_response_error(response, `GET ${ENDPOINT}`), {
                 cause: response.status
             });
         }
 
         return await response.json() as Audience[];
     } catch (error) {
-        throw new Error(`Error fetching fleet types: ${error.message}`, { cause: error.cause });
+        throw new Error(`Error fetching fleet audiences: ${error.message}`, { cause: error.cause });
     }
 }
 

--- a/frontend/app/src/helpers/fetching/doctrines.ts
+++ b/frontend/app/src/helpers/fetching/doctrines.ts
@@ -19,6 +19,24 @@ function normalize_doctrine_type(type: string): DoctrineTypes {
     return 'non_strategic'
 }
 
+/** Id/name only — fleet schedule form dropdown. Does not hydrate fittings or SDE. */
+export async function fetch_doctrine_options(): Promise<DoctrineType[]> {
+    const api_doctrines: Doctrine[] = await get_doctrines()
+
+    return api_doctrines.map((doctrine) => ({
+        id: doctrine.id,
+        name: doctrine.name,
+        description: doctrine.description,
+        created_at: doctrine.created_at,
+        updated_at: doctrine.updated_at,
+        type: normalize_doctrine_type(doctrine.type),
+        primary_fittings: [],
+        secondary_fittings: [],
+        support_fittings: [],
+        location_ids: doctrine.location_ids ?? [],
+    }))
+}
+
 export async function fetch_doctrines() {
     let api_doctrines:Doctrine[]
 

--- a/frontend/app/src/pages/fleets/add.astro
+++ b/frontend/app/src/pages/fleets/add.astro
@@ -94,7 +94,7 @@ if (Astro.request.method === "POST") {
 }
 
 import { get_user_character } from '@helpers/fetching/characters'
-import { fetch_doctrines } from '@helpers/fetching/doctrines'
+import { fetch_doctrine_options } from '@helpers/fetching/doctrines'
 
 let doctrines:DoctrineType[] = []
 let fleet_commander:CharacterBasic | null = null
@@ -113,7 +113,7 @@ try {
         character_name: user_profile.character_name,
     }
 
-    doctrines = await fetch_doctrines()
+    doctrines = await fetch_doctrine_options()
     audiences = await get_audiences(auth_token as string)
     locations = await get_locations(auth_token as string)
 } catch (error) {

--- a/frontend/app/src/pages/fleets/upcoming/edit/[fleet_id].astro
+++ b/frontend/app/src/pages/fleets/upcoming/edit/[fleet_id].astro
@@ -81,7 +81,7 @@ if (Astro.request.method === "POST") {
 }
 
 import type { FleetUI } from '@dtypes/layout_components'
-import { fetch_doctrines } from '@helpers/fetching/doctrines'
+import { fetch_doctrine_options } from '@helpers/fetching/doctrines'
 import { fetch_fleet_by_id } from '@helpers/fetching/fleets'
 
 let doctrines:DoctrineType[] = []
@@ -97,7 +97,7 @@ try {
         character_id: fleet.fleet_commander_id,
         character_name: fleet.fleet_commander_name,
     }
-    doctrines = await fetch_doctrines()
+    doctrines = await fetch_doctrine_options()
     audiences = await get_audiences(auth_token as string)
     locations = await get_locations(auth_token as string)
 } catch (error) {

--- a/frontend/app/src/pages/partials/fleet_form_component.astro
+++ b/frontend/app/src/pages/partials/fleet_form_component.astro
@@ -26,7 +26,7 @@ import type { DoctrineType, CharacterBasic } from '@dtypes/layout_components'
 const fleet_id = parseInt(Astro.url.searchParams.get('fleet_id') as string)
 
 import type { FleetUI } from '@dtypes/layout_components'
-import { fetch_doctrines } from '@helpers/fetching/doctrines'
+import { fetch_doctrine_options } from '@helpers/fetching/doctrines'
 import { fetch_fleet_by_id } from '@helpers/fetching/fleets'
 
 let doctrines:DoctrineType[] = []
@@ -45,7 +45,7 @@ try {
         }
     }
     
-    doctrines = await fetch_doctrines()
+    doctrines = await fetch_doctrine_options()
     audiences = await get_audiences(auth_token as string)
     locations = await get_locations(auth_token as string)
 } catch (error) {


### PR DESCRIPTION
## Summary
- Restore the missing `TimerIcon` import on the fleet schedule form. `#2689` used the icon without importing it, so `/fleets/add/` streamed the heading then died with **Internal server error**.
- Load doctrine id/name only for the dropdown (badges still hydrate via htmx on select) and surface real location/audience API errors.

## Test plan
- [ ] Open `/fleets/add/` as an FC — form renders (location, doctrine, audience, submit), not the error line under **Schedule fleet**.
- [ ] Submit a fleet and land on `/fleets/upcoming/<id>`.
- [ ] Edit an upcoming fleet and confirm the same form still loads.


Made with [Cursor](https://cursor.com)