### PR TITLE
Poll NPSI calendar feeds every 4 hours

### DIFF
--- a/backend/app/settings_celery.py
+++ b/backend/app/settings_celery.py
@@ -285,7 +285,7 @@ CELERYBEAT_OTHER = [
         "[Misc] Poll NPSI calendar feeds",
         {
             "task": "fleets.tasks.poll_npsi_events",
-            "schedule": schedule(timedelta(minutes=15)),
+            "schedule": schedule(timedelta(hours=4)),
         },
     ),
     (


### PR DESCRIPTION
## Summary
- Slow Celery Beat NPSI calendar ingest from every 15 minutes to every 4 hours (`fleets.tasks.poll_npsi_events`).

## Test plan
- [ ] Confirm Beat shows `[Misc] Poll NPSI calendar feeds` on a 4-hour schedule after deploy/restart.
- [ ] Optionally kick off `poll_npsi_events` once and check logs still ingest/notify as before.


Made with [Cursor](https://cursor.com)