### PR TITLE
Keep allocated fitting-buy variants as item rows

### DIFF
--- a/backend/market/endpoints/fitting_buy_orders/get_order.py
+++ b/backend/market/endpoints/fitting_buy_orders/get_order.py
@@ -3,6 +3,7 @@
 from app.errors import ErrorResponse
 from authentication import AuthBearer
 from market.endpoints.fitting_buy_orders.common import get_order_or_404
+from market.helpers.fitting_buy_plan import sync_order_items
 from market.helpers.fitting_buy_serialize import (
     FittingBuyOrderDetailSchema,
     serialize_order_detail,
@@ -21,4 +22,5 @@ def get_fitting_buy_order(request, order_id: int):
     order, err = get_order_or_404(order_id)
     if err:
         return err
+    sync_order_items(order)
     return serialize_order_detail(order, request.user)

--- a/backend/market/helpers/fitting_buy_allocations.py
+++ b/backend/market/helpers/fitting_buy_allocations.py
@@ -149,6 +149,34 @@ def normalize_entries(entries: list[dict]) -> list[dict]:
     ]
 
 
+def allocated_variant_qtys(order: FittingBuyOrder, plan) -> dict[int, int]:
+    """Buy qty per allocated variant type (excludes the preferred type)."""
+    result: dict[int, int] = {}
+    for type_id, qty in effective_buy_map(order, plan).items():
+        if qty <= 0:
+            continue
+        if type_id in plan.needed:
+            continue
+        result[type_id] = qty
+    return result
+
+
+def cached_jita_item_fields(
+    order: FittingBuyOrder,
+    type_id: int,
+    *,
+    items_by_id: dict[int, FittingBuyOrderItem] | None = None,
+) -> dict:
+    """Jita columns for a new/updated item row from the item or variant cache."""
+    depth = cached_jita_depth(order, type_id, items_by_id=items_by_id)
+    sell_min = depth.get("jita_sell_min")
+    return {
+        "jita_sell_volume": depth.get("jita_sell_volume"),
+        "jita_order_count": depth.get("jita_order_count"),
+        "jita_sell_min": parse_jita_sell_min(sell_min),
+    }
+
+
 def effective_buy_map(order: FittingBuyOrder, plan) -> dict[int, int]:
     """plan.buy with shopping_allocations applied.
 
@@ -244,8 +272,7 @@ def set_allocations(
     if not normalized:
         if key in allocations:
             allocations.pop(key, None)
-            order.shopping_allocations = allocations
-            order.save(update_fields=["shopping_allocations", "updated_at"])
+            _persist_allocations(order, allocations)
         return
 
     fitting_ids = order.lines.values_list("fitting_id", flat=True)
@@ -277,8 +304,7 @@ def set_allocations(
     if not clamped:
         if key in allocations:
             allocations.pop(key, None)
-            order.shopping_allocations = allocations
-            order.save(update_fields=["shopping_allocations", "updated_at"])
+            _persist_allocations(order, allocations)
         return
 
     total = sum(entry["qty"] for entry in clamped)
@@ -288,5 +314,15 @@ def set_allocations(
         )
 
     allocations[key] = clamped
+    _persist_allocations(order, allocations)
+
+
+def _persist_allocations(order: FittingBuyOrder, allocations: dict) -> None:
     order.shopping_allocations = allocations
     order.save(update_fields=["shopping_allocations", "updated_at"])
+    # Circular: fitting_buy_plan.sync_order_items imports prune_invalid_allocations.
+    from market.helpers.fitting_buy_plan import (  # pylint: disable=import-outside-toplevel
+        sync_order_items,
+    )
+
+    sync_order_items(order)

--- a/backend/market/helpers/fitting_buy_check.py
+++ b/backend/market/helpers/fitting_buy_check.py
@@ -87,6 +87,19 @@ def apply_depth_to_order(
         row.jita_order_count = depth.order_count
         row.jita_sell_min = depth.sell_min
         to_update.append(row)
+    updated_ids = {row.eve_type_id for row in to_update}
+    for row in items.values():
+        if row.eve_type_id in updated_ids:
+            continue
+        if row.needed_qty > 0 or row.buy_qty <= 0:
+            continue
+        depth = depths.get(row.eve_type_id)
+        if depth is None:
+            continue
+        row.jita_sell_volume = depth.volume
+        row.jita_order_count = depth.order_count
+        row.jita_sell_min = depth.sell_min
+        to_update.append(row)
 
     with transaction.atomic():
         if to_update:

--- a/backend/market/helpers/fitting_buy_plan.py
+++ b/backend/market/helpers/fitting_buy_plan.py
@@ -10,7 +10,11 @@ from eveuniverse.models import EveType
 
 from industry.helpers.plan_stock import parse_stock_paste
 from market.helpers.contract_match import fitting_type_quantities_bulk
-from market.helpers.fitting_buy_allocations import prune_invalid_allocations
+from market.helpers.fitting_buy_allocations import (
+    allocated_variant_qtys,
+    cached_jita_item_fields,
+    prune_invalid_allocations,
+)
 from market.models.fitting_buy_order import (
     FittingBuyOrder,
     FittingBuyOrderItem,
@@ -162,13 +166,20 @@ def build_shopping_plan(order: FittingBuyOrder) -> ShoppingPlan:
 
 def sync_order_items(order: FittingBuyOrder) -> ShoppingPlan:
     plan = build_shopping_plan(order)
+    prune_invalid_allocations(order, plan)
+    variant_buy = allocated_variant_qtys(order, plan)
+    bom_ids = set(plan.needed.keys())
+    keep_ids = bom_ids | set(variant_buy)
     existing = {row.eve_type_id: row for row in order.items.all()}
-    keep_ids = set(plan.needed.keys())
-    deleted = order.items.exclude(eve_type_id__in=keep_ids).delete()[0]
+    bom_row_dropped = any(
+        type_id not in keep_ids and row.needed_qty > 0
+        for type_id, row in existing.items()
+    )
+    order.items.exclude(eve_type_id__in=keep_ids).delete()
 
     to_create: list[FittingBuyOrderItem] = []
     to_update: list[FittingBuyOrderItem] = []
-    bom_changed = deleted > 0
+    bom_changed = bom_row_dropped
     for type_id, needed in plan.needed.items():
         stock_qty = plan.stock.get(type_id, 0)
         buy_qty = plan.buy.get(type_id, 0)
@@ -198,6 +209,31 @@ def sync_order_items(order: FittingBuyOrder) -> ShoppingPlan:
             to_update.append(row)
             bom_changed = True
 
+    for type_id, buy_qty in variant_buy.items():
+        jita = cached_jita_item_fields(order, type_id, items_by_id=existing)
+        row = existing.get(type_id)
+        if row is None:
+            to_create.append(
+                FittingBuyOrderItem(
+                    order=order,
+                    eve_type_id=type_id,
+                    needed_qty=0,
+                    stock_qty=0,
+                    buy_qty=buy_qty,
+                    **jita,
+                )
+            )
+            continue
+        if row.needed_qty != 0 or row.stock_qty != 0 or row.buy_qty != buy_qty:
+            row.needed_qty = 0
+            row.stock_qty = 0
+            row.buy_qty = buy_qty
+            if row.jita_sell_volume is None:
+                row.jita_sell_volume = jita["jita_sell_volume"]
+                row.jita_order_count = jita["jita_order_count"]
+                row.jita_sell_min = jita["jita_sell_min"]
+            to_update.append(row)
+
     if to_create:
         FittingBuyOrderItem.objects.bulk_create(to_create)
     if to_update:
@@ -215,7 +251,6 @@ def sync_order_items(order: FittingBuyOrder) -> ShoppingPlan:
     if bom_changed and order.jita_checked_at is not None:
         order.jita_checked_at = None
         order.save(update_fields=["jita_checked_at", "updated_at"])
-    prune_invalid_allocations(order, plan)
     return plan
 
 

--- a/backend/market/helpers/fitting_buy_serialize.py
+++ b/backend/market/helpers/fitting_buy_serialize.py
@@ -470,11 +470,12 @@ def serialize_order_detail(  # noqa: C901
                 bool(row.shortfall and row.shortfall > 0)
                 or type_id in preferred_ids_with_alloc
             )
+            from_id = allocated_from.get(type_id)
             item_schemas.append(
                 display_row(
                     type_id=type_id,
                     buy_qty=buy_qty,
-                    needed_qty=row.needed_qty,
+                    needed_qty=buy_qty if from_id else row.needed_qty,
                     stock_qty=row.stock_qty,
                     jita_sell_volume=row.jita_sell_volume,
                     jita_order_count=row.jita_order_count,
@@ -488,6 +489,7 @@ def serialize_order_detail(  # noqa: C901
                         if row.unit_price is not None
                         else None
                     ),
+                    allocated_from_type_id=from_id,
                     can_allocate=can_allocate,
                     allocate_buy_qty=row.buy_qty if can_allocate else None,
                     alternates=alts,
@@ -533,11 +535,12 @@ def serialize_order_detail(  # noqa: C901
         ):
             continue
         display_buy = effective_buy.get(row.eve_type_id, 0)
+        from_id = allocated_from.get(row.eve_type_id)
         item_schemas.append(
             display_row(
                 type_id=row.eve_type_id,
                 buy_qty=display_buy,
-                needed_qty=row.needed_qty,
+                needed_qty=display_buy if from_id else row.needed_qty,
                 stock_qty=row.stock_qty,
                 jita_sell_volume=row.jita_sell_volume,
                 jita_order_count=row.jita_order_count,
@@ -549,6 +552,7 @@ def serialize_order_detail(  # noqa: C901
                 unit_price=(
                     str(row.unit_price) if row.unit_price is not None else None
                 ),
+                allocated_from_type_id=from_id,
                 can_allocate=can_allocate,
                 allocate_buy_qty=row.buy_qty if can_allocate else None,
                 alternates=fitted,

--- a/backend/market/tests/test_fitting_buy_orders.py
+++ b/backend/market/tests/test_fitting_buy_orders.py
@@ -39,6 +39,7 @@ from market.helpers.fitting_buy_allocations import (
     effective_buy_map,
     set_allocations,
 )
+from market.helpers.fitting_buy_guide import shopping_landed_complete
 from market.helpers.fitting_buy_plan import (
     build_shopping_plan,
     sync_order_items,
@@ -946,6 +947,81 @@ class FittingBuyAllocationTestCase(TestCase):
             if item["type_id"] == self.faction.id
         )
         self.assertEqual(faction_item["buy_qty"], 5)
+        self.assertTrue(
+            self.order.items.filter(eve_type_id=self.compact.id).exists()
+        )
+        self.assertTrue(
+            self.order.items.filter(eve_type_id=self.faction.id).exists()
+        )
+
+    def test_variant_items_keep_landed_prices_across_sync(self):
+        set_allocations(
+            self.order,
+            preferred_type_id=self.preferred.id,
+            entries=[
+                {"type_id": self.preferred.id, "qty": 7},
+                {"type_id": self.compact.id, "qty": 8},
+                {"type_id": self.faction.id, "qty": 5},
+            ],
+        )
+        preferred = self.order.items.get(eve_type_id=self.preferred.id)
+        preferred.unit_price = Decimal("100")
+        preferred.save(update_fields=["unit_price"])
+        self.assertFalse(shopping_landed_complete(self.order))
+
+        updated, unresolved = apply_landed_prices(
+            self.order,
+            f"{self.compact.name}\t10\n{self.faction.name}\t20",
+        )
+        self.assertEqual(updated, 2)
+        self.assertEqual(unresolved, [])
+        self.assertTrue(shopping_landed_complete(self.order))
+        self.order.refresh_from_db()
+        self.assertIsNotNone(self.order.jita_checked_at)
+
+        sync_order_items(self.order)
+        compact = self.order.items.get(eve_type_id=self.compact.id)
+        self.assertEqual(compact.buy_qty, 8)
+        self.assertEqual(compact.needed_qty, 0)
+        self.assertEqual(compact.unit_price, Decimal("10"))
+        self.assertEqual(compact.jita_sell_volume, 8)
+        self.assertTrue(shopping_landed_complete(self.order))
+        self.assertIsNotNone(self.order.jita_checked_at)
+
+        set_allocations(
+            self.order,
+            preferred_type_id=self.preferred.id,
+            entries=[],
+        )
+        self.assertFalse(
+            self.order.items.filter(eve_type_id=self.compact.id).exists()
+        )
+        self.assertFalse(
+            self.order.items.filter(eve_type_id=self.faction.id).exists()
+        )
+
+    def test_get_order_heals_missing_variant_items(self):
+        self.order.shopping_allocations = {
+            str(self.preferred.id): [
+                {"type_id": self.preferred.id, "qty": 7},
+                {"type_id": self.compact.id, "qty": 8},
+            ]
+        }
+        self.order.save(update_fields=["shopping_allocations", "updated_at"])
+        self.assertFalse(
+            self.order.items.filter(eve_type_id=self.compact.id).exists()
+        )
+        response = self.client.get(
+            f"/fitting-buy-orders/{self.order.id}",
+            headers=_auth_headers(self.owner),
+        )
+        self.assertEqual(response.status_code, 200)
+        compact = self.order.items.get(eve_type_id=self.compact.id)
+        self.assertEqual(compact.buy_qty, 8)
+        self.assertEqual(compact.needed_qty, 0)
+        self.assertEqual(compact.jita_sell_volume, 8)
+        self.order.refresh_from_db()
+        self.assertIsNotNone(self.order.jita_checked_at)
 
     def test_rejects_unknown_variant_and_over_sum(self):
         with self.assertRaises(AllocationError):


### PR DESCRIPTION
## Summary
- Persist Jita-split variant types as `FittingBuyOrderItem` rows (and keep them across BOM sync) so landed unit prices can attach.
- Reload of an order heals missing variant rows without clearing the Jita check.
- Fixes orders stuck on the purchase step after allocating a short onto an alternate (e.g. order 15 / Dark Blood Kinetic Coating).

## Test plan
- [ ] `pipenv run python manage.py test market.tests.test_fitting_buy_orders market.tests.test_fitting_buy_guide --settings=app.settings_test` from `backend/`
- [ ] Open a fitting buy order, allocate a short onto a variant, paste landed prices including that variant, confirm the guide advances to contract
- [ ] Reload the order and confirm the variant row is still there and Jita depth is unchanged
- [ ] After deploy, reload `/market/fitting_orders/15/` and paste Dark Blood Kinetic Coating (or set its `unit_price`) so it can leave purchase


Made with [Cursor](https://cursor.com)