### PR TITLE
Fix tribe group manage access and buyback contract matching

### DIFF
--- a/backend/buyback/helpers/purchase_orders.py
+++ b/backend/buyback/helpers/purchase_orders.py
@@ -6,7 +6,7 @@ from django.db import transaction
 from django.db.models import Q, Sum
 from django.utils import timezone
 from eveonline.helpers.characters import user_primary_character
-from eveonline.models import EveCharacter
+from eveonline.models import EveCharacter, EveCorporation
 from eveuniverse.models import EveType
 
 from buyback.discord_tasks import (
@@ -16,6 +16,7 @@ from buyback.discord_tasks import (
 from buyback.helpers.purchase_discord import discord_thread_url
 from buyback.helpers.purchase_fill import PurchaseFill, fill_purchase
 from buyback.helpers.remaining import remaining_sale_quantities
+from buyback.helpers.sell_pricing import contract_total_isk, line_total
 from buyback.models import (
     BuybackLedgerEntry,
     BuybackPurchaseOrder,
@@ -112,11 +113,40 @@ def serialize_order(order: BuybackPurchaseOrder) -> dict:
     }
 
 
-def _sold_by_type_since(character_id: int, since) -> dict[int, int]:
+def _match_entity_ids(order: BuybackPurchaseOrder) -> set[int]:
+    """Characters and corps that count as this thread maker for outbound matching."""
+    ids: set[int] = set()
+    if order.character_id:
+        ids.add(int(order.character_id))
+    user_id = order.created_by_id
+    if not user_id:
+        return ids
+    characters = list(
+        EveCharacter.objects.filter(user_id=user_id).values_list(
+            "character_id", "corporation_id"
+        )
+    )
+    for character_id, corporation_id in characters:
+        ids.add(int(character_id))
+        if corporation_id:
+            ids.add(int(corporation_id))
+    ids.update(
+        int(corporation_id)
+        for corporation_id in EveCorporation.objects.filter(
+            ceo__user_id=user_id
+        ).values_list("corporation_id", flat=True)
+        if corporation_id
+    )
+    return ids
+
+
+def _sold_by_type_since(entity_ids: set[int], since) -> dict[int, int]:
+    if not entity_ids:
+        return {}
     rows = (
         BuybackLedgerEntry.objects.filter(
             reason=BuybackLedgerEntry.Reason.SOLD_CONTRACT,
-            counterparty_id=character_id,
+            counterparty_id__in=entity_ids,
             occurred_at__gte=since,
         )
         .values("eve_type_id")
@@ -129,27 +159,42 @@ def _sold_by_type_since(character_id: int, since) -> dict[int, int]:
     }
 
 
+def _claimed_qty(
+    allocated: dict[tuple[int, int], int],
+    entity_ids: set[int],
+    type_id: int,
+) -> int:
+    if not entity_ids:
+        return 0
+    return max(
+        (allocated.get((entity_id, type_id), 0) for entity_id in entity_ids),
+        default=0,
+    )
+
+
 def _allocate_order_lines(
     order: BuybackPurchaseOrder,
     allocated: dict[tuple[int, int], int],
 ) -> None:
-    if not order.character_id:
+    entity_ids = _match_entity_ids(order)
+    if not entity_ids:
         return
     for line in order.lines.all():
-        key = (order.character_id, line.eve_type_id)
-        allocated[key] = allocated.get(key, 0) + int(line.quantity)
+        for entity_id in entity_ids:
+            key = (entity_id, line.eve_type_id)
+            allocated[key] = allocated.get(key, 0) + int(line.quantity)
 
 
 def _allocated_before_order(
     order: BuybackPurchaseOrder,
 ) -> dict[tuple[int, int], int]:
     allocated: dict[tuple[int, int], int] = {}
-    if not order.character_id:
+    entity_ids = _match_entity_ids(order)
+    if not entity_ids:
         return allocated
     earlier = (
         BuybackPurchaseOrder.objects.filter(
             status=BuybackPurchaseOrder.Status.PENDING,
-            character_id=order.character_id,
         )
         .filter(
             Q(created_at__lt=order.created_at)
@@ -159,23 +204,60 @@ def _allocated_before_order(
         .order_by("created_at", "pk")
     )
     for earlier_order in earlier:
-        _allocate_order_lines(earlier_order, allocated)
+        if _match_entity_ids(earlier_order) & entity_ids:
+            _allocate_order_lines(earlier_order, allocated)
     return allocated
+
+
+def _outbound_cover_for_order(
+    order: BuybackPurchaseOrder,
+    allocated: dict[tuple[int, int], int],
+) -> dict[int, int]:
+    entity_ids = _match_entity_ids(order)
+    if not entity_ids:
+        return {}
+    sold = _sold_by_type_since(entity_ids, order.created_at)
+    cover: dict[int, int] = {}
+    for line in order.lines.all():
+        claimed = _claimed_qty(allocated, entity_ids, line.eve_type_id)
+        available = sold.get(line.eve_type_id, 0) - claimed
+        cover[line.eve_type_id] = max(available, 0)
+    return cover
 
 
 def _outbound_available_for_order(
     order: BuybackPurchaseOrder,
     allocated: dict[tuple[int, int], int],
 ) -> bool:
-    if not order.character_id:
+    entity_ids = _match_entity_ids(order)
+    if not entity_ids:
         return False
-    sold = _sold_by_type_since(order.character_id, order.created_at)
+    cover = _outbound_cover_for_order(order, allocated)
     for line in order.lines.all():
-        key = (order.character_id, line.eve_type_id)
-        available = sold.get(line.eve_type_id, 0) - allocated.get(key, 0)
-        if available < line.quantity:
+        if cover.get(line.eve_type_id, 0) < line.quantity:
             return False
     return True
+
+
+def _apply_outbound_fill(
+    order: BuybackPurchaseOrder, cover: dict[int, int]
+) -> None:
+    remaining = dict(cover)
+    totals = []
+    for line in list(order.lines.all()):
+        available = remaining.get(line.eve_type_id, 0)
+        shipped = min(int(line.quantity), available)
+        remaining[line.eve_type_id] = available - shipped
+        if shipped <= 0:
+            line.delete()
+            continue
+        if shipped != line.quantity:
+            line.quantity = shipped
+            line.line_total = line_total(line.unit_price, shipped)
+            line.save(update_fields=["quantity", "line_total"])
+        totals.append(line.line_total)
+    order.contract_total = contract_total_isk(totals)
+    order.save(update_fields=["contract_total", "updated_at"])
 
 
 def _order_character(order_character: EveCharacter | None, user):
@@ -280,10 +362,13 @@ def complete_purchase_order(order: BuybackPurchaseOrder, user) -> None:
     if order.status != BuybackPurchaseOrder.Status.PENDING:
         raise PurchaseOrderError("Only pending orders can be completed.")
     allocated = _allocated_before_order(order)
-    if not _outbound_available_for_order(order, allocated):
+    cover = _outbound_cover_for_order(order, allocated)
+    if not any(qty > 0 for qty in cover.values()):
         raise PurchaseOrderError(
             "No matching outbound contract has synced for this order yet."
         )
+    if not _outbound_available_for_order(order, allocated):
+        _apply_outbound_fill(order, cover)
     order.status = BuybackPurchaseOrder.Status.COMPLETED
     order.completed_at = timezone.now()
     order.completed_by = user

--- a/backend/buyback/tests/test_stockpile_edge_cases.py
+++ b/backend/buyback/tests/test_stockpile_edge_cases.py
@@ -29,6 +29,7 @@ from buyback.models import (
 )
 from buyback.tests.helpers import BASE_URL, ensure_type
 from eveonline.models import (
+    EveCharacter,
     EveCorporation,
     EveCorporationContract,
     EveLocation,
@@ -294,6 +295,62 @@ class FifoAutoCompleteEdgeCaseTestCase(StockpileEdgeCaseBase):
         with self.assertRaises(PurchaseOrderError):
             complete_purchase_order(order, self.user)
 
+    def test_contract_to_buyer_corporation_completes(self):
+        EveCharacter.objects.filter(character_id=123456).update(
+            corporation_id=98832280
+        )
+        order = self._place(10)
+        _ledger(
+            eve_type=self.water,
+            quantity=10,
+            reason=BuybackLedgerEntry.Reason.SOLD_CONTRACT,
+            source_id="out:buyer-corp",
+            counterparty_id=98832280,
+            occurred_at=timezone.now(),
+        )
+        self.assertEqual(try_complete_from_outbound_contracts(), 1)
+        order.refresh_from_db()
+        self.assertEqual(order.status, BuybackPurchaseOrder.Status.COMPLETED)
+
+    def test_contract_to_buyer_alt_completes(self):
+        EveCharacter.objects.create(
+            character_id=222222,
+            character_name="Alt Char",
+            user=self.user,
+        )
+        order = self._place(10)
+        _ledger(
+            eve_type=self.water,
+            quantity=10,
+            reason=BuybackLedgerEntry.Reason.SOLD_CONTRACT,
+            source_id="out:buyer-alt",
+            counterparty_id=222222,
+            occurred_at=timezone.now(),
+        )
+        self.assertEqual(try_complete_from_outbound_contracts(), 1)
+        order.refresh_from_db()
+        self.assertEqual(order.status, BuybackPurchaseOrder.Status.COMPLETED)
+
+    def test_contract_to_ceo_corporation_completes(self):
+        char = EveCharacter.objects.get(character_id=123456)
+        EveCorporation.objects.create(
+            corporation_id=5550001,
+            name="Owned Corp",
+            ceo=char,
+        )
+        order = self._place(10)
+        _ledger(
+            eve_type=self.water,
+            quantity=10,
+            reason=BuybackLedgerEntry.Reason.SOLD_CONTRACT,
+            source_id="out:ceo-corp",
+            counterparty_id=5550001,
+            occurred_at=timezone.now(),
+        )
+        self.assertEqual(try_complete_from_outbound_contracts(), 1)
+        order.refresh_from_db()
+        self.assertEqual(order.status, BuybackPurchaseOrder.Status.COMPLETED)
+
 
 class HangarCapEdgeCaseTestCase(TestCase):
     def setUp(self):
@@ -449,6 +506,43 @@ class MultiLineOrderEdgeCaseTestCase(TestCase):
             counterparty_id=123456,
         )
         self.assertEqual(try_complete_from_outbound_contracts(), 1)
+
+    def test_manual_complete_accepts_partial_outbound(self):
+        order = BuybackPurchaseOrder.objects.create(
+            status=BuybackPurchaseOrder.Status.PENDING,
+            created_by=self.user,
+            character_id=123456,
+            character_name="Test Char",
+            paste="Water\t10\nBiocells\t10",
+            contract_total=2000,
+            sell_price_basis=SellPriceBasis.JITA_SPLIT,
+            sell_markup=0,
+        )
+        for eve_type, qty in ((self.water, 10), (self.bio, 10)):
+            order.lines.create(
+                eve_type=eve_type,
+                name=eve_type.name,
+                quantity=qty,
+                unit_price=Decimal("100.00"),
+                line_total=Decimal("1000.00"),
+            )
+        _ledger(
+            eve_type=self.water,
+            quantity=6,
+            reason=BuybackLedgerEntry.Reason.SOLD_CONTRACT,
+            source_id="out:water-partial",
+            counterparty_id=123456,
+        )
+        complete_purchase_order(order, self.user)
+        order.refresh_from_db()
+        self.assertEqual(order.status, BuybackPurchaseOrder.Status.COMPLETED)
+        lines = list(order.lines.all())
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0].eve_type_id, self.water.id)
+        self.assertEqual(lines[0].quantity, 6)
+        self.assertEqual(order.contract_total, 600)
+        self.assertEqual(remaining_sale_quantities()[self.water.id], 44)
+        self.assertEqual(remaining_sale_quantities()[self.bio.id], 50)
 
 
 class ConcurrentPlaceEdgeCaseTestCase(TestCase):

--- a/backend/tribes/endpoints/groups/schemas.py
+++ b/backend/tribes/endpoints/groups/schemas.py
@@ -55,6 +55,7 @@ class TribeGroupSchema(BaseModel):
     require_off_trial: bool = False
     allowed_affiliations: List[AffiliationRefSchema] = []
     can_apply: bool = False
+    can_manage: bool = False
 
 
 class TribeGroupReportSchema(BaseModel):

--- a/backend/tribes/endpoints/groups/serializers.py
+++ b/backend/tribes/endpoints/groups/serializers.py
@@ -16,6 +16,7 @@ from tribes.endpoints.groups.schemas import (
     TribeGroupSchema,
 )
 from tribes.endpoints.serialization import user_to_character_ref
+from tribes.helpers import user_can_manage_group
 from tribes.models import TribeGroup, TribeGroupMembership
 
 
@@ -46,12 +47,14 @@ def serialize_tribe_group(
         ).count()
     chief_ref = user_to_character_ref(tg.chief) if tg.chief else None
     can_apply = False
+    can_manage = False
     if request_user is not None and getattr(
         request_user, "is_authenticated", False
     ):
         can_apply = can_use_feature(
             request_user, "tribes.apply", tribe_group=tg
         )
+        can_manage = user_can_manage_group(request_user, tg)
 
     return TribeGroupSchema(
         id=tg.pk,
@@ -96,4 +99,5 @@ def serialize_tribe_group(
         require_off_trial=bool(tg.require_off_trial),
         allowed_affiliations=effective_allowed_affiliations(tg),
         can_apply=can_apply,
+        can_manage=can_manage,
     )

--- a/backend/tribes/tests/test_affiliation_gate.py
+++ b/backend/tribes/tests/test_affiliation_gate.py
@@ -129,6 +129,7 @@ class TribeGroupAffiliationGateTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertTrue(data["can_apply"])
+        self.assertFalse(data["can_manage"])
         names = {a["name"] for a in data["allowed_affiliations"]}
         self.assertEqual(names, {"Alliance"})
 
@@ -141,6 +142,17 @@ class TribeGroupAffiliationGateTestCase(TestCase):
             HTTP_AUTHORIZATION=f"Bearer {self.token}",
         )
         self.assertFalse(response.json()["can_apply"])
+        self.assertFalse(response.json()["can_manage"])
+
+    def test_group_schema_can_manage_for_group_chief(self):
+        self.alliance_only.chief = self.user
+        self.alliance_only.save(update_fields=["chief"])
+        response = self.client.get(
+            f"{BASE_URL}/{self.tribe.pk}/groups/{self.alliance_only.pk}",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["can_manage"])
 
     def test_offboard_only_ineligible_memberships(self):
         alliance_membership = TribeGroupMembership.objects.create(

--- a/frontend/app/src/components/blocks/Dropdown.astro
+++ b/frontend/app/src/components/blocks/Dropdown.astro
@@ -55,7 +55,7 @@ import CollapsableButton from "@components/blocks/CollapsableButton.astro";
         <div
             class:list={[
                 attributes.class,
-                '[ dropdown-panel light-transparency ][ px-[var(--space-3xs)] py-[var(--space-3xs)] ]',
+                '[ dropdown-panel solid-transparency ][ px-[var(--space-3xs)] py-[var(--space-3xs)] ]',
                 { 'button-dropdown-panel': variant === 'button' },
             ]}
             x-ref="panel"
@@ -78,17 +78,20 @@ import CollapsableButton from "@components/blocks/CollapsableButton.astro";
         position: relative;
     }
 
+    [x-cloak] {
+        display: none !important;
+    }
+</style>
+
+<style lang="scss" is:global>
     .dropdown-panel {
         z-index: var(--tooltips-z-index);
     }
 
     .button-dropdown-panel {
-        min-width: var(--button-dropdown-min-width, 0px);
-        width: var(--button-dropdown-min-width, max-content);
+        min-width: max(12rem, var(--button-dropdown-min-width, 0px));
+        width: max-content;
+        max-width: min(24rem, calc(100vw - var(--space-s)));
         box-sizing: border-box;
-    }
-
-    [x-cloak] {
-        display: none !important;
     }
 </style>

--- a/frontend/app/src/components/blocks/TribeGroupActions.astro
+++ b/frontend/app/src/components/blocks/TribeGroupActions.astro
@@ -9,7 +9,7 @@ import type {
     TribeAvailableCharacter,
 } from '@dtypes/api.minmatar.org'
 import { tribe_group_apply_ui_state } from '@helpers/tribe_group_apply_ui'
-import { query_string } from '@helpers/string'
+import { tribe_group_can_manage } from '@helpers/tribe_group_viewer'
 import { query_string } from '@helpers/string'
 
 interface Props {
@@ -63,11 +63,15 @@ const status_partial = translatePath(
     `/partials/tribe_group_status_component?tribe_id=${tribe_id}&group_id=${group_id}&ui=actions`,
 )
 const auth_redirect = `${translatePath('/redirects/auth_init')}?redirect_url=${encodeURIComponent(Astro.url.toString())}`
+const can_manage = tribe_group_can_manage({
+    group,
+    is_leader,
+    is_superuser,
+})
 
 const show_membership_action =
     !is_leader && (!is_auth || can_apply || has_open_membership)
-const show_manage_members = is_leader || (is_superuser && !is_leader)
-const show_actions = show_membership_action || show_manage_members
+const show_actions = show_membership_action || can_manage
 
 import Dropdown from '@components/blocks/Dropdown.astro'
 import ButtonApplyTribe from '@components/blocks/ButtonApplyTribe.astro'
@@ -175,23 +179,13 @@ import ButtonTribeMembership from '@components/blocks/ButtonTribeMembership.astr
                     </>
                 }
 
-                {is_leader &&
+                {can_manage &&
                     <a
                         class="[ tribe-group-actions-menu__item ]"
                         href={members_href}
                         x-on:click="close()"
                     >
                         {t('manage_membership')}
-                    </a>
-                }
-
-                {is_superuser && !is_leader &&
-                    <a
-                        class="[ tribe-group-actions-menu__item ]"
-                        href={members_href}
-                        x-on:click="close()"
-                    >
-                        {t('manage')}
                     </a>
                 }
             </nav>

--- a/frontend/app/src/components/blocks/TribeGroupTile.astro
+++ b/frontend/app/src/components/blocks/TribeGroupTile.astro
@@ -17,6 +17,7 @@ import type {
     TribeAvailableCharacter,
 } from '@dtypes/api.minmatar.org'
 import { tribe_group_cover } from '@helpers/tribe_covers'
+import { tribe_group_can_manage, tribe_group_is_leader } from '@helpers/tribe_group_viewer'
 
 interface Props {
     tribe_group:            TribeGroup;
@@ -39,9 +40,17 @@ const {
 const id = `tribe-group-${tribe_group.tribe_id}-${tribe_group.id}`
 
 const membership = membership_by_group.get(tribe_group.id) ?? null
-const user_character_ids = membership?.characters.map(character => character.character_id) ?? []
 const leaders = tribe_group.chief ? [ tribe_group.chief ] : []
-const is_leader = leaders.find((leader) => leader.character_id === membership?.primary_character_id) || leaders.find(leader => user_character_ids?.includes(leader?.character_id ?? 0))
+const is_leader = tribe_group_is_leader({
+    group: tribe_group,
+    membership,
+    user_characters,
+})
+const can_manage = tribe_group_can_manage({
+    group: tribe_group,
+    is_leader,
+    is_superuser: Boolean(is_superuser),
+})
 const is_member = membership?.status === 'active'
 const is_pending = membership?.status === 'pending'
 const has_open_membership = is_member || is_pending
@@ -170,9 +179,9 @@ import NotificationBadge from './NotificationBadge.astro'
                 }
             </Flexblock>
 
-            {(show_status_actions) &&
+            {(show_status_actions || can_manage) &&
                 <FlexInline>
-                    {!is_leader ?
+                    {!is_leader &&
                         <TribeStatus
                             group={tribe_group}
                             tribe_id={tribe_group.tribe_id}
@@ -182,15 +191,8 @@ import NotificationBadge from './NotificationBadge.astro'
                             is_auth={is_auth}
                             membership_by_group={membership_by_group}
                         />
-                        <>{is_superuser &&
-                            <Button
-                                href={translatePath(`/alliance/tribes/${tribe_group.tribe_id}/${tribe_group.id}/members`)}
-                                color='transparent'
-                            >
-                                {t('manage')}
-                            </Button>
-                        }</>
-                        :
+                    }
+                    {can_manage &&
                         <Button
                             href={translatePath(`/alliance/tribes/${tribe_group.tribe_id}/${tribe_group.id}/members`)}
                         >

--- a/frontend/app/src/helpers/tribe_group_viewer.ts
+++ b/frontend/app/src/helpers/tribe_group_viewer.ts
@@ -1,0 +1,22 @@
+import type { SummaryCharacter, TribeGroup, TribeMembership } from '@dtypes/api.minmatar.org'
+
+export function tribe_group_is_leader(args: {
+    group: TribeGroup | null | undefined
+    membership: TribeMembership | null
+    user_characters?: Pick<SummaryCharacter, 'character_id'>[]
+}): boolean {
+    const chief_id = args.group?.chief?.character_id
+    if (!chief_id) return false
+    if (args.membership?.primary_character_id === chief_id) return true
+    if (args.membership?.characters?.some((character) => character.character_id === chief_id))
+        return true
+    return Boolean(args.user_characters?.some((character) => character.character_id === chief_id))
+}
+
+export function tribe_group_can_manage(args: {
+    group: TribeGroup | null | undefined
+    is_leader: boolean
+    is_superuser: boolean
+}): boolean {
+    return Boolean(args.group?.can_manage) || args.is_leader || args.is_superuser
+}

--- a/frontend/app/src/pages/alliance/tribes/[tribe_id]/[group_id].astro
+++ b/frontend/app/src/pages/alliance/tribes/[tribe_id]/[group_id].astro
@@ -38,6 +38,7 @@ import {
 } from '@helpers/api.minmatar.org/tribes'
 import { get_characters_summary_sorted } from '@helpers/fetching/characters'
 import { TRIBE_ACTIVITY_BY_CODE } from '@helpers/tribe_activity'
+import { tribe_group_can_manage, tribe_group_is_leader } from '@helpers/tribe_group_viewer'
 
 const tribe_id = parseInt(Astro?.params?.tribe_id ?? '')
 const group_id = parseInt(Astro?.params?.group_id ?? '')
@@ -108,13 +109,16 @@ if (!fetch_group_error && !tribe_group)
     return HTTP_404_Not_Found()
 
 const membership = membership_by_group.get(group_id) ?? null
-const user_character_ids = membership?.characters?.map((c) => c.character_id) ?? []
-const is_leader = Boolean(
-    tribe_group?.chief && (
-        tribe_group.chief.character_id === membership?.primary_character_id
-        || user_character_ids.includes(tribe_group.chief.character_id)
-    )
-)
+const is_leader = tribe_group_is_leader({
+    group: tribe_group,
+    membership,
+    user_characters,
+})
+const can_manage = tribe_group_can_manage({
+    group: tribe_group,
+    is_leader,
+    is_superuser,
+})
 const activity = tribe_group?.code
     ? TRIBE_ACTIVITY_BY_CODE[tribe_group.code]
     : undefined
@@ -172,6 +176,7 @@ import TribeGroupMembershipRequirements from '@components/blocks/TribeGroupMembe
 import GuidePostCard from '@components/blocks/GuidePostCard.astro'
 import PropagandaPostCard from '@components/blocks/PropagandaPostCard.astro'
 import LandingSwiper from '@components/blocks/LandingSwiper.astro'
+import Button from '@components/blocks/Button.astro'
 ---
 
 <Viewport
@@ -212,18 +217,28 @@ import LandingSwiper from '@components/blocks/LandingSwiper.astro'
                     </FlexInline>
                 </Flexblock>
                 {tribe_group &&
-                    <TribeGroupActions
-                        group={tribe_group}
-                        tribe_id={tribe_id}
-                        group_id={group_id}
-                        is_auth={is_auth}
-                        is_leader={is_leader}
-                        is_superuser={is_superuser}
-                        user_on_trial={user_on_trial}
-                        user_characters={user_characters}
-                        available_characters={available_characters}
-                        membership_by_group={membership_by_group}
-                    />
+                    <FlexInline gap="var(--space-xs)" class="[ items-start! ]">
+                        {can_manage &&
+                            <Button
+                                href={translatePath(`/alliance/tribes/${tribe_id}/${group_id}/members`)}
+                                size="sm"
+                            >
+                                {t('manage_membership')}
+                            </Button>
+                        }
+                        <TribeGroupActions
+                            group={tribe_group}
+                            tribe_id={tribe_id}
+                            group_id={group_id}
+                            is_auth={is_auth}
+                            is_leader={is_leader}
+                            is_superuser={is_superuser}
+                            user_on_trial={user_on_trial}
+                            user_characters={user_characters}
+                            available_characters={available_characters}
+                            membership_by_group={membership_by_group}
+                        />
+                    </FlexInline>
                 }
             </FlexInline>
 

--- a/frontend/app/src/pages/alliance/tribes/[tribe_id]/[group_id]/members.astro
+++ b/frontend/app/src/pages/alliance/tribes/[tribe_id]/[group_id]/members.astro
@@ -26,6 +26,7 @@ if (isNaN(tribe_id) || isNaN(group_id))
 import type { TribeGroup, SummaryCharacter, TribeMembership } from '@dtypes/api.minmatar.org'
 import { get_tribe, get_tribe_group, get_memberships } from '@helpers/api.minmatar.org/tribes'
 import { get_characters_summary_sorted } from '@helpers/fetching/characters'
+import { tribe_group_can_manage, tribe_group_is_leader } from '@helpers/tribe_group_viewer'
 
 let tribe_group:TribeGroup | null = null
 let tribe_slug = ''
@@ -46,9 +47,18 @@ try {
     const summary = await get_characters_summary_sorted(auth_token)
     user_characters = summary.characters ?? []
 
-    const is_chief = Boolean(user_characters.find(character => character.character_id === tribe_group?.chief?.character_id))
+    const is_chief = tribe_group_is_leader({
+        group: tribe_group,
+        membership: null,
+        user_characters,
+    })
+    const can_manage = tribe_group_can_manage({
+        group: tribe_group,
+        is_leader: is_chief,
+        is_superuser,
+    })
     
-    if (!is_superuser && !is_chief)
+    if (!can_manage)
         return HTTP_403_Forbidden()
 
     approved = await get_memberships(auth_token as string, tribe_id, tribe_group.id, {

--- a/frontend/app/src/pages/partials/tribe_group_memberships_component.astro
+++ b/frontend/app/src/pages/partials/tribe_group_memberships_component.astro
@@ -124,6 +124,7 @@ if (Astro.request.method === "DELETE") {
 }
 
 import { get_characters_summary_sorted } from '@helpers/fetching/characters'
+import { tribe_group_can_manage, tribe_group_is_leader } from '@helpers/tribe_group_viewer'
 
 let tribe_group:TribeGroup | null = null
 let tribe_slug = ''
@@ -144,9 +145,18 @@ try {
     const summary = await get_characters_summary_sorted(auth_token)
     user_characters = summary.characters ?? []
 
-    const is_chief = Boolean(user_characters.find(character => character.character_id === tribe_group?.chief?.character_id))
+    const is_chief = tribe_group_is_leader({
+        group: tribe_group,
+        membership: null,
+        user_characters,
+    })
+    const can_manage = tribe_group_can_manage({
+        group: tribe_group,
+        is_leader: is_chief,
+        is_superuser,
+    })
     
-    if (!is_superuser && !is_chief)
+    if (!can_manage)
         return HTTP_403_Forbidden()
 
     approved = await get_memberships(auth_token as string, tribe_id, tribe_group.id, {

--- a/frontend/app/src/pages/partials/tribe_group_status_component.astro
+++ b/frontend/app/src/pages/partials/tribe_group_status_component.astro
@@ -108,6 +108,7 @@ import { get_user_profile } from '@helpers/permissions'
 import type { TribeGroup, SummaryCharacter, TribeMembership, TribeAvailableCharacter } from '@dtypes/api.minmatar.org'
 import { get_tribe_group, get_memberships, get_membership_characters_available } from '@helpers/api.minmatar.org/tribes'
 import { get_characters_summary_sorted } from '@helpers/fetching/characters'
+import { tribe_group_is_leader } from '@helpers/tribe_group_viewer'
 
 const actions_ui = Astro.url.searchParams.get('ui') === 'actions'
 
@@ -143,14 +144,11 @@ try {
     const membership = membership_by_group.get(tribe_group.id) ?? null
     is_member = membership?.status === 'active'
     is_pending = membership?.status === 'pending'
-
-    const user_character_ids = membership?.characters?.map((c) => c.character_id) ?? []
-    is_leader = Boolean(
-        tribe_group?.chief && (
-            tribe_group.chief.character_id === membership?.primary_character_id
-            || user_character_ids.includes(tribe_group.chief.character_id)
-        )
-    )
+    is_leader = tribe_group_is_leader({
+        group: tribe_group,
+        membership,
+        user_characters,
+    })
 
     const user_profile = user?.username
         ? await get_user_profile(user.username)

--- a/frontend/app/src/types/api.minmatar.org.ts
+++ b/frontend/app/src/types/api.minmatar.org.ts
@@ -74,6 +74,7 @@ export interface TribeGroup {
     require_off_trial?:     boolean;
     allowed_affiliations?:  TribeAffiliationRef[];
     can_apply?:             boolean;
+    can_manage?:            boolean;
 }
 
 export interface Tribe {

--- a/frontend/app/testing/helpers/tribe_group_viewer.test.ts
+++ b/frontend/app/testing/helpers/tribe_group_viewer.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+
+import type { TribeGroup, TribeMembership } from '@dtypes/api.minmatar.org'
+import { tribe_group_can_manage, tribe_group_is_leader } from '@helpers/tribe_group_viewer'
+
+function group(overrides: Partial<TribeGroup> = {}): TribeGroup {
+    return {
+        id: 1,
+        tribe_id: 1,
+        tribe_name: 'Supply',
+        name: 'Mining',
+        code: 'supply.mining',
+        description: '',
+        member_count: 0,
+        requirements: [],
+        discord_channel_id: null,
+        chief: { character_id: 91439324, character_name: 'Keldor Eternia' },
+        ship_type_ids: [],
+        blueprint_type_ids: [],
+        is_active: true,
+        ...overrides,
+    }
+}
+
+function membership(overrides: Partial<TribeMembership> = {}): TribeMembership {
+    return {
+        id: 10,
+        user_id: 5,
+        tribe_group_id: 1,
+        tribe_group_name: 'Mining',
+        tribe_id: 1,
+        status: 'active',
+        rank_id: null,
+        rank_code: null,
+        rank_name: null,
+        inactive_reason: null,
+        requirement_snapshot: null,
+        created_at: '',
+        approved_by_id: null,
+        approved_at: null,
+        left_at: null,
+        characters: [],
+        primary_character_id: null,
+        primary_character_name: '',
+        ...overrides,
+    }
+}
+
+describe('tribe_group_is_leader', () => {
+    it('treats the group chief character on the account as leader even without membership', () => {
+        expect(tribe_group_is_leader({
+            group: group(),
+            membership: null,
+            user_characters: [{ character_id: 91439324 }],
+        })).toBe(true)
+    })
+
+    it('is false when the viewer does not own the chief character', () => {
+        expect(tribe_group_is_leader({
+            group: group(),
+            membership: membership({ primary_character_id: 1 }),
+            user_characters: [{ character_id: 2 }],
+        })).toBe(false)
+    })
+})
+
+describe('tribe_group_can_manage', () => {
+    it('follows the API can_manage flag for tribe chiefs who are not the group chief toon', () => {
+        expect(tribe_group_can_manage({
+            group: group({ can_manage: true, chief: { character_id: 1, character_name: 'Other' } }),
+            is_leader: false,
+            is_superuser: false,
+        })).toBe(true)
+    })
+
+    it('is false for regular members', () => {
+        expect(tribe_group_can_manage({
+            group: group({ can_manage: false }),
+            is_leader: false,
+            is_superuser: false,
+        })).toBe(false)
+    })
+})


### PR DESCRIPTION
## Summary
- Tribe group APIs now return `can_manage`, so tribe chiefs and other managers can open membership from the group hub even when they are not the group's chief toon.
- Buyback outbound matching counts contracts issued by the thread maker's alts, corporations, and CEO corps, and manual complete can accept a partial fill against the synced contract.

## Test plan
- [ ] As a tribe chief who is not the group chief, open a tribe group page and confirm Manage membership is shown and the members page loads.
- [ ] As a regular member, confirm Manage membership stays hidden.
- [ ] Place a buyback purchase, then issue the outbound contract from an alt or corp and confirm auto-complete.
- [ ] Place a multi-line purchase, sync a partial outbound, complete the thread, and confirm remaining lines/qty match the contract.


Made with [Cursor](https://cursor.com)