### PR TITLE
Show promote off trial on Evaluating

### DIFF
--- a/frontend/app/src/helpers/api.minmatar.org/alliance_health.ts
+++ b/frontend/app/src/helpers/api.minmatar.org/alliance_health.ts
@@ -214,12 +214,12 @@ export function can_promote_alliance_health_trial(opts: {
     switch (bucket) {
         case 'approve':
         case 'remove':
+        case 'evaluating':
             return true
         case 'passing':
             return (opts.alliance_days ?? 0) >= 60
         case 'current':
         case 'failing':
-        case 'evaluating':
         case 'add':
         case 'flagged':
         case 'too_early':

--- a/frontend/app/src/pages/alliance/health.astro
+++ b/frontend/app/src/pages/alliance/health.astro
@@ -288,13 +288,7 @@ const last_updated_text = overview?.computed_at
                         >
                             <AllianceHealthTrialsTable
                                 pilots={trials.pilots}
-                                can_promote={
-                                    can_mutate &&
-                                    (trials.bucket === 'current' ||
-                                        trials.bucket === 'passing' ||
-                                        trials.bucket === 'remove' ||
-                                        trials.bucket === 'approve')
-                                }
+                                can_promote={can_mutate}
                                 officer_corp_ids={officer_corp_ids}
                                 alliance_wide={alliance_wide}
                                 initial_corp={initial_corp}

--- a/frontend/app/src/pages/partials/alliance_health_trials_component.astro
+++ b/frontend/app/src/pages/partials/alliance_health_trials_component.astro
@@ -90,12 +90,7 @@ const PARTIAL_URL = translatePath('/partials/alliance_health_trials_component')
     ) : (
         <AllianceHealthTrialsTable
             pilots={pilots}
-            can_promote={can_mutate && (
-                bucket === 'current' ||
-                bucket === 'passing' ||
-                bucket === 'approve' ||
-                bucket === 'remove'
-            )}
+            can_promote={can_mutate}
             officer_corp_ids={officer_corp_ids}
             alliance_wide={alliance_wide}
             initial_corp={initial_corp}

--- a/frontend/app/testing/helpers/alliance_health.test.ts
+++ b/frontend/app/testing/helpers/alliance_health.test.ts
@@ -35,6 +35,36 @@ describe('can_promote_alliance_health_trial', () => {
         ).toBe(false)
     })
 
+    it('shows promote on evaluating for people who are not passing yet', () => {
+        expect(
+            can_promote_alliance_health_trial({
+                ...base,
+                bucket: 'evaluating',
+                decision: 'nudge',
+                alliance_days: 80,
+            }),
+        ).toBe(true)
+        expect(
+            can_promote_alliance_health_trial({
+                ...base,
+                bucket: 'evaluating',
+                decision: 'hold',
+                alliance_days: 90,
+            }),
+        ).toBe(true)
+    })
+
+    it('hides promote on evaluating for too-early tenure', () => {
+        expect(
+            can_promote_alliance_health_trial({
+                ...base,
+                bucket: 'evaluating',
+                decision: 'too_early',
+                alliance_days: 20,
+            }),
+        ).toBe(false)
+    })
+
     it('hides promote on passing when tenure is under 60 days', () => {
         expect(
             can_promote_alliance_health_trial({


### PR DESCRIPTION
## Summary
- Officers can promote trial members from the **Evaluating** alliance health tab, not only from Passing.
- Too-early tenure (under 60 days) still hides the button. Passing/Current behavior is unchanged.

## Test plan
- [ ] Open Alliance Health as an officer with mutate rights.
- [ ] On **Evaluating**, confirm **Promote to member** appears for nudge/hold pilots.
- [ ] Confirm it still does **not** appear for too-early pilots.
- [ ] Confirm **Passing** still shows the button and **Current** still only shows it for approve-ready people.
- [ ] Promote one evaluating pilot and confirm they leave the table / become active.


Made with [Cursor](https://cursor.com)