### PR TITLE
Close LP buyback Discord threads on cancel and delete

### DIFF
--- a/backend/industry/helpers/lp_buyback_discord.py
+++ b/backend/industry/helpers/lp_buyback_discord.py
@@ -29,6 +29,18 @@ discord = DiscordClient()
 # Discord does not reopen the thread when a post lands after close.
 THREAD_ARCHIVE_DELAY_SECONDS = 5
 
+# Deleted orders 122/123 and cancelled order 130 (thread created after cancel).
+ORPHAN_LP_BUYBACK_THREAD_IDS = (
+    1541754525805842462,
+    1541754700171452416,
+    1542512504742346832,
+)
+
+_TERMINAL_STATUSES = (
+    IndustryLoyaltyPointMarketOrder.Status.CANCELLED,
+    IndustryLoyaltyPointMarketOrder.Status.COMPLETED,
+)
+
 
 def order_site_url(order: IndustryLoyaltyPointMarketOrder) -> str:
     base = getattr(settings, "WEB_LINK_URL", "https://my.minmatar.org").rstrip(
@@ -156,14 +168,23 @@ def create_order_thread(order: IndustryLoyaltyPointMarketOrder) -> int | None:
         return None
 
 
+def close_lp_buyback_thread_id(thread_id: int | None) -> bool:
+    """Archive/lock a buyback forum thread by Discord channel id."""
+    if not thread_id:
+        return False
+    try:
+        discord.close_thread(channel_id=int(thread_id))
+        return True
+    except Exception as exc:
+        logger.error(
+            "Failed closing LP buyback Discord thread %s: %s", thread_id, exc
+        )
+        return False
+
+
 def close_order_thread(order: IndustryLoyaltyPointMarketOrder) -> None:
     """Archive/lock the order thread without posting (avoids Discord reopen race)."""
-    if not order.discord_thread_id:
-        return
-    try:
-        discord.close_thread(channel_id=order.discord_thread_id)
-    except Exception as exc:
-        logger.error("Failed closing LP buyback Discord thread: %s", exc)
+    close_lp_buyback_thread_id(order.discord_thread_id)
 
 
 def post_order_status_update(
@@ -186,12 +207,29 @@ def post_order_status_update(
 
 
 def notify_order_created(order: IndustryLoyaltyPointMarketOrder) -> None:
-    thread_id = create_order_thread(order)
-    if thread_id:
-        IndustryLoyaltyPointMarketOrder.objects.filter(pk=order.pk).update(
-            discord_thread_id=thread_id
-        )
-        order.discord_thread_id = thread_id
+    try:
+        current = IndustryLoyaltyPointMarketOrder.objects.select_related(
+            "loyalty_point", "created_by"
+        ).get(pk=order.pk)
+    except IndustryLoyaltyPointMarketOrder.DoesNotExist:
+        return
+    if current.status in _TERMINAL_STATUSES:
+        close_order_thread(current)
+        return
+
+    thread_id = create_order_thread(current)
+    if not thread_id:
+        return
+
+    attached = (
+        IndustryLoyaltyPointMarketOrder.objects.filter(pk=current.pk)
+        .exclude(status__in=_TERMINAL_STATUSES)
+        .update(discord_thread_id=thread_id)
+    )
+    if not attached:
+        close_lp_buyback_thread_id(thread_id)
+        return
+    current.discord_thread_id = thread_id
 
 
 def _destination_label(
@@ -417,7 +455,3 @@ def notify_order_status_changed(
         # Post first, wait, then archive — never post after close (Discord
         # unarchives). Caller must invoke after DB commit (see transition_order).
         _post_completed_then_archive(order)
-    elif status == order.Status.CANCELLED:
-        # Do not post a cancel message — Discord unarchives threads when
-        # anything is sent (including after archive), same race as help tickets.
-        close_order_thread(order)

--- a/backend/industry/management/commands/close_orphan_lp_buyback_threads.py
+++ b/backend/industry/management/commands/close_orphan_lp_buyback_threads.py
@@ -1,0 +1,31 @@
+"""Archive leftover LP buyback Discord forum threads."""
+
+from django.core.management.base import BaseCommand
+
+from industry.helpers.lp_buyback_discord import (
+    ORPHAN_LP_BUYBACK_THREAD_IDS,
+    close_lp_buyback_thread_id,
+)
+
+
+class Command(BaseCommand):
+    help = "Archive leftover LP buyback Discord threads."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print thread ids without calling Discord.",
+        )
+
+    def handle(self, *args, **options):
+        if options["dry_run"]:
+            for thread_id in ORPHAN_LP_BUYBACK_THREAD_IDS:
+                self.stdout.write(str(thread_id))
+            return
+
+        closed = 0
+        for thread_id in ORPHAN_LP_BUYBACK_THREAD_IDS:
+            if close_lp_buyback_thread_id(thread_id):
+                closed += 1
+        self.stdout.write(self.style.SUCCESS(f"closed={closed}"))

--- a/backend/industry/migrations/0047_close_orphan_lp_buyback_discord_threads.py
+++ b/backend/industry/migrations/0047_close_orphan_lp_buyback_discord_threads.py
@@ -1,0 +1,28 @@
+from django.conf import settings
+from django.db import migrations
+
+
+def close_orphan_threads(apps, schema_editor):
+    if getattr(settings, "TESTING", False):
+        return
+    from industry.helpers.lp_buyback_discord import (
+        ORPHAN_LP_BUYBACK_THREAD_IDS,
+        close_lp_buyback_thread_id,
+    )
+
+    for thread_id in ORPHAN_LP_BUYBACK_THREAD_IDS:
+        close_lp_buyback_thread_id(thread_id)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("industry", "0046_delete_miningupgradecompletion"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            close_orphan_threads,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/backend/industry/signals.py
+++ b/backend/industry/signals.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import logging
 
-from django.db.models.signals import m2m_changed
+from django.db.models.signals import m2m_changed, post_save, pre_delete
 from django.dispatch import receiver
 
-from industry.models import IndustryOrder
+from industry.models import IndustryLoyaltyPointMarketOrder, IndustryOrder
 
 logger = logging.getLogger(__name__)
 
@@ -51,3 +51,40 @@ def notify_when_order_tribe_groups_added(
             "change on order %s",
             instance.pk,
         )
+
+
+def _close_market_order_discord_thread(thread_id: int | None) -> None:
+    if not thread_id:
+        return
+    from industry.tasks import (  # pylint: disable=import-outside-toplevel
+        close_lp_buyback_discord_thread_task,
+    )
+
+    close_lp_buyback_discord_thread_task.delay(int(thread_id))
+
+
+@receiver(
+    pre_delete,
+    sender=IndustryLoyaltyPointMarketOrder,
+    dispatch_uid="lp_buyback_order_pre_delete_close_thread",
+)
+def close_lp_buyback_thread_on_order_delete(sender, instance, **kwargs):
+    _close_market_order_discord_thread(instance.discord_thread_id)
+
+
+@receiver(
+    post_save,
+    sender=IndustryLoyaltyPointMarketOrder,
+    dispatch_uid="lp_buyback_order_post_save_close_thread",
+)
+def close_lp_buyback_thread_on_order_cancel(
+    sender, instance, created, **kwargs
+):
+    if created:
+        return
+    if instance.status != IndustryLoyaltyPointMarketOrder.Status.CANCELLED:
+        return
+    update_fields = kwargs.get("update_fields")
+    if update_fields is not None and "status" not in update_fields:
+        return
+    _close_market_order_discord_thread(instance.discord_thread_id)

--- a/backend/industry/tasks.py
+++ b/backend/industry/tasks.py
@@ -37,6 +37,15 @@ logger = logging.getLogger(__name__)
 
 
 @app.task()
+def close_lp_buyback_discord_thread_task(thread_id: int) -> None:
+    """Archive an LP buyback Discord thread by id."""
+    # pylint: disable=import-outside-toplevel
+    from industry.helpers.lp_buyback_discord import close_lp_buyback_thread_id
+
+    close_lp_buyback_thread_id(thread_id)
+
+
+@app.task()
 def notify_lp_buyback_order_created_task(order_id: int) -> None:
     """Create Discord forum thread for a new LP buyback order (off request)."""
     # pylint: disable=import-outside-toplevel

--- a/backend/industry/tests/test_loyalty_buyback.py
+++ b/backend/industry/tests/test_loyalty_buyback.py
@@ -837,6 +837,59 @@ class LoyaltyBuybackDiscordTestCase(AppTestCase):
         self.assertIsNone(self.order.discord_thread_id)
         discord_mock.create_forum_thread.assert_not_called()
 
+    @patch("industry.helpers.lp_buyback_discord.discord")
+    def test_notify_order_created_skips_cancelled(self, discord_mock):
+        IndustryLoyaltyPointMarketOrder.objects.filter(
+            pk=self.order.pk
+        ).update(
+            status=IndustryLoyaltyPointMarketOrder.Status.CANCELLED,
+            discord_thread_id=777,
+        )
+        self.order.refresh_from_db()
+        notify_order_created(self.order)
+        discord_mock.create_forum_thread.assert_not_called()
+        discord_mock.close_thread.assert_called_once_with(channel_id=777)
+
+    @patch("industry.helpers.lp_buyback_discord.discord")
+    def test_notify_order_created_closes_if_deleted_during_create(
+        self, discord_mock
+    ):
+        self._stub_forum_create(discord_mock, "888999000")
+
+        def _create_then_delete(*args, **kwargs):
+            self.order.delete()
+            return discord_mock.create_forum_thread.return_value
+
+        discord_mock.create_forum_thread.side_effect = _create_then_delete
+        notify_order_created(self.order)
+        discord_mock.close_thread.assert_called_once_with(channel_id=888999000)
+
+    @patch("industry.helpers.lp_buyback_discord.discord")
+    def test_notify_order_created_closes_if_cancelled_during_create(
+        self, discord_mock
+    ):
+        self._stub_forum_create(discord_mock, "888999001")
+
+        def _create_then_cancel(*args, **kwargs):
+            IndustryLoyaltyPointMarketOrder.objects.filter(
+                pk=self.order.pk
+            ).update(status=IndustryLoyaltyPointMarketOrder.Status.CANCELLED)
+            return discord_mock.create_forum_thread.return_value
+
+        discord_mock.create_forum_thread.side_effect = _create_then_cancel
+        notify_order_created(self.order)
+        discord_mock.close_thread.assert_called_once_with(channel_id=888999001)
+        self.order.refresh_from_db()
+        self.assertIsNone(self.order.discord_thread_id)
+
+    def _stub_forum_create(self, discord_mock, thread_id: str):
+        response = MagicMock()
+        response.json.return_value = {"id": thread_id}
+        discord_mock.create_forum_thread.return_value = response
+        channel_response = MagicMock()
+        channel_response.json.return_value = {"available_tags": [], "flags": 0}
+        discord_mock.get_channel.return_value = channel_response
+
     def test_receive_lp_buyback_is_unique(self):
         other = DiscordChannel.objects.create(
             channel_id=999000111,
@@ -1074,13 +1127,65 @@ class LpBuybackSideAwareMessagingTestCase(AppTestCase):
             side=IndustryLoyaltyPointMarketOrder.Side.SELL,
             quantity=1000,
             isk_per_lp=800,
-            status=IndustryLoyaltyPointMarketOrder.Status.CANCELLED,
             created_by=self.seller,
             discord_thread_id=777,
         )
-        notify_order_status_changed(order)
+        order.status = IndustryLoyaltyPointMarketOrder.Status.CANCELLED
+        order.save()
         discord_mock.create_message.assert_not_called()
         discord_mock.close_thread.assert_called_once_with(channel_id=777)
+
+
+class LpBuybackThreadCloseSignalTestCase(AppTestCase):
+    def setUp(self):
+        super().setUp()
+        self.currency, _ = IndustryLoyaltyPoint.objects.update_or_create(
+            corporation_id=TLIB_CORP_ID,
+            defaults={
+                "name": "Tribal Liberation Force",
+                "default_isk_per_lp": 800,
+                "is_active": True,
+            },
+        )
+
+    def _open_order(self, thread_id=555):
+        return IndustryLoyaltyPointMarketOrder.objects.create(
+            loyalty_point=self.currency,
+            side=IndustryLoyaltyPointMarketOrder.Side.SELL,
+            quantity=1000,
+            isk_per_lp=800,
+            created_by=self.user,
+            discord_thread_id=thread_id,
+        )
+
+    @patch("industry.signals._close_market_order_discord_thread")
+    def test_delete_order_enqueues_thread_close(self, enqueue_mock):
+        order = self._open_order()
+        order.delete()
+        enqueue_mock.assert_called_once_with(555)
+
+    @patch("industry.signals._close_market_order_discord_thread")
+    def test_delete_user_enqueues_thread_close(self, enqueue_mock):
+        self._open_order(thread_id=666)
+        self.user.delete()
+        enqueue_mock.assert_called_once_with(666)
+
+    @patch("industry.signals._close_market_order_discord_thread")
+    def test_cancel_enqueues_thread_close(self, enqueue_mock):
+        order = self._open_order()
+        order.status = IndustryLoyaltyPointMarketOrder.Status.CANCELLED
+        order.save()
+        enqueue_mock.assert_called_once_with(555)
+
+    @patch("industry.signals._close_market_order_discord_thread")
+    def test_note_edit_does_not_enqueue_close(self, enqueue_mock):
+        order = self._open_order()
+        order.status = IndustryLoyaltyPointMarketOrder.Status.CANCELLED
+        order.save()
+        enqueue_mock.reset_mock()
+        order.notes = "updated"
+        order.save(update_fields=["notes", "updated_at"])
+        enqueue_mock.assert_not_called()
 
 
 class LpBuybackDiscordAckApiTestCase(LoyaltyBuybackApiTestCase):


### PR DESCRIPTION
## Summary
- Archive the order's Discord forum thread when the market-order row is deleted (including user CASCADE) or cancelled, so leftover "Open" threads cannot outlive the site book.
- Skip or immediately close a thread if create-notify races a cancel/delete (the Zelaya 130 case: thread created after the order was already cancelled).
- On deploy, migration `0047` closes the three known orphan threads (orders 122, 123, 130). Retry with `close_orphan_lp_buyback_threads` if needed.

## Test plan
- [ ] `pipenv run python manage.py test industry.tests.test_loyalty_buyback --settings=app.settings_test`
- [ ] Cancel an open LP order and confirm the Discord thread archives with no new cancel post
- [ ] Delete a user who has an open LP order (or delete the order in admin) and confirm the thread archives
- [ ] After migrate on prod, confirm threads for orders 122/123/130 are archived; if not, run `docker compose -f docker-compose-prod.yml exec app python3 manage.py close_orphan_lp_buyback_threads`


Made with [Cursor](https://cursor.com)