### PR TITLE
Always show Promote on alliance trial cards

### DIFF
--- a/frontend/app/src/components/blocks/AllianceHealthTrialsTable.astro
+++ b/frontend/app/src/components/blocks/AllianceHealthTrialsTable.astro
@@ -52,12 +52,9 @@ const extra_query = alliance_health_table_params({
 const can_act = (pilot: AllianceHealthTrialPilot) =>
     can_promote_alliance_health_trial({
         can_mutate: can_promote,
-        bucket,
         alliance_wide,
         officer_corp_ids,
         corporation_id: pilot.corporation_id,
-        decision: pilot.decision,
-        alliance_days: pilot.alliance_days,
     })
 
 const order_by_options: AllianceHealthOrderOption[] = [

--- a/frontend/app/src/helpers/api.minmatar.org/alliance_health.ts
+++ b/frontend/app/src/helpers/api.minmatar.org/alliance_health.ts
@@ -191,44 +191,14 @@ export function can_act_on_alliance_health_corp(
 
 export function can_promote_alliance_health_trial(opts: {
     can_mutate: boolean
-    bucket: AllianceHealthTrialBucket | string
     alliance_wide: boolean
     officer_corp_ids: number[]
     corporation_id?: number | null
-    decision?: string | null
-    alliance_days?: number | null
 }): boolean {
     if (!opts.can_mutate) return false
-    if (
-        !can_act_on_alliance_health_corp(
-            opts.alliance_wide,
-            opts.corporation_id,
-            opts.officer_corp_ids,
-        )
-    ) {
-        return false
-    }
-    if (opts.decision === 'too_early') return false
-    if (opts.decision === 'approve') return true
-    const bucket = opts.bucket as AllianceHealthTrialBucket
-    switch (bucket) {
-        case 'approve':
-        case 'remove':
-        case 'evaluating':
-            return true
-        case 'passing':
-            return (opts.alliance_days ?? 0) >= 60
-        case 'current':
-        case 'failing':
-        case 'add':
-        case 'flagged':
-        case 'too_early':
-        case 'fail':
-        case 'nudge':
-            return false
-        default: {
-            const _never: never = bucket
-            return _never
-        }
-    }
+    return can_act_on_alliance_health_corp(
+        opts.alliance_wide,
+        opts.corporation_id,
+        opts.officer_corp_ids,
+    )
 }

--- a/frontend/app/src/i18n/ui.ts
+++ b/frontend/app/src/i18n/ui.ts
@@ -1789,7 +1789,7 @@ export const ui = {
         'alliance.health.bucket.dark': 'Gone for months',
         'alliance.health.bucket.seasonal': 'Comes and goes',
         'alliance.health.trials.title': 'Trials',
-        'alliance.health.trials.caption': 'Your trial members. Open Passing and hit Promote when they have been here 60 days and are still showing up. Failing needs a conversation. Evaluating is the gray area — nudge them in Discord.',
+        'alliance.health.trials.caption': 'Your trial members. Hit Promote when they have been here 60 days and are still showing up. Failing needs a conversation. Evaluating is the gray area — nudge them in Discord.',
         'alliance.health.trials.aria': 'Trial hygiene lists',
         'alliance.health.trials.empty': 'Nobody in this list.',
         'alliance.health.bucket.approve': 'Come off trial',

--- a/frontend/app/testing/helpers/alliance_health.test.ts
+++ b/frontend/app/testing/helpers/alliance_health.test.ts
@@ -13,84 +13,33 @@ const base = {
 }
 
 describe('can_promote_alliance_health_trial', () => {
-    it('shows promote on the default current tab for approve decisions', () => {
+    it('shows promote whenever the officer can act on the corp', () => {
         expect(
             can_promote_alliance_health_trial({
                 ...base,
-                bucket: 'current',
-                decision: 'approve',
-                alliance_days: 70,
+                corporation_id: 1,
             }),
         ).toBe(true)
     })
 
-    it('hides promote on current for people who are not approve-ready', () => {
+    it('shows promote for officers scoped to that corp', () => {
         expect(
             can_promote_alliance_health_trial({
-                ...base,
-                bucket: 'current',
-                decision: 'nudge',
-                alliance_days: 80,
-            }),
-        ).toBe(false)
-    })
-
-    it('shows promote on evaluating for people who are not passing yet', () => {
-        expect(
-            can_promote_alliance_health_trial({
-                ...base,
-                bucket: 'evaluating',
-                decision: 'nudge',
-                alliance_days: 80,
-            }),
-        ).toBe(true)
-        expect(
-            can_promote_alliance_health_trial({
-                ...base,
-                bucket: 'evaluating',
-                decision: 'hold',
-                alliance_days: 90,
+                can_mutate: true,
+                alliance_wide: false,
+                officer_corp_ids: [7],
+                corporation_id: 7,
             }),
         ).toBe(true)
     })
 
-    it('hides promote on evaluating for too-early tenure', () => {
+    it('hides promote for a corp the officer cannot act on', () => {
         expect(
             can_promote_alliance_health_trial({
-                ...base,
-                bucket: 'evaluating',
-                decision: 'too_early',
-                alliance_days: 20,
-            }),
-        ).toBe(false)
-    })
-
-    it('hides promote on passing when tenure is under 60 days', () => {
-        expect(
-            can_promote_alliance_health_trial({
-                ...base,
-                bucket: 'passing',
-                decision: null,
-                alliance_days: 40,
-            }),
-        ).toBe(false)
-        expect(
-            can_promote_alliance_health_trial({
-                ...base,
-                bucket: 'passing',
-                decision: null,
-                alliance_days: null,
-            }),
-        ).toBe(false)
-    })
-
-    it('hides promote for too-early pilots on passing', () => {
-        expect(
-            can_promote_alliance_health_trial({
-                ...base,
-                bucket: 'passing',
-                decision: 'too_early',
-                alliance_days: 20,
+                can_mutate: true,
+                alliance_wide: false,
+                officer_corp_ids: [7],
+                corporation_id: 9,
             }),
         ).toBe(false)
     })
@@ -100,9 +49,6 @@ describe('can_promote_alliance_health_trial', () => {
             can_promote_alliance_health_trial({
                 ...base,
                 can_mutate: false,
-                bucket: 'passing',
-                decision: 'approve',
-                alliance_days: 70,
             }),
         ).toBe(false)
     })


### PR DESCRIPTION
## Summary
- Show **Promote to member** on every trial card a director can act on (On trial, Passing, Failing, Evaluating), including too-early tenure.
- Keep the existing permission gate (mutate + corp scope). 60-day guidance stays in the caption, not as a hidden button.
- Update unit tests for the simpler promote rule.

## Test plan
- [ ] On `/alliance/health` Trials, confirm Promote appears on On trial rows that are tagged too early (under 60 days).
- [ ] Confirm a corp director still cannot promote a trial in a corp they do not cover.
- [ ] Promote still confirms, sets community status to active, and drops the row from the trial lists.
- [ ] Frontend: `npm run test -- --run testing/helpers/alliance_health.test.ts` (already passing locally).


Made with [Cursor](https://cursor.com)