### PR TITLE
Grant application access to associate corp recruiters

### DIFF
--- a/backend/groups/helpers/__init__.py
+++ b/backend/groups/helpers/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.contrib.auth.models import Group as AuthGroup
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Permission, User
 
 from eveonline.models import EveCorporation
 from groups.models import (
@@ -31,6 +31,60 @@ CORPORATION_GROUP_SUFFIXES = {
     EveCorporationGroup.GROUP_TYPE_GUNNER: " Gunner",
 }
 
+# Same Django permissions as alliance corp recruiter groups (A-RAT, L3ARN, …).
+# Associate recruiters are not in the Alliance group, so they only get site
+# access if these are on their Corp <TICKER> Recruiter group.
+RECRUITER_APPLICATION_PERMISSION_CODENAMES = (
+    "add_evecorporationapplication",
+    "change_evecorporationapplication",
+    "delete_evecorporationapplication",
+    "view_evecorporationapplication",
+)
+
+
+def recruiter_application_permissions():
+    """Permissions that let recruiters view/manage corp applications on the site."""
+    return list(
+        Permission.objects.filter(
+            content_type__app_label="applications",
+            codename__in=RECRUITER_APPLICATION_PERMISSION_CODENAMES,
+        )
+    )
+
+
+def ensure_recruiter_application_permissions(auth_group: AuthGroup) -> None:
+    """Grant corp-application perms on a recruiter Django group if missing."""
+    perms = recruiter_application_permissions()
+    if not perms:
+        logger.warning(
+            "Application permissions missing; cannot grant them to %s",
+            auth_group.name,
+        )
+        return
+    existing = set(
+        auth_group.permissions.filter(
+            pk__in=[p.pk for p in perms]
+        ).values_list("pk", flat=True)
+    )
+    missing = [p for p in perms if p.pk not in existing]
+    if missing:
+        auth_group.permissions.add(*missing)
+        logger.info(
+            "Granted application permissions to recruiter group %s",
+            auth_group.name,
+        )
+
+
+def _grant_recruiter_permissions_for_corp_groups(
+    corporation_groups: list[EveCorporationGroup],
+) -> None:
+    for corporation_group in corporation_groups:
+        if (
+            corporation_group.group_type
+            == EveCorporationGroup.GROUP_TYPE_RECRUITER
+        ):
+            ensure_recruiter_application_permissions(corporation_group.group)
+
 
 def ensure_corporation_groups_for_corp(
     corporation: EveCorporation,
@@ -42,11 +96,13 @@ def ensure_corporation_groups_for_corp(
     Returns the list of EveCorporationGroup for this corporation.
     """
     if not corporation.generate_corporation_groups or not corporation.ticker:
-        return list(
+        groups = list(
             EveCorporationGroup.objects.filter(
                 corporation=corporation
             ).order_by("group_type")
         )
+        _grant_recruiter_permissions_for_corp_groups(groups)
+        return groups
 
     base_name = f"Corp {corporation.ticker}"
     created_groups = []
@@ -71,11 +127,13 @@ def ensure_corporation_groups_for_corp(
         )
         created_groups.append(ecg)
 
-    return list(
+    groups = list(
         EveCorporationGroup.objects.filter(corporation=corporation).order_by(
             "group_type"
         )
     )
+    _grant_recruiter_permissions_for_corp_groups(groups)
+    return groups
 
 
 def offboard_corporation_groups(corporation: EveCorporation) -> None:

--- a/backend/groups/tasks.py
+++ b/backend/groups/tasks.py
@@ -15,6 +15,7 @@ from eveonline.helpers.characters import (
 from eveonline.models import EveCharacter
 
 from .helpers import (
+    ensure_recruiter_application_permissions,
     process_bulk_community_status_row,
     sync_tribe_chief_group_membership,
     sync_user_community_groups,
@@ -368,6 +369,11 @@ def sync_eve_corporation_groups():
 
         corp = corporation_group.corporation
         group = corporation_group.group
+        if (
+            corporation_group.group_type
+            == EveCorporationGroup.GROUP_TYPE_RECRUITER
+        ):
+            ensure_recruiter_application_permissions(group)
 
         in_group_user_ids = set(group.user_set.values_list("id", flat=True))
         recruiter_user_ids = {

--- a/backend/groups/tests/test_corporation_groups.py
+++ b/backend/groups/tests/test_corporation_groups.py
@@ -1,0 +1,94 @@
+import factory
+from django.contrib.auth.models import Group, User
+from django.db.models import signals
+
+from app.test import TestCase
+from eveonline.models import EveCharacter, EveCorporation
+from groups.helpers import (
+    RECRUITER_APPLICATION_PERMISSION_CODENAMES,
+    ensure_corporation_groups_for_corp,
+)
+from groups.models import EveCorporationGroup
+from groups.tasks import sync_eve_corporation_groups
+
+
+class CorporationGroupPermissionTestCase(TestCase):
+    """Recruiter groups need application perms for associate (non-Alliance) users."""
+
+    def _recruiter_codenames(self, group):
+        return set(
+            group.permissions.filter(
+                content_type__app_label="applications",
+                codename__in=RECRUITER_APPLICATION_PERMISSION_CODENAMES,
+            ).values_list("codename", flat=True)
+        )
+
+    @factory.django.mute_signals(
+        signals.pre_save, signals.post_save, signals.m2m_changed
+    )
+    def test_ensure_grants_application_permissions_to_recruiter_group(self):
+        corp = EveCorporation.objects.create(
+            corporation_id=98838663,
+            name="Minmatar Extraction Company",
+            ticker="M-EXC",
+            generate_corporation_groups=True,
+        )
+
+        groups = ensure_corporation_groups_for_corp(corp)
+        by_type = {g.group_type: g for g in groups}
+
+        self.assertEqual(
+            set(RECRUITER_APPLICATION_PERMISSION_CODENAMES),
+            self._recruiter_codenames(by_type["recruiter"].group),
+        )
+        self.assertEqual(
+            set(), self._recruiter_codenames(by_type["member"].group)
+        )
+        self.assertEqual(
+            set(), self._recruiter_codenames(by_type["director"].group)
+        )
+        self.assertEqual(
+            set(), self._recruiter_codenames(by_type["gunner"].group)
+        )
+
+    @factory.django.mute_signals(
+        signals.pre_save, signals.post_save, signals.m2m_changed
+    )
+    def test_sync_heals_recruiter_group_permissions_for_associate_user(self):
+        corp = EveCorporation.objects.create(
+            corporation_id=98838664,
+            name="Associate Recruiter Corp",
+            ticker="A-REC",
+        )
+        recruiter_group = Group.objects.create(name="Corp A-REC Recruiter")
+        EveCorporationGroup.objects.create(
+            corporation=corp,
+            group=recruiter_group,
+            group_type=EveCorporationGroup.GROUP_TYPE_RECRUITER,
+        )
+        user = User.objects.create(username="associate_recruiter")
+        char = EveCharacter.objects.create(
+            character_id=2117531911,
+            character_name="Parv the IV",
+            corporation_id=corp.corporation_id,
+            user=user,
+        )
+        corp.recruiters.add(char)
+
+        self.assertFalse(
+            user.has_perm("applications.change_evecorporationapplication")
+        )
+
+        sync_eve_corporation_groups()
+        user = User.objects.get(pk=user.pk)
+
+        self.assertEqual(
+            set(RECRUITER_APPLICATION_PERMISSION_CODENAMES),
+            self._recruiter_codenames(recruiter_group),
+        )
+        self.assertTrue(
+            user.has_perm("applications.change_evecorporationapplication")
+        )
+        self.assertTrue(
+            user.has_perm("applications.view_evecorporationapplication")
+        )


### PR DESCRIPTION
## Summary
- Associate recruiters (e.g. M-EXC) can interview in Discord but get **403** on `/alliance/corporations/applications/` because that page requires `applications.change_evecorporationapplication`.
- Alliance recruiters get that perm via the Alliance group and manually granted Corp Recruiter groups (A-RAT, L3ARN, SLTAR, TDT). Associate recruiters are only in `Corp <TICKER> Recruiter`, which had no Django permissions.
- Grant the same application permissions on every recruiter corp group when groups are created or synced (~30m beat).

## Test plan
- [ ] `pipenv run python manage.py test groups.tests.test_corporation_groups groups.tests.test_tasks --settings=app.settings_test`
- [ ] After deploy, wait for `sync_eve_corporation_groups` (or save M-EXC in admin) then have an associate recruiter reload applications
- [ ] Confirm alliance recruiter groups still work; member/director/gunner groups do not pick up extra perms


Made with [Cursor](https://cursor.com)