### PR TITLE
Record September 2026 recruitment scout send-shape learnings

### DIFF
--- a/.cursor/skills/fl33t-recruitment-scout/SKILL.md
+++ b/.cursor/skills/fl33t-recruitment-scout/SKILL.md
@@ -268,6 +268,8 @@ primary corp. Skip or note poor fits (e.g. WH-only seekers) in a short bullet li
   corps, not FW alliance corps. MFA lives in **highsec bulwark systems** with
   **lowsec excursions** — pitch that, not FW daily life. Mention a PvP corp only
   as an optional side path, not the primary pitch.
+- **Academy is Omega-only** (API `requirements`). Alpha seekers go MFA / highsec
+  PvE, not L3ARN.
 
 One primary corp per prospect. Optional one-liner for a graduate path or
 bigger/smaller corp in the same alliance — name only, no ad link. Use
@@ -289,13 +291,14 @@ recognize complementary seats, not a pecking order.
 | **FOSFO** (ad ticker; user shorthand FASFO) | Experienced **small-gang** crews, **UK especially**. Only name/route when the corp is on the corporations API (or a live `u/MinmatarFleet` ad you are intentionally linking). Use the live API/ad name — do not invent Administrative Atrocities / DHDR if the listing differs. |
 | **Banshee Squadron** | **Small, tight-knit new players in EUTZ**, **UK especially**. Prefer when the ask is EU/UK newbro + small roster rather than the larger Academy feeder. |
 | **The Dark Tribe (TDT)** | **Late-night USTZ**, small / tight-knit home for newer pilots in that window (check API requirements — currently 30m SP / KB / capital-ready; if OP does not match those, route Academy or Soltech for that TZ instead). |
-| **Minmatar Fleet Academy (L3ARN)** | **All-TZ new players** default feeder. API may still list US fleet hours — recruit as all-TZ newbro door; natural next homes include Banshee (EU), TDT or Soltech (US), or Rattini when they grow into caps/multi-box. |
+| **Minmatar Fleet Academy (L3ARN)** | **All-TZ new Omega players** default feeder. Skip alphas (Omega required). API may still list US fleet hours — recruit as all-TZ newbro door; natural next homes include Banshee (EU), TDT or Soltech (US), or Rattini when they grow into caps/multi-box. |
 
 Additional principles:
 
 - **New EU/UK pilots:** Banshee Squadron when they want a small tight EUTZ home; Academy (L3ARN) when they want the all-TZ feeder / “learn by undocking” frame. Rattini and Soltech are usually later seats, not the first EU newbro door.
 - **New USTZ / late USTZ:** Academy (L3ARN) for brand-new; TDT for late-night tight-knit if they match requirements; Soltech for late-USTZ pilots who want the daily Amamake intermediate seat.
-- **Industry-primary:** MFA associate corps primary. Base in highsec bulwark systems, lowsec excursions when people want out. PvP corp is a side note only. Name **Minmatar Extraction Company** (and its Amo mining ad) when they want organized mining fleets; MFA network + Keldor for general industry/PvE. Dual accounts (mining main + PvP alt) can split Extraction + a FW corp (e.g. Soltech) — on forums, linking `my.minmatar.org/alliance/corporations/` works when dual-routing. **Always close mining/industry pitches with Rock Hoppin'** (`https://youtu.be/XCApG7Pt6m4`).
+- **Industry-primary:** MFA associate corps primary. Base in highsec bulwark systems, lowsec excursions when people want out. PvP corp is a side note only. Name **Minmatar Extraction Company** (and its Amo mining ad) when they want organized mining fleets; MFA network + **Keldor00** on Discord for general industry/PvE. Dual accounts (mining main + PvP alt) can split Extraction + a FW corp (e.g. Soltech) — on forums, linking `my.minmatar.org/alliance/corporations/` works when dual-routing. Small industry **corps** seeking a null alliance home still get Extraction (fleet density / ore volume), not a silent skip. **Always close mining/industry pitches with Rock Hoppin'** (`https://youtu.be/XCApG7Pt6m4`).
+- **Ex-FL33T returning:** if they already left Rattini (or another cap/multi-box seat) for IRL / inactivity and are not asking for dreads, route **Soltech** (IRL-first Amamake) rather than sending them back to the same corp.
 - **Caps / multi-box veterans:** Rattini. Unused capital + learning lowsec → Rattini (own the dread-feed joke); mention Soltech only as a same-alliance option when they want the Amamake intermediate seat instead of the capital culture. **Always close PvP pitches with Bring Fun Shit** (`https://youtu.be/7-eGTtq9vWo`); add a fresh capital AAR from pre-scout 1c when it strengthens the cap hook. **Straylight is not in the alliance** — never route or link there.
 - **Alliance positioning:** we are a **faction warfare** alliance. Daily content is FW and lowsec small gang. Do not pitch nullsec, sovereignty, null ratting, structure timers, or bloc null. If OP wants dedicated sov-null mining, pitch highsec bulwarks / Extraction instead — never "we have sov too." If OP wants dedicated nullbloc PAP/CRAB lifestyle with no industry-or-FW opening, leave unanswered rather than inventing a null pitch.
 - **WH → FW redirects:** alliance door + **Bring Fun Shit** (`https://youtu.be/7-eGTtq9vWo`); optional fresh AAR from pre-scout 1c as a second beat. Do not close WH→FW with Rock Hoppin'.
@@ -303,26 +306,32 @@ Additional principles:
 ### Draft outreach
 
 Read [examples.md](examples.md) for past learnings if any exist. Every recommended
-message is **one short paragraph** — punchy, readable on a phone, no line breaks.
+**pitch** is **one short paragraph** — punchy, readable on a phone, no line breaks
+inside that block. Proof video and forum oneboxes are **separate send blocks**,
+never glued onto the pitch sentence.
 
 #### Shape (always)
 
-**One paragraph. 2–4 sentences max.** Weave their detail, name one primary corp,
-what it does, then ad link and/or discord inline at the end. No bullet lists, no
-second paragraph, no wall of text.
+**One pitch paragraph. 2–4 sentences max.** Weave their detail, name one primary
+corp, what it does, then ad link and/or discord inline at the end of that
+paragraph only. No bullet lists, no wall of text.
 
 ```
 [hook: their words, a fear, or what the corp does — first sentence grabs attention]
 
 [corp + one concrete detail tied to their post + optional graduate/alt corp in passing]
 
-[ad link and/or discord.gg/minmatar woven into the last sentence]
-
-[proof video — required by type: Rock Hoppin' for mining/industry, Bring Fun Shit for PvP/FW]
+[ad link and/or discord.gg/minmatar woven into the last sentence of the pitch]
 ```
 
-On Reddit the proof video may sit in a second short block after the paragraph (same
-family as examples.md). On forums, multi-block proof closes are fine.
+**Send-shape (required — do not collapse into the pitch):**
+
+| Surface | After the pitch paragraph |
+|---------|---------------------------|
+| **Reddit** | Blank line, then the proof video URL alone on its own line. Discord may also sit on its own line when the pitch has no ad. |
+| **Forums** | Onebox on its own line (`reddit.com/r/evejobs/s/…` shortlink, `my.minmatar.org`, or corp directory). Then a **bare** `https://youtu.be/…` URL on its own line so Discourse embeds the player. Do not bold the YouTube URL. Do not wrap it in markdown. |
+
+Proof video by type: **Rock Hoppin'** (`https://youtu.be/XCApG7Pt6m4`) mining/industry; **Bring Fun Shit** (`https://youtu.be/7-eGTtq9vWo`) PvP/FW.
 
 #### Variety (mandatory per scout run)
 
@@ -369,10 +378,15 @@ Shit.
   or "we have sov too" in outreach. We are FW/lowsec; sov-null seekers get skipped
   or an honest FW pitch only if their ask fits.
 - **One paragraph only** for the corp pitch. Reddit and forums use the same shape
-  for that block. Link + discord inline; skip discord when the ad link is enough.
-  **Proof video is required** and may be a second short block: **Rock Hoppin'**
-  (`https://youtu.be/XCApG7Pt6m4`) for mining/industry, **Bring Fun Shit**
-  (`https://youtu.be/7-eGTtq9vWo`) for PvP/FW. Do not swap them. Do not omit them.
+  for that block. Link + discord inline in the pitch; skip discord when the ad
+  link is enough. **Proof video is required as its own send block** (see
+  send-shape above). Do not swap Rock Hoppin' / Bring Fun Shit. Do not omit them.
+  Do not paste the video URL into the pitch paragraph (table glue is how it gets
+  sent glued).
+- **Forums Reddit ads:** prefer `/r/evejobs/s/` shortlinks so Discourse oneboxes
+  as `Reddit`. Full reddit.com comment URLs also onebox as `Reddit`.
+- **MFA Discord contact:** `ask for Keldor00` (handle, not the older `Keldor`
+  shorthand).
 - Keep motivational lines only when OP is about to quit EVE (still one paragraph).
 
 ### Present output
@@ -387,7 +401,10 @@ Shit.
 | Title | Corp fit | Responded | Type | Link | Recommended message |
 |-------|----------|-----------|------|------|---------------------|
 
-Put recommended messages in the table as a **single paragraph** (no line breaks).
+Put the **pitch** in the table as a **single paragraph** (no line breaks, no
+video URL in that cell). Recruiter send-shape is pitch, then the video/onebox
+blocks above — call that out in a one-line note under the tables if a draft
+would otherwise glue the YouTube link.
 
 Below the tables, optionally list:
 

--- a/.cursor/skills/fl33t-recruitment-scout/examples.md
+++ b/.cursor/skills/fl33t-recruitment-scout/examples.md
@@ -4,6 +4,158 @@ Real responses that worked. Add entries here after you send outreach — no temp
 
 ---
 
+## 2026-09-09 scout run
+
+### Ex-Rattini, USTZ, fried PSU / kicked for inactivity (72m SP)
+**Thread:** [72m SP Looking for a new home](https://www.reddit.com/r/evejobs/comments/1wbe6sk/72m_sp_looking_for_a_new_home/)  
+**Routed:** Soltech Armada  
+**Author:** BearThatCares
+
+**Sent (matched scout pitch, video glued):**
+> Leadership that kicks you after a fried PSU is a bad look, and Soltech Armada is an IRL-first Amamake crew in Minmatar faction warfare that wants you on comms for fleets and leaves you alone while you gas-huff through work. Central and Eastern US evenings are the busy window, with room to sneak an EU hour, and the mining/gas alts sit beside the pew without a dread tax. [Ad](https://www.reddit.com/r/evejobs/comments/1w80at6/sltar_soltech_armada_were_probably_a_bad/) or [discord.gg/minmatar](http://discord.gg/minmatar) [https://youtu.be/7-eGTtq9vWo](https://youtu.be/7-eGTtq9vWo)
+
+**Formatting issue:** Scout table put Bring Fun Shit in the same paragraph. Send it as pitch → blank line → video alone (see action-thread send below).
+
+**Routing note:** Already did a year in Rattini, not interested in dreads, patchy IRL → Soltech IRL-first, not Rattini again.
+
+---
+
+### Alpha, Amarr staging, L3s + FW
+**Thread:** [Corp looking](https://www.reddit.com/r/evejobs/comments/1wbd6q6/corp_looking/)  
+**Routed:** Minmatar Fleet Associates  
+**Author:** BearThatCares
+
+**Sent (matched scout pitch, video glued):**
+> Alpha with short grind time is still enough for Minmatar Fleet Associates, highsec bulwark missions and industry without an Omega tax, and you can keep Amarr as a staging while you decide if a subscription is worth it later. [discord.gg/minmatar](http://discord.gg/minmatar) and ask for Keldor [https://youtu.be/XCApG7Pt6m4](https://youtu.be/XCApG7Pt6m4)
+
+**What to change next time:** Same glue issue. Split Rock Hoppin' onto its own line. Discord contact is now **Keldor00** (this send still said Keldor).
+
+**Routing note:** Academy API requires Omega. Alpha + highsec missions → MFA, not L3ARN.
+
+---
+
+### 380m SP Delve industrialist, four accounts, prefers a large bloc
+**Thread:** [Looking for a new home](https://www.reddit.com/r/evejobs/comments/1w9xy2o/looking_for_a_new_home/)  
+**Routed:** Minmatar Extraction Company  
+**Author:** BearThatCares
+
+**Sent (matched scout pitch, video glued):**
+> The new highsec bulwark systems pay well enough that a four-account miner with a JF and a demanding job does not need another Delve shuffle, and Minmatar Extraction Company runs multiple Amo fleets a day with roughly 24/7 coverage inside Minmatar Fleet Associates. [discord.gg/minmatar](http://discord.gg/minmatar) and ask for Keldor, or [the mining ad](https://www.reddit.com/r/evejobs/comments/1w9rlea/mining_for_the_largest_war_in_new_eden/) [https://youtu.be/XCApG7Pt6m4](https://youtu.be/XCApG7Pt6m4)
+
+**Routing note:** Sov-null / Delve-prefer mining lock still gets Extraction; never “we have sov too.” Split the video next time. Use Keldor00.
+
+---
+
+### r/Eve: returning Goons, “where’s the action”
+**Thread:** [Returning player, where’s the action](https://www.reddit.com/r/Eve/comments/1wad0w2/returning_player_wheres_the_action/)  
+**Routed:** alliance FW redirect  
+**Author:** BearThatCares
+
+**Scout draft (one paragraph, video glued):**
+> Delve is quieter than the 2022 Goons memory and Amarr-Minmatar faction warfare is where the back-to-back fights actually are, Amamake especially, so skip the asset-safety trip. discord.gg/minmatar + Bring Fun Shit
+
+**Sent:**
+> Delve is quieter than the 2022 Goons memory and Amarr-Minmatar faction warfare is where the back-to-back fights actually are, Amamake especially, so skip the asset-safety trip.
+>
+> [discord.gg/minmatar](http://discord.gg/minmatar)
+>
+> [https://youtu.be/7-eGTtq9vWo](https://youtu.be/7-eGTtq9vWo)
+
+**What changed and why:** Split discord and Bring Fun Shit onto their own lines. This is the Reddit send-shape for a no-ad FW redirect (pitch / discord / video).
+
+**Routing note:** Location/advice threads still count when they are shopping for where to play. Proof-first FW, no named corp.
+
+---
+
+### Forum: UK 53m SP, wants 0.0 roams / Sabre
+**Thread:** [Returning long time player looking for a new home UK TZ](https://forums.eveonline.com/t/returning-long-time-player-looking-for-a-new-home-uk-tz/517891)  
+**Routed:** FOSFO (live ad; not on corporations API)  
+**Author:** BearThatCares
+
+**Scout draft:**
+> Skip another 0.0 PAP home if the real ask is UK evening roams in a Sabre. FOSFO … [full evejobs comment URL] **https://youtu.be/7-eGTtq9vWo**
+
+**Sent:**
+> Skip another 0.0 PAP home if the real ask is UK evening roams in a Sabre. FOSFO is the tight EUTZ Minmatar FW skirmish crew for that window, small roster, thick skin, and alliance fights when something huge shows up.
+>
+> https://www.reddit.com/r/evejobs/s/qjCRmobtF5
+>
+> https://youtu.be/7-eGTtq9vWo
+
+**What changed and why:**
+- Reddit **shortlink** (`/r/evejobs/s/…`) so Discourse oneboxes as the word `Reddit`.
+- Bare YouTube URL on its own line → native video embed. Do **not** bold the URL (that was the old house close; embeds beat bold text).
+
+**Routing note:** Prefer-null + UK small-gang roam → FOSFO live ad OK while corp is missing from the API.
+
+---
+
+### Forum: small EU indy corp seeking a null-sec home
+**Thread:** [Small EU Indy Corp Looking for a Null-Sec Home](https://forums.eveonline.com/t/small-eu-indy-corp-looking-for-a-null-sec-home/517953)  
+**Routed:** Minmatar Extraction Company  
+**Author:** BearThatCares
+
+**Scout draft:** pitch + Keldor + mining ad + Rock Hoppin' in one blob.
+
+**Sent:**
+> Null-sec politics are optional when the rocks are in highsec bulwarks. Minmatar Extraction Company runs multiple daily Amo fleets with 100% Jita buyback inside Minmatar Fleet Associates if a small EU industry group wants a laid-back home that still undocks.
+>
+> discord.gg/minmatar and ask for Keldor00
+>
+> https://youtu.be/XCApG7Pt6m4
+
+**What changed and why:** Dropped the Reddit mining ad (site/discord is enough when the ask is a group home). Discord contact **Keldor00**. Bare YouTube on its own line for the embed. Pitch / contact / video.
+
+**Routing note:** Industry **corp** hunting a null alliance is still an Extraction redirect, not a skip.
+
+---
+
+### Forum: 14-person Gallente mine/build corp looking to merge
+**Thread:** [Small Corp looking to disband and merge into another team](https://forums.eveonline.com/t/small-corp-looking-to-disband-and-merge-into-another-team/517824)  
+**Routed:** Minmatar Extraction Company  
+**Author:** BearThatCares
+
+**Scout draft (not sent):**
+> Fourteen people who mainly mine and build, tired of alliance merges that do not stick, is the Minmatar Extraction Company picture: organized Amo fleets, 100% Jita buyback, highsec bulwarks, and a network that already absorbs small industry groups. discord.gg/minmatar and ask for Keldor + Rock Hoppin'
+
+**Sent:**
+> Minmatar Extraction Company has 3-5 mining fleets a day, and supplies 100B+ of highsec ore every month to the faction warfare efforts.
+>
+> https://my.minmatar.org/
+>
+> https://youtu.be/XCApG7Pt6m4
+
+**What changed and why:** Dropped the 14-person weave and Keldor. Fleet-density + monthly ore volume is the fear-kill for empty mining promises. Site onebox (`my.minmatar.org`) then Rock Hoppin' embed. Same family as “4 fleets per day / 24/7” sov-miner redirects.
+
+**Routing note:** Corp-merge industry seekers → Extraction stats + site, not a brochure paragraph.
+
+---
+
+### Already on the thread before this scout closed
+- [Returner 76m SP lf...](https://www.reddit.com/r/evejobs/comments/1wai32z/returner_76m_sp_lf/) — Bear: casual-dad FW + my.minmatar.org
+- [Returning player looking for PvX WH corp UK/EU TZ](https://www.reddit.com/r/evejobs/comments/1w79ue3/returning_player_looking_for_pvx_wh_corp_ukeu_tz/) — Bear: WH second-job / FW session math + Bring Fun Shit (glued in one paragraph; split next time)
+- [EU based returning bittervet looking for home](https://www.reddit.com/r/evejobs/comments/1w7132l/eu_based_returning_bittervet_looking_for_home/) — Sycamoria: Soltech
+- [Back into the fray](https://forums.eveonline.com/t/back-into-the-fray/517708) — Bear: Soltech + MFA PI, corp directory onebox, Bring Fun Shit embed
+
+---
+
+## Patterns (2026-09-09 run)
+
+| Situation | What landed |
+|-----------|-------------|
+| Ex-Rattini USTZ, no caps, IRL patchy | Soltech; do not recycle Rattini |
+| Alpha / no Omega | MFA; Academy is Omega-gated |
+| Delve / sov-prefer miner | Extraction bulwarks; video split next time |
+| r/Eve “where’s the action” | FW redirect; pitch / discord / video as three blocks |
+| UK Sabre roam, wants 0.0 | FOSFO live ad; forum Reddit **shortlink** + bare youtu.be embed |
+| EU indy corp seeking null home | Extraction; Keldor00; drop mining ad; YouTube embed |
+| 14-person mine/build merge | Extraction **stats** (3–5 fleets/day, 100B+ ore/month) + my.minmatar.org + Rock Hoppin' embed |
+| Reddit send-shape | Pitch paragraph → blank → proof video alone. Do not glue youtu.be into the pitch |
+| Forum send-shape | Pitch → onebox (shortlink or my.minmatar.org) → **bare** youtu.be (Discourse video player). Stop bolding YouTube URLs |
+| MFA Discord | `Keldor00` |
+
+---
+
 ## 2026-08-10 scout run
 
 ### Returning US Central, 12m SP, PvE-leaning learner


### PR DESCRIPTION
## Summary
- Adds the 2026-09-09 scout run to `examples.md` from what was actually posted (Reddit splits, forum YouTube embeds, FOSFO shortlink, Extraction stats, `Keldor00`).
- Updates the recruitment scout skill so drafts keep the pitch as one paragraph and put proof videos / Discourse oneboxes in separate send blocks, plus routing notes for alphas and ex-Rattini returns.

## Test plan
- [ ] Skim `examples.md` against the live BearThatCares comments on the Sep 9 LFC threads
- [ ] Next scout run: table pitches have no youtu.be URL in the cell; Reddit/forum send-shape matches the skill table


Made with [Cursor](https://cursor.com)