### PR TITLE
Link FAX guide Apostle hull to Buffer Apostle

### DIFF
--- a/frontend/app/src/components/blocks/capital-guide/CapitalGuideMetaBlocks.astro
+++ b/frontend/app/src/components/blocks/capital-guide/CapitalGuideMetaBlocks.astro
@@ -4,7 +4,7 @@ const { t } = i18n(Astro.url)
 
 import ItemPicture from '@components/blocks/ItemPicture.astro'
 import FittingLink from '@components/blocks/FittingLink.astro'
-import { fittingsForShipId, type MetaBlock } from '@/data/capital-guide'
+import { primary_fitting_for_ship, type MetaBlock } from '@/data/capital-guide'
 import type { Fitting } from '@dtypes/api.minmatar.org'
 
 interface Props {
@@ -49,9 +49,13 @@ const no_fitting_label = t('ships.capital_guide.no_fitting')
                     </thead>
                     <tbody>
                         {block.rows.map((row) => {
-                            const fittings =
-                                row.ship_id != null ? fittingsForShipId(row.ship_id, fitting_library) : []
-                            const primary = fittings[0] ?? null
+                            const primary =
+                                row.ship_id != null
+                                    ? primary_fitting_for_ship(row.ship_id, fitting_library, {
+                                          fit_match: row.fit_match,
+                                          notes: row.cells[1],
+                                      })
+                                    : null
                             const hull_content = (
                                 <span class="cap-table__hull">
                                     {row.ship_id != null && (

--- a/frontend/app/src/data/capital-guide/fittings.ts
+++ b/frontend/app/src/data/capital-guide/fittings.ts
@@ -10,3 +10,56 @@ export function fittingsForShipId(ship_id: number, library: Fitting[]): Fitting[
 export function fittingsForHull(hull: CapitalHull, library: Fitting[]): Fitting[] {
     return fittingsForShipId(hull.shipId, library)
 }
+
+export function infer_fit_match(notes?: string): string | undefined {
+    if (!notes) {
+        return undefined
+    }
+    if (/\bbuffer\b|\bpassive\b/i.test(notes)) {
+        return 'Buffer'
+    }
+    if (/\bactive\b/i.test(notes)) {
+        return 'Active'
+    }
+    return undefined
+}
+
+function pick_fitting_by_name_match(fittings: Fitting[], match: string): Fitting | undefined {
+    const needle = match.trim().toLowerCase()
+    if (!needle) {
+        return undefined
+    }
+    const hits = fittings.filter((fit) => fit.name.toLowerCase().includes(needle))
+    if (hits.length === 0) {
+        return undefined
+    }
+    const without_geno = hits.filter((fit) => !/\bgeno\b/i.test(fit.name))
+    const pool = without_geno.length > 0 ? without_geno : hits
+    return [...pool].sort((left, right) => {
+        const by_length = left.name.length - right.name.length
+        if (by_length !== 0) {
+            return by_length
+        }
+        return left.id - right.id
+    })[0]
+}
+
+export function primary_fitting(
+    fittings: Fitting[],
+    options?: { fit_match?: string; notes?: string },
+): Fitting | null {
+    if (fittings.length === 0) {
+        return null
+    }
+    const match = options?.fit_match?.trim() || infer_fit_match(options?.notes)
+    const matched = match ? pick_fitting_by_name_match(fittings, match) : undefined
+    return matched ?? fittings[0]
+}
+
+export function primary_fitting_for_ship(
+    ship_id: number,
+    library: Fitting[],
+    options?: { fit_match?: string; notes?: string },
+): Fitting | null {
+    return primary_fitting(fittingsForShipId(ship_id, library), options)
+}

--- a/frontend/app/src/data/capital-guide/index.ts
+++ b/frontend/app/src/data/capital-guide/index.ts
@@ -10,7 +10,13 @@ export type {
     GuideInfoTable,
 } from './types'
 export { capitalTierLabels } from './types'
-export { fittingsForHull, fittingsForShipId } from './fittings'
+export {
+    fittingsForHull,
+    fittingsForShipId,
+    infer_fit_match,
+    primary_fitting,
+    primary_fitting_for_ship,
+} from './fittings'
 export { buildCapitalGuideJsonLd } from './seo'
 export { load_capital_guide_runtime } from './runtime'
 export type { CapitalGuideRuntime, CapitalGuideRuntimeOptions } from './runtime'

--- a/frontend/app/src/data/capital-guide/types.ts
+++ b/frontend/app/src/data/capital-guide/types.ts
@@ -41,7 +41,7 @@ export type MetaBlock =
     | {
         type: 'table'
         headers: [string, string]
-        rows: { cells: [string, string]; ship_id?: number }[]
+        rows: { cells: [string, string]; ship_id?: number; fit_match?: string }[]
     }
 
 export type CrosstrainingRow = {

--- a/frontend/app/src/data/fax-guide/content.ts
+++ b/frontend/app/src/data/fax-guide/content.ts
@@ -30,16 +30,16 @@ export const metaBlocks: MetaBlock[] = [
         type: 'table',
         headers: ['Hull', 'Notes'],
         rows: [
-            { cells: ['Apostle', 'Recommended. Buffer armor fax, often in pairs.'], ship_id: 37604 },
-            { cells: ['Ninazu', 'Active armor fax, can also repair shield. Cheap escalation bait.'], ship_id: 37607 },
-            { cells: ['Lif', 'Active shield fax, can also repair armor. Cheap. Extremely good against neutralizers.'], ship_id: 37606 },
-            { cells: ['Minokawa', 'Buffer shield fax, often in pairs.'], ship_id: 37605 },
+            { cells: ['Apostle', 'Recommended. Buffer (passive) armor fax, often in pairs.'], ship_id: 37604, fit_match: 'Buffer' },
+            { cells: ['Ninazu', 'Active armor fax, can also repair shield. Cheap escalation bait.'], ship_id: 37607, fit_match: 'Active Ninazu' },
+            { cells: ['Lif', 'Active shield fax, can also repair armor. Cheap. Extremely good against neutralizers.'], ship_id: 37606, fit_match: 'Active' },
+            { cells: ['Minokawa', 'Buffer shield fax, often in pairs.'], ship_id: 37605, fit_match: 'Buffer' },
         ],
     },
 ]
 
 export const guidanceLead =
-    'In Minmatar Fleet, we recommend pilots start with the <strong>Apostle</strong>. It is our primary buffer armor fax. Train a <strong>Ninazu</strong> next if you want a cheaper active hull for starting escalations — it can also repair shield. The Lif is useful against heavy neut pressure and cross-trains into a Nidhoggur.'
+    'In Minmatar Fleet, we recommend pilots start with the <strong>buffer (passive) Apostle</strong>. It is our primary buffer armor fax. Train a <strong>Ninazu</strong> next if you want a cheaper active hull for starting escalations — it can also repair shield. The Lif is useful against heavy neut pressure and cross-trains into a Nidhoggur.'
 
 export const apostleSkillPlan: string[] = [
     'Drones 2',

--- a/frontend/app/testing/data/capital-guide-fittings.test.ts
+++ b/frontend/app/testing/data/capital-guide-fittings.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+    infer_fit_match,
+    primary_fitting,
+    primary_fitting_for_ship,
+} from '@/data/capital-guide/fittings'
+import type { Fitting } from '@dtypes/api.minmatar.org'
+
+function fitting(partial: Pick<Fitting, 'id' | 'name' | 'ship_id'> & Partial<Fitting>): Fitting {
+    return {
+        description: '',
+        created_at: new Date(0),
+        updated_at: new Date(0),
+        eft_format: '',
+        minimum_pod: '',
+        recommended_pod: '',
+        latest_version: '',
+        known_key: null,
+        refits: [],
+        tags: ['faction_warfare'],
+        ...partial,
+    }
+}
+
+const apostle_id = 37604
+
+const library: Fitting[] = [
+    fitting({ id: 15, name: '[FL33T] Active Apostle', ship_id: apostle_id }),
+    fitting({ id: 17, name: '[FL33T] Buffer Apostle', ship_id: apostle_id }),
+    fitting({ id: 228, name: '[FL33T] Active Ninazu', ship_id: 37607 }),
+    fitting({ id: 440, name: '[FL33T] Active Geno Ninazu', ship_id: 37607 }),
+    fitting({ id: 16, name: '[FL33T] Active Minokawa', ship_id: 37605 }),
+    fitting({ id: 335, name: '[FL33T] Buffer Minokawa', ship_id: 37605 }),
+    fitting({ id: 441, name: '[FL33T] Active Geno Minokawa', ship_id: 37605 }),
+]
+
+describe('capital guide primary fitting', () => {
+    it('infers Buffer from buffer or passive notes', () => {
+        expect(infer_fit_match('Recommended. Buffer armor fax, often in pairs.')).toBe('Buffer')
+        expect(infer_fit_match('Start with the Passive Apostle fit')).toBe('Buffer')
+        expect(infer_fit_match('Active armor fax')).toBe('Active')
+    })
+
+    it('links Apostle hulls to Buffer Apostle instead of the older Active fit', () => {
+        const primary = primary_fitting_for_ship(apostle_id, library, {
+            notes: 'Recommended. Buffer (passive) armor fax, often in pairs.',
+            fit_match: 'Buffer',
+        })
+        expect(primary?.id).toBe(17)
+        expect(primary?.name).toContain('Buffer Apostle')
+    })
+
+    it('prefers Buffer Minokawa when the hull is described as buffer', () => {
+        const primary = primary_fitting_for_ship(37605, library, {
+            notes: 'Buffer shield fax, often in pairs.',
+        })
+        expect(primary?.id).toBe(335)
+    })
+
+    it('prefers the non-Geno Active Ninazu over Active Geno Ninazu', () => {
+        const primary = primary_fitting_for_ship(37607, library, {
+            fit_match: 'Active Ninazu',
+            notes: 'Active armor fax',
+        })
+        expect(primary?.id).toBe(228)
+    })
+
+    it('falls back to the first fit when no name matches', () => {
+        const only_active = [
+            fitting({ id: 15, name: '[FL33T] Active Apostle', ship_id: apostle_id }),
+        ]
+        expect(primary_fitting(only_active, { fit_match: 'Buffer' })?.id).toBe(15)
+        expect(primary_fitting([], { fit_match: 'Buffer' })).toBeNull()
+    })
+})


### PR DESCRIPTION
## Summary
- The FAX guide tells people to start on the buffer (passive) Apostle, but the hull name linked to the first Apostle fit in the library (`[FL33T] Active Apostle`, id 15).
- Hull rows now pick a fit by name (`Buffer` / `Active`), so Apostle and Minokawa go to the buffer doctrines and Ninazu stays on the non-Geno active fit.

## Test plan
- [x] `npm run test -- testing/data/capital-guide-fittings.test.ts --run`
- [x] `npm run check`
- [ ] After deploy, on `/learning/guides/force-auxiliary-carrier-guide/` click **Apostle** and confirm it opens `[FL33T] Buffer Apostle` (not Active)
- [ ] Confirm Minokawa opens Buffer Minokawa and Ninazu still opens Active Ninazu


Made with [Cursor](https://cursor.com)