### PR TITLE
Fix external-link dialog returning to the current page

### DIFF
--- a/frontend/app/src/components/blocks/AlertDialog.astro
+++ b/frontend/app/src/components/blocks/AlertDialog.astro
@@ -131,3 +131,15 @@ interface Props {
         }
     }
 </style>
+
+<script>
+    import { schedule_alert_dialog_reset } from '@helpers/alertDialog'
+
+    declare global {
+        interface Window {
+            __schedule_alert_dialog_reset?: typeof schedule_alert_dialog_reset
+        }
+    }
+
+    window.__schedule_alert_dialog_reset = schedule_alert_dialog_reset
+</script>

--- a/frontend/app/src/components/partials/AlpineScripts.astro
+++ b/frontend/app/src/components/partials/AlpineScripts.astro
@@ -57,12 +57,28 @@ export const AlertDialogXData = `
         
         return new Promise((resolve) => {
             this.alert_dialog_close().then((result) => {
-                this.alert_dialog_open = false
-                this.alert_dialog_accept_href = ''
-                this.alert_dialog_accept_label = ''
-                this.alert_dialog_cancel_label = ''
-                this.alert_dialog_show_cancel = false
-                resolve(result.action == 'accept' ? this.alert_dialog_return_on_accept : false) 
+                const accepted = result.action == 'accept' ? this.alert_dialog_return_on_accept : false
+                const finish = () => {
+                    this.alert_dialog_open = false
+                    this.alert_dialog_accept_href = ''
+                    this.alert_dialog_accept_label = ''
+                    this.alert_dialog_cancel_label = ''
+                    this.alert_dialog_show_cancel = false
+                    resolve(accepted)
+                }
+                const schedule = window.__schedule_alert_dialog_reset
+                if (typeof schedule === 'function') {
+                    schedule({
+                        action: result.action,
+                        accept_href: this.alert_dialog_accept_href || '',
+                        finish,
+                    })
+                    return
+                }
+                if (result.action == 'accept' && this.alert_dialog_accept_href)
+                    setTimeout(finish, 0)
+                else
+                    finish()
             })
         })
     },

--- a/frontend/app/src/helpers/alertDialog.ts
+++ b/frontend/app/src/helpers/alertDialog.ts
@@ -1,0 +1,22 @@
+/**
+ * Keep Open's bound href until after the click's default action.
+ *
+ * Accept with `accept_href` is a real `<a target="_blank">`. Resetting
+ * `alert_dialog_accept_href` (or closing the dialog) in the same turn
+ * clears that href and the browser navigates the current tab instead.
+ */
+export function schedule_alert_dialog_reset(options: {
+    action: string
+    accept_href: string
+    finish: () => void
+    defer?: (callback: () => void) => void
+}): void {
+    const defer = options.defer ?? ((callback) => {
+        setTimeout(callback, 0)
+    })
+    if (options.action === 'accept' && options.accept_href) {
+        defer(options.finish)
+        return
+    }
+    options.finish()
+}

--- a/frontend/app/testing/components/blocks/AlertDialog.test.ts
+++ b/frontend/app/testing/components/blocks/AlertDialog.test.ts
@@ -1,10 +1,18 @@
 import { experimental_AstroContainer as AstroContainer } from "astro/container";
 import { expect, test } from "vitest";
+import { AlertDialogXData } from "@components/partials/AlpineScripts.astro";
 import AlertDialog from "@components/blocks/AlertDialog.astro";
 
-test("AlertDialog defaults", async () => {
-  const container = await AstroContainer.create();
-  const result = await container.renderToString(AlertDialog, {});
+test("alert dialog defers reset when Open has an accept href", () => {
+    expect(AlertDialogXData).toContain("window.__schedule_alert_dialog_reset");
+    expect(AlertDialogXData).toContain("accept_href: this.alert_dialog_accept_href");
+    expect(AlertDialogXData).toContain("setTimeout(finish, 0)");
+});
 
-  // expect(result).toMatchSnapshot();
+test("AlertDialog installs the reset helper and Open is a new-tab link", async () => {
+    const container = await AstroContainer.create();
+    const result = await container.renderToString(AlertDialog, {});
+
+    expect(result).toContain("x-bind:href=\"alert_dialog_accept_href\"");
+    expect(result).toContain("alert-dialog-action=\"accept\"");
 });

--- a/frontend/app/testing/helpers/alertDialog.test.ts
+++ b/frontend/app/testing/helpers/alertDialog.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest'
+import { schedule_alert_dialog_reset } from '@helpers/alertDialog'
+
+describe('schedule_alert_dialog_reset', () => {
+    it('defers finish when Accept has an external href so the Open link can navigate', () => {
+        const finish = vi.fn()
+        const defer = vi.fn()
+
+        schedule_alert_dialog_reset({
+            action: 'accept',
+            accept_href: 'https://developers.eveonline.com/authorized-apps',
+            finish,
+            defer,
+        })
+
+        expect(finish).not.toHaveBeenCalled()
+        expect(defer).toHaveBeenCalledTimes(1)
+        defer.mock.calls[0][0]()
+        expect(finish).toHaveBeenCalledTimes(1)
+    })
+
+    it('finishes immediately on Cancel', () => {
+        const finish = vi.fn()
+        const defer = vi.fn()
+
+        schedule_alert_dialog_reset({
+            action: 'close',
+            accept_href: 'https://developers.eveonline.com/authorized-apps',
+            finish,
+            defer,
+        })
+
+        expect(defer).not.toHaveBeenCalled()
+        expect(finish).toHaveBeenCalledTimes(1)
+    })
+
+    it('finishes immediately when Accept has no href', () => {
+        const finish = vi.fn()
+        const defer = vi.fn()
+
+        schedule_alert_dialog_reset({
+            action: 'accept',
+            accept_href: '',
+            finish,
+            defer,
+        })
+
+        expect(defer).not.toHaveBeenCalled()
+        expect(finish).toHaveBeenCalledTimes(1)
+    })
+})


### PR DESCRIPTION
## Summary
- Opening an external link (for example Authorized Third-Party applications on `/account/`) showed the leaving-site dialog, then **Open** reloaded the same page instead of CCP.
- The dialog was clearing `alert_dialog_accept_href` during the same click as the Open `<a>`, so the browser followed an empty href.
- Reset of that href is deferred until after the click’s default action. Help ticket #160.

## Test plan
- [ ] Logged in, `/account/` → Authorized Third-Party applications → Open → CCP authorized-apps opens in a new tab (not `/account/`)
- [ ] Uncheck “Don’t show this anymore” if needed, repeat Open without the persist shortcut
- [ ] Cancel still closes the dialog without navigating
- [ ] `npm run test -- testing/helpers/alertDialog.test.ts testing/components/blocks/AlertDialog.test.ts`


Made with [Cursor](https://cursor.com)