### PR TITLE
Stop Discord corp roles reverting after a corp move

### DIFF
--- a/backend/discord/tests.py
+++ b/backend/discord/tests.py
@@ -1024,10 +1024,11 @@ class DiscordOffboardSyncTests(TestCase):
     def test_sync_discord_user_missing_user_is_noop(self):
         sync_discord_user(999999)
 
+    @patch("users.router.sync_user_corporation_groups")
     @patch("users.router.sync_discord_user")
     @patch("users.router.update_affiliation")
     def test_sync_user_endpoint_returns_410_after_offboard(
-        self, mock_affiliation, mock_sync
+        self, mock_affiliation, mock_sync, mock_corp_groups
     ):
         user_id = self.user.id
 
@@ -1044,10 +1045,11 @@ class DiscordOffboardSyncTests(TestCase):
         self.assertIn(b"offboarded", response.content)
 
     @patch("users.router.offboard_user")
+    @patch("users.router.sync_user_corporation_groups")
     @patch("users.router.sync_discord_user")
     @patch("users.router.update_affiliation")
     def test_sync_user_endpoint_returns_410_on_affiliation_member_missing(
-        self, mock_affiliation, mock_sync, mock_offboard
+        self, mock_affiliation, mock_sync, mock_corp_groups, mock_offboard
     ):
         """REST-API-MZ/MX: DiscordRoleAssignmentError rolls back in-atomic offboard."""
         user_id = self.user.id
@@ -1069,12 +1071,14 @@ class DiscordOffboardSyncTests(TestCase):
         self.assertIn(b"offboarded", response.content)
         mock_offboard.assert_called_once_with(user_id)
         mock_sync.assert_not_called()
+        mock_corp_groups.assert_not_called()
         self.assertFalse(User.objects.filter(id=user_id).exists())
 
+    @patch("users.router.sync_user_corporation_groups")
     @patch("users.router.sync_discord_user")
     @patch("users.router.update_affiliation")
     def test_sync_user_endpoint_returns_404_when_user_missing(
-        self, mock_affiliation, mock_sync
+        self, mock_affiliation, mock_sync, mock_corp_groups
     ):
         mock_affiliation.side_effect = User.DoesNotExist
         client = Client()
@@ -1085,6 +1089,7 @@ class DiscordOffboardSyncTests(TestCase):
         self.assertEqual(response.status_code, 404)
         self.assertIn(b"not found", response.content)
         mock_sync.assert_not_called()
+        mock_corp_groups.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/backend/eveonline/helpers/characters/affiliations.py
+++ b/backend/eveonline/helpers/characters/affiliations.py
@@ -1,3 +1,6 @@
+from eveonline.helpers.characters.corporation_history import (
+    corporation_id_preferring_history_over_stale_esi,
+)
 from eveonline.models import EveCharacter
 
 
@@ -8,6 +11,9 @@ def update_character_with_affiliations(
     faction_id: int | None = None,
 ) -> bool:
     character = EveCharacter.objects.get(character_id=character_id)
+    corporation_id = corporation_id_preferring_history_over_stale_esi(
+        character, corporation_id
+    )
     updated = False
     if (corporation_id and character.corporation_id != corporation_id) or (
         not corporation_id and character.corporation_id is not None

--- a/backend/eveonline/helpers/characters/corporation_history.py
+++ b/backend/eveonline/helpers/characters/corporation_history.py
@@ -24,6 +24,39 @@ CORPORATION_HISTORY_TTL = timedelta(hours=24)
 ALLIANCE_HISTORY_TTL = timedelta(hours=1)
 
 
+def corporation_id_preferring_history_over_stale_esi(
+    character: EveCharacter, esi_corporation_id: int | None
+) -> int | None:
+    """
+    ESI character public data and /characters/affiliation/ often lag a corp
+    join. If history already records a newer membership and ESI still reports
+    the previous corporation, keep the history corporation.
+    """
+    if not esi_corporation_id:
+        return esi_corporation_id
+    rows = list(
+        character.corporation_history.order_by(
+            "-start_date", "-record_id"
+        ).only("corporation_id")[:2]
+    )
+    if len(rows) < 2:
+        return esi_corporation_id
+    latest, previous = rows[0], rows[1]
+    if (
+        esi_corporation_id != latest.corporation_id
+        and esi_corporation_id == previous.corporation_id
+    ):
+        logger.info(
+            "Ignoring stale ESI corporation %s for character %s; "
+            "corporation history current is %s",
+            esi_corporation_id,
+            character.character_id,
+            latest.corporation_id,
+        )
+        return latest.corporation_id
+    return esi_corporation_id
+
+
 def character_corporation_history_is_stale(
     character: EveCharacter,
     *,

--- a/backend/eveonline/helpers/characters/public_data.py
+++ b/backend/eveonline/helpers/characters/public_data.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 from eveonline.client import EsiResponse, esi_public, live_esi_allowed
 from eveonline.helpers.characters.characters import orphan_character
 from eveonline.helpers.characters.corporation_history import (
+    corporation_id_preferring_history_over_stale_esi,
     sync_character_corporation_history,
 )
 from eveonline.helpers.esi import raise_if_esi_error_limited
@@ -26,7 +27,9 @@ def apply_character_public_data(
         character.character_name = name
         updated = True
 
-    corporation_id = esi_character.get("corporation_id")
+    corporation_id = corporation_id_preferring_history_over_stale_esi(
+        character, esi_character.get("corporation_id")
+    )
     if (
         corporation_id is not None
         and character.corporation_id != corporation_id

--- a/backend/eveonline/tests/helpers/test_corporation_history.py
+++ b/backend/eveonline/tests/helpers/test_corporation_history.py
@@ -11,13 +11,18 @@ from esi.exceptions import ESIErrorLimitException
 
 from app.test import TestCase
 from eveonline.client import EsiResponse
+from eveonline.helpers.characters.affiliations import (
+    update_character_with_affiliations,
+)
 from eveonline.helpers.characters.corporation_history import (
     alliance_id_at,
     character_corporation_history_is_stale,
+    corporation_id_preferring_history_over_stale_esi,
     ensure_corporation_alliance_history,
     sync_character_corporation_history,
 )
 from eveonline.helpers.characters.public_data import (
+    apply_character_public_data,
     update_character_public_data,
 )
 from eveonline.models import (
@@ -380,3 +385,70 @@ class CorporationHistorySyncTests(TestCase):
         )
         update_character_public_data(self.character.character_id)
         sync_history.assert_called_once()
+
+
+class StaleEsiCorporationOverrideTests(TestCase):
+    @factory.django.mute_signals(signals.pre_save, signals.post_save)
+    def setUp(self):
+        self.character = EveCharacter.objects.create(
+            character_id=91000011,
+            character_name="Corp Mover",
+            corporation_id=98741376,
+        )
+        now = timezone.now()
+        EveCharacterCorporationHistory.objects.create(
+            character=self.character,
+            record_id=2,
+            corporation_id=98741376,
+            start_date=now,
+        )
+        EveCharacterCorporationHistory.objects.create(
+            character=self.character,
+            record_id=1,
+            corporation_id=98838034,
+            start_date=now - timedelta(days=10),
+        )
+
+    @factory.django.mute_signals(signals.pre_save, signals.post_save)
+    def test_keeps_history_corp_when_esi_still_reports_previous(self):
+        self.assertEqual(
+            98741376,
+            corporation_id_preferring_history_over_stale_esi(
+                self.character, 98838034
+            ),
+        )
+
+    @factory.django.mute_signals(signals.pre_save, signals.post_save)
+    def test_applies_esi_when_it_reports_a_new_corporation(self):
+        self.assertEqual(
+            1000045,
+            corporation_id_preferring_history_over_stale_esi(
+                self.character, 1000045
+            ),
+        )
+
+    @factory.django.mute_signals(signals.pre_save, signals.post_save)
+    def test_affiliations_do_not_revert_to_previous_corp(self):
+        updated = update_character_with_affiliations(
+            character_id=self.character.character_id,
+            corporation_id=98838034,
+            alliance_id=99000001,
+        )
+        self.character.refresh_from_db()
+        self.assertTrue(updated)
+        self.assertEqual(98741376, self.character.corporation_id)
+        self.assertEqual(99000001, self.character.alliance_id)
+
+    @factory.django.mute_signals(signals.pre_save, signals.post_save)
+    def test_public_data_does_not_revert_to_previous_corp(self):
+        updated = apply_character_public_data(
+            self.character,
+            {
+                "name": "Corp Mover",
+                "corporation_id": 98838034,
+                "security_status": 1.0,
+            },
+        )
+        self.assertTrue(updated)
+        self.assertEqual(98741376, self.character.corporation_id)
+        self.assertEqual(1.0, self.character.security_status)

--- a/backend/groups/tasks.py
+++ b/backend/groups/tasks.py
@@ -430,6 +430,47 @@ def sync_eve_corporation_groups():
                     )
 
 
+def sync_user_corporation_groups(user: User) -> None:
+    """
+    Recompute Corp <TICKER> auth groups for one user from linked characters.
+
+    Used by Discord role refresh so corp roles do not wait for the :19/:49 beat.
+    """
+    for corporation_group in EveCorporationGroup.objects.select_related(
+        "corporation", "group"
+    ):
+        if not corporation_group.corporation:
+            continue
+        group = corporation_group.group
+        qualifies = _user_qualifies_for_corporation_group(
+            user, corporation_group
+        )
+        in_group = user.groups.filter(pk=group.id).exists()
+        try:
+            if qualifies and not in_group:
+                user.groups.add(group)
+                logger.info(
+                    "User %s qualifies for corporation group %s, adding",
+                    user.id,
+                    group.name,
+                )
+            elif not qualifies and in_group:
+                user.groups.remove(group)
+                logger.info(
+                    "User %s no longer qualifies for corporation group %s, "
+                    "removing",
+                    user.id,
+                    group.name,
+                )
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(
+                "Error updating user %s corporation group %s: %s",
+                user.id,
+                corporation_group,
+                e,
+            )
+
+
 @app.task
 def sync_tribe_chief_group():
     """Ensure Tribe - Chief auth group exists and matches active tribe chiefs."""

--- a/backend/groups/tests/test_tasks.py
+++ b/backend/groups/tests/test_tasks.py
@@ -26,6 +26,7 @@ from groups.helpers import (
 from groups.tasks import (
     update_affiliations,
     sync_eve_corporation_groups,
+    sync_user_corporation_groups,
 )
 from tribes.models import Tribe, TribeGroup
 
@@ -294,6 +295,43 @@ class GroupTasksTestCase(TestCase):
 
         self.assertEqual(
             [group_a.name],
+            list(self.user.groups.values_list("name", flat=True)),
+        )
+
+    @factory.django.mute_signals(
+        signals.pre_save, signals.post_save, signals.m2m_changed
+    )
+    def test_sync_user_corporation_groups_switches_corp(self):
+        old_corp = EveCorporation.objects.create(
+            corporation_id=98838034,
+            name="FOSFO",
+        )
+        new_corp = EveCorporation.objects.create(
+            corporation_id=98741376,
+            name="L3ARN",
+        )
+        old_group = Group.objects.create(name="Corp FOSFO")
+        new_group = Group.objects.create(name="Corp L3ARN")
+        EveCorporationGroup.objects.create(
+            corporation=old_corp, group=old_group
+        )
+        EveCorporationGroup.objects.create(
+            corporation=new_corp, group=new_group
+        )
+        char = EveCharacter.objects.create(
+            character_id=2115133763,
+            character_name="Paul Steinor",
+            corporation_id=old_corp.corporation_id,
+        )
+        set_primary_character(self.user, char)
+        self.user.groups.add(old_group)
+
+        char.corporation_id = new_corp.corporation_id
+        char.save(update_fields=["corporation_id"])
+        sync_user_corporation_groups(self.user)
+
+        self.assertEqual(
+            [new_group.name],
             list(self.user.groups.values_list("name", flat=True)),
         )
 

--- a/backend/tech/router.py
+++ b/backend/tech/router.py
@@ -20,7 +20,7 @@ from discord.models import DiscordUser
 from discord.tasks import sync_discord_user, sync_discord_nickname
 from discord.helpers import remove_all_roles_from_guild_member
 from groups.helpers.feature_access import can_use_feature
-from groups.tasks import update_affiliation
+from groups.tasks import sync_user_corporation_groups, update_affiliation
 from eveonline.client import esi_for, EsiClient
 from eveonline.models import (
     EveCharacter,
@@ -615,6 +615,9 @@ def force_refresh(request, username: str):
 
     update_affiliation(user.id)
     response.append(f"Updated affiliations for {username}")
+
+    sync_user_corporation_groups(user)
+    response.append(f"Synced corporation groups for {username}")
 
     sync_discord_user(user.id)
     response.append(f"Synced Discord roles for {username}")

--- a/backend/users/router.py
+++ b/backend/users/router.py
@@ -21,7 +21,7 @@ from esi.views import sso_redirect
 from audit.models import AuditEntry
 
 # from eveonline.models import EvePlayer
-from groups.tasks import update_affiliation
+from groups.tasks import sync_user_corporation_groups, update_affiliation
 from users.eve_sso import EVE_LOGIN_SCOPES
 from users.jwt_auth import decode_user_jwt, issue_discord_user_jwt
 from users.redirects import oauth_redirect
@@ -308,6 +308,7 @@ def sync_user(request, user_id: int):
         return 403, ErrorResponse(detail="You can only sync your own account.")
     try:
         update_affiliation(user_id)
+        sync_user_corporation_groups(request.user)
         sync_discord_user(user_id)
     except DiscordRoleAssignmentError as e:
         # Offboard inside affiliation's atomic block rolls back; redo outside.


### PR DESCRIPTION
## Summary
- After a corp join, ESI affiliation/public data often still reports the previous corporation. Affiliation sync was treating that as truth and Discord corp roles bounced back (FOSFO after a move to L3ARN).
- Affiliation and public-data updates now keep the current corp from corporation history when ESI still reports the previous one.
- Refresh Discord roles and tech force-refresh recompute Corp ticker groups for that user instead of waiting for the :19/:49 beat.

Help ticket: pulse-technology-major (Paul Steinor / major.).

## Test plan
- [ ] `pipenv run python manage.py test eveonline.tests.helpers.test_corporation_history.StaleEsiCorporationOverrideTests groups.tests.test_tasks.GroupTasksTestCase.test_sync_user_corporation_groups_switches_corp --settings=app.settings_test`
- [ ] After deploy, have a recently transferred character hit Refresh Discord roles on `/account/` and confirm the old Corp ticker role is removed and the new one stays
- [ ] Confirm a genuine new corp join (ESI reports a corp that is not the previous history row) still updates `corporation_id`


Made with [Cursor](https://cursor.com)