### PR TITLE
Record BUILD alliance BPC packs as a product call, not a site bug

### DIFF
--- a/.cursor/skills/help-ticket-investigation/SKILL.md
+++ b/.cursor/skills/help-ticket-investigation/SKILL.md
@@ -118,7 +118,8 @@ ticket = (
 If no row: still use Discord text/screenshots; note the gap.
 
 Follow-up **replies** show up in `read_messages`. Include them. The starter
-still needs `HelpTicket.body`.
+still needs `HelpTicket.body`. If that body is a stub (one-line category
+label), the real ask is in follow-up messages plus screenshots.
 
 ### Screenshots
 
@@ -173,6 +174,7 @@ Scan this table before inventing a new theory.
 | Wrong doctrine behind a hull chip | Capital guides (`CapitalGuideMetaBlocks`) must use `primary_fitting_for_ship` / `fit_match`, **not** `fittings[0]` (lowest id). “Passive” often means Buffer. Dump `EveFitting` for that `ship_id` on `production_readonly`. Local Astro often has an empty fittings API — use production HTML or unit tests with real names. |
 | Tribe Actions “wack” / Discord channel missing | **Withdraw** = pending or active (cancel/leave), not a broken menu. Auth/Discord roles (`Tribe Group - …`) sync on **active** only. Each group is a separate apply. Channel list ≠ site membership (overwrites can leak). Dump `TribeGroupMembership` + history before blaming Discord. |
 | Corp Discord role looked right, then the **previous** ticker came back | ESI `/characters/affiliation/` and public character data often still report the **old** corp after a join. Bulk `update_character_affilliations` can overwrite `corporation_id`; corporation **history** is usually current first. `Corp <TICKER>` groups sync on `sync_eve_corporation_groups` (different beat). Refresh-Discord-roles should recompute `sync_user_corporation_groups` then `sync_discord_user`. Dump primary `corporation_id`, latest two `corporation_history` rows, `user.groups` `Corp *`, and `DiscordRole.name` (display name may lag a Django group rename). |
+| Show BUILD alliance BPC / mineral packs on blueprints, ops/contracts, or in industry-order claim | Feature request, not a 403. `/industry/blueprints/` is hangar inventory search. `/market/ops/contracts/` is doctrine **fitting** stock (`EveMarketContract` + `fitting_id` not null). Alliance pack listings live on `EveCorporationContract` (`for_corporation`, `assignee_id` = BUILD alliance id); ESI `availability` is often `personal` with the alliance as assignee. They are not fitting-matched and the structure may not be an `EveLocation`, so they never appear on ops. Claim UI (`ButtonClaimOrder`) is quantity + “I have blueprints.” `IndustryContractAssociation` matches producer **delivery** contracts to orders, not supply packs. 48h claim cap is per-line `self_assign_maximum` (order config; stepping qty to 10/20/30 is a separate code change). Tag BearThatCares for product intent. |
 
 ### Discord reply
 
@@ -254,6 +256,7 @@ done until that PR exists.
 | Hull-chip / dialog-race / progress-% classes | Full ticket dumps |
 | Associates vs `MAIN_NOT_IN_FL33T` | Channel overwrite archaeology |
 | Tribe pending vs Discord role timing | Prod Discord REST from a local bot token |
+| BPC/mineral packs vs fitting contracts | Pack issuer names, in-game contract dumps |
 
 ## Additional resources
 

--- a/.cursor/skills/help-ticket-investigation/learnings.md
+++ b/.cursor/skills/help-ticket-investigation/learnings.md
@@ -41,6 +41,25 @@ do not duplicate it — one clarifying clause at most.
 
 ---
 
+## 2026-09-09 — BUILD alliance BPC packs not on site / claim
+
+**Category:** pulse.technology
+**Verdict:** needs-decision (plus clarify: not a bug)
+**Discord:** tagged decision owner
+**PR:** skill-only
+**Symptom vs cause:** Asked to surface BUILD alliance BPC/mineral packs in
+industry-order claim and/or on `/industry/blueprints/` or a
+`/market/ops/contracts/`-style industrial page. Those pages are hangar
+BPC search and doctrine fitting stock. Packs exist as corp ESI contracts
+assigned to BUILD; they are not `EveFitting`-matched and the structure
+was not an `EveLocation`, so they never hit `EveMarketContract`. Claim is
+quantity + blueprints checkbox. 48h cap is `self_assign_maximum`.
+**Durable rule:** Alliance industrial packs ≠ ops contracts. Dump
+`EveCorporationContract` (`assignee_id` = BUILD) before treating missing
+site listings as a sync bug. Product intent before building a new
+surface.
+**Skill update:** failure-class row; stub `HelpTicket.body` → read replies.
+
 ## Seed patterns (anonymized)
 
 These are the classes already encoded in SKILL.md. New tickets append


### PR DESCRIPTION
## Summary
- Help-ticket investigation: missing BUILD alliance BPC/mineral packs on `/industry/blueprints/`, `/market/ops/contracts/`, and industry-order claim is expected current behavior, not a sync bug.
- Skill update so the next agent dumps `EveCorporationContract` (BUILD assignee) instead of treating those pages as broken, and treats stub ticket bodies as “read the replies.”

## Test plan
- [ ] Skim the new Known failure class row: packs ≠ fitting contracts, claim is quantity + blueprints checkbox, cap is `self_assign_maximum`.
- [ ] Confirm learnings entry has no names, snowflakes, or ticket ids.


Made with [Cursor](https://cursor.com)