### PR TITLE
Fix Sentry crashes on fleet start, affiliations, and feed rollups

### DIFF
--- a/backend/feed/migrations/0015_feed_event_link_on_delete_cascade.py
+++ b/backend/feed/migrations/0015_feed_event_link_on_delete_cascade.py
@@ -1,0 +1,88 @@
+# Production MySQL FKs on feed event links are RESTRICT despite CASCADE on the
+# Django models, so AlterField is a no-op. Recreate them with ON DELETE CASCADE.
+
+from django.db import migrations
+
+_TABLES = (
+    "feed_feedeventkillmaillink",
+    "feed_feedeventfleetlink",
+)
+
+
+def _alter_feed_event_fks_to_cascade(apps, schema_editor):
+    if schema_editor.connection.vendor != "mysql":
+        return
+
+    with schema_editor.connection.cursor() as cursor:
+        for table in _TABLES:
+            cursor.execute(
+                """
+                SELECT CONSTRAINT_NAME
+                FROM information_schema.KEY_COLUMN_USAGE
+                WHERE TABLE_SCHEMA = DATABASE()
+                  AND TABLE_NAME = %s
+                  AND COLUMN_NAME = 'feed_event_id'
+                  AND REFERENCED_TABLE_NAME = 'feed_feedevent'
+                """,
+                [table],
+            )
+            names = [row[0] for row in cursor.fetchall()]
+            for name in names:
+                if not str(name).replace("_", "").isalnum():
+                    raise ValueError(f"unexpected FK name {name!r}")
+                cursor.execute(
+                    f"ALTER TABLE `{table}` DROP FOREIGN KEY `{name}`"
+                )
+            cursor.execute(f"""
+                ALTER TABLE `{table}`
+                ADD CONSTRAINT `{table}_feed_event_id_fk`
+                FOREIGN KEY (`feed_event_id`)
+                REFERENCES `feed_feedevent` (`id`)
+                ON DELETE CASCADE
+                """)
+
+
+def _alter_feed_event_fks_to_restrict(apps, schema_editor):
+    if schema_editor.connection.vendor != "mysql":
+        return
+
+    with schema_editor.connection.cursor() as cursor:
+        for table in _TABLES:
+            cursor.execute(
+                """
+                SELECT CONSTRAINT_NAME
+                FROM information_schema.KEY_COLUMN_USAGE
+                WHERE TABLE_SCHEMA = DATABASE()
+                  AND TABLE_NAME = %s
+                  AND COLUMN_NAME = 'feed_event_id'
+                  AND REFERENCED_TABLE_NAME = 'feed_feedevent'
+                """,
+                [table],
+            )
+            names = [row[0] for row in cursor.fetchall()]
+            for name in names:
+                if not str(name).replace("_", "").isalnum():
+                    raise ValueError(f"unexpected FK name {name!r}")
+                cursor.execute(
+                    f"ALTER TABLE `{table}` DROP FOREIGN KEY `{name}`"
+                )
+            cursor.execute(f"""
+                ALTER TABLE `{table}`
+                ADD CONSTRAINT `{table}_feed_event_id_fk`
+                FOREIGN KEY (`feed_event_id`)
+                REFERENCES `feed_feedevent` (`id`)
+                """)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("feed", "0014_remove_stale_celery_beat_tasks"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _alter_feed_event_fks_to_cascade,
+            _alter_feed_event_fks_to_restrict,
+        ),
+    ]

--- a/backend/feed/rollups/writer.py
+++ b/backend/feed/rollups/writer.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from feed.helpers.amarr_fleet_pings import maybe_notify_amarr_fleet
 from feed.models import (
     FeedEvent,
+    FeedEventFleetLink,
     FeedEventKillmailLink,
     FeedKillmail,
 )
@@ -91,9 +92,7 @@ def _upsert_event(result: RollupResult) -> FeedEvent:
         event = matches[0]
         prior_payloads.append(dict(event.payload or {}))
         if len(matches) > 1:
-            FeedEvent.objects.filter(
-                pk__in=[row.pk for row in matches[1:]]
-            ).delete()
+            _delete_feed_events([row.pk for row in matches[1:]])
         for field, value in defaults.items():
             setattr(event, field, value)
         event.save()
@@ -221,9 +220,15 @@ def _coalesce_fleet_active_event(
     _apply_upgrade_metadata(event, prior_payloads)
 
     if duplicates:
-        FeedEvent.objects.filter(
-            pk__in=[dup.pk for dup in duplicates]
-        ).delete()
+        _delete_feed_events([dup.pk for dup in duplicates])
+
+
+def _delete_feed_events(pks: list[int]) -> None:
+    if not pks:
+        return
+    FeedEventKillmailLink.objects.filter(feed_event_id__in=pks).delete()
+    FeedEventFleetLink.objects.filter(feed_event_id__in=pks).delete()
+    FeedEvent.objects.filter(pk__in=pks).delete()
 
 
 def _sync_killmail_links(event: FeedEvent, killmail_ids: list[int]) -> None:

--- a/backend/feed/tasks.py
+++ b/backend/feed/tasks.py
@@ -41,7 +41,9 @@ def detect_feed_clusters() -> int:
     return count
 
 
-@app.task(queue="celery")
+@app.task(
+    base=QueueOnce, once={"graceful": True, "timeout": 300}, queue="celery"
+)
 def run_feed_rollups(*, since_hours: int = 48) -> int:
     now = timezone.now()
     since = now - timedelta(hours=since_hours)

--- a/backend/feed/tests/test_writer.py
+++ b/backend/feed/tests/test_writer.py
@@ -119,6 +119,101 @@ class WriterTestCase(TestCase):
         self.assertEqual(event.payload.get("previous_tier"), "medium")
         self.assertIsNotNone(event.payload.get("upgraded_at"))
 
+    def test_write_coalesces_duplicate_fleet_active_events_with_killmail_links(
+        self,
+    ):
+        now = timezone.now()
+        related = "fleet_engagement:30002542:500002:2026-06-19T21:00"
+        keep = FeedEvent.objects.create(
+            kind=FeedEvent.Kind.FLEET_ACTIVE,
+            rollup_code="fleet_active",
+            cluster_key="fleet_active:30002542:500002:2026-06-19T21:00",
+            occurred_at=now,
+            title="Medium Minmatar gang active",
+            subheader="",
+            preview="",
+            body="",
+            accent=FeedEvent.Accent.MILITIA,
+            payload={
+                "system_id": 30002542,
+                "faction": "minmatar",
+                "related_cluster_key": related,
+                "engagement_tier": "medium",
+                "kills": 14,
+                "pilots": 12,
+            },
+            rollup_version=1,
+        )
+        dup = FeedEvent.objects.create(
+            kind=FeedEvent.Kind.FLEET_ACTIVE,
+            rollup_code="fleet_active",
+            cluster_key="fleet_active:30002542:500002:2026-06-19T21:05",
+            occurred_at=now,
+            title="Medium Minmatar gang active",
+            subheader="",
+            preview="",
+            body="",
+            accent=FeedEvent.Accent.MILITIA,
+            payload={
+                "system_id": 30002542,
+                "faction": "minmatar",
+                "related_cluster_key": related,
+                "engagement_tier": "medium",
+                "kills": 14,
+                "pilots": 12,
+            },
+            rollup_version=1,
+        )
+        km = FeedKillmail.objects.create(
+            killmail_id=137371130,
+            hash="def",
+            killmail_time=now,
+            solar_system_id=30002542,
+            raw_killmail={},
+        )
+        FeedEventKillmailLink.objects.create(feed_event=dup, feed_killmail=km)
+
+        write_rollup_results(
+            [
+                RollupResult(
+                    kind=FeedEvent.Kind.FLEET_ACTIVE,
+                    occurred_at=now,
+                    title="Major Minmatar fleet active",
+                    subheader="",
+                    preview="",
+                    body="",
+                    accent=FeedEvent.Accent.MILITIA,
+                    payload={
+                        "system_id": 30002542,
+                        "faction": "minmatar",
+                        "related_cluster_key": related,
+                        "engagement_tier": "major",
+                        "kills": 60,
+                        "pilots": 45,
+                    },
+                    rollup_code="fleet_active",
+                    rollup_version=1,
+                    cluster_key=keep.cluster_key,
+                    killmail_ids=[km.killmail_id],
+                )
+            ]
+        )
+
+        events = FeedEvent.objects.filter(rollup_code="fleet_active")
+        self.assertEqual(events.count(), 1)
+        survivor = events.get()
+        self.assertEqual(survivor.pk, keep.pk)
+        self.assertFalse(FeedEvent.objects.filter(pk=dup.pk).exists())
+        self.assertEqual(
+            FeedEventKillmailLink.objects.filter(feed_killmail=km).count(),
+            1,
+        )
+        self.assertTrue(
+            FeedEventKillmailLink.objects.filter(
+                feed_event=survivor, feed_killmail=km
+            ).exists()
+        )
+
     def test_write_keeps_distinct_fleet_active_events_apart(self):
         now = timezone.now()
         # A different system/faction engagement must not be coalesced.

--- a/backend/groups/tasks.py
+++ b/backend/groups/tasks.py
@@ -4,6 +4,7 @@ import logging
 from collections import defaultdict
 
 from django.contrib.auth.models import User
+from django.db import IntegrityError
 
 from app.celery import app
 from discord.client import DiscordClient
@@ -182,29 +183,7 @@ def _update_affiliation_for_user(user, affiliation_rules):
                 user,
                 affiliation,
             )
-            if UserAffiliation.objects.filter(
-                user=user, affiliation=affiliation
-            ).exists():
-                logger.info(
-                    "User %s already has affiliation %s",
-                    user,
-                    affiliation,
-                )
-                return
-
-            if UserAffiliation.objects.filter(user=user).exists():
-                logger.info(
-                    "User %s already has an affiliation, removing",
-                    user,
-                )
-                UserAffiliation.objects.filter(user=user).delete()
-
-            logger.info(
-                "Creating affiliation for user %s with %s",
-                user,
-                affiliation,
-            )
-            UserAffiliation.objects.create(user=user, affiliation=affiliation)
+            _ensure_user_affiliation(user, affiliation)
             return
 
         logger.info(
@@ -234,7 +213,39 @@ def _update_affiliation_for_user(user, affiliation_rules):
 @app.task
 def update_affiliation(user_id: int):
     user = User.objects.get(id=user_id)
-    _update_affiliation_for_user(user, _load_affiliation_rules())
+    try:
+        _update_affiliation_for_user(user, _load_affiliation_rules())
+    except Exception as e:  # pylint: disable=broad-except
+        log_affiliation_update_error(user, e)
+
+
+def _ensure_user_affiliation(user, affiliation):
+    UserAffiliation.objects.filter(user=user).exclude(
+        affiliation=affiliation
+    ).delete()
+    try:
+        _, created = UserAffiliation.objects.get_or_create(
+            user=user, affiliation=affiliation
+        )
+    except IntegrityError:
+        logger.info(
+            "User %s already has affiliation %s",
+            user,
+            affiliation,
+        )
+        return
+    if created:
+        logger.info(
+            "Creating affiliation for user %s with %s",
+            user,
+            affiliation,
+        )
+    else:
+        logger.info(
+            "User %s already has affiliation %s",
+            user,
+            affiliation,
+        )
 
 
 def log_affiliation_update_error(user: User, e):

--- a/backend/groups/tests/test_tasks.py
+++ b/backend/groups/tests/test_tasks.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
 import factory
 
 from django.contrib.auth.models import Group, User
+from django.db import IntegrityError
 from django.db.models import signals
 from django.test import Client
 from esi.models import Token
@@ -24,6 +27,8 @@ from groups.helpers import (
     sync_tribe_chief_group_membership,
 )
 from groups.tasks import (
+    _ensure_user_affiliation,
+    update_affiliation,
     update_affiliations,
     sync_eve_corporation_groups,
     sync_user_corporation_groups,
@@ -190,6 +195,88 @@ class UserAffiliationTestCase(TestCase):
         update_affiliations()
         user_affiliation = UserAffiliation.objects.get(user=user)
         assert user_affiliation.affiliation == affiliation_type_2
+
+    def test_set_user_affiliation_replaces_lower_priority(self):
+        user = User.objects.create(
+            username="test_set_user_affiliation_replaces_lower_priority"
+        )
+        group = Group.objects.create(
+            name="test_set_user_affiliation_replaces_lower_priority"
+        )
+        group_2 = Group.objects.create(
+            name="test_set_user_affiliation_replaces_lower_priority_2"
+        )
+        corporation = EveCorporation.objects.create(corporation_id=98726135)
+        character = EveCharacter.objects.create(character_id=124)
+        token = Token.objects.create(
+            character_id=124,
+            user=user,
+        )
+        character.token = token
+        character.save()
+        set_primary_character(user, character)
+        affiliation_type = AffiliationType.objects.create(
+            name="Example",
+            description="Example",
+            image_url="https://example.com/image.png",
+            group=group,
+            priority=1,
+        )
+        affiliation_type_2 = AffiliationType.objects.create(
+            name="Example",
+            description="Example",
+            image_url="https://example.com/image.png",
+            group=group_2,
+            priority=5,
+        )
+        affiliation_type.corporations.add(corporation)
+        character.corporation_id = corporation.corporation_id
+        character.save()
+        update_affiliations()
+        self.assertEqual(
+            UserAffiliation.objects.get(user=user).affiliation,
+            affiliation_type,
+        )
+
+        affiliation_type_2.corporations.add(corporation)
+        update_affiliations()
+        self.assertEqual(UserAffiliation.objects.filter(user=user).count(), 1)
+        self.assertEqual(
+            UserAffiliation.objects.get(user=user).affiliation,
+            affiliation_type_2,
+        )
+
+    def test_ensure_user_affiliation_swallows_integrity_error(self):
+        user = User.objects.create(
+            username="test_ensure_user_affiliation_integrity"
+        )
+        group = Group.objects.create(
+            name="test_ensure_user_affiliation_integrity"
+        )
+        affiliation = AffiliationType.objects.create(
+            name="Example",
+            description="Example",
+            image_url="https://example.com/image.png",
+            group=group,
+            priority=1,
+        )
+        UserAffiliation.objects.create(user=user, affiliation=affiliation)
+        with patch(
+            "groups.tasks.UserAffiliation.objects.get_or_create",
+            side_effect=IntegrityError(),
+        ):
+            _ensure_user_affiliation(user, affiliation)
+        self.assertEqual(UserAffiliation.objects.filter(user=user).count(), 1)
+
+    def test_update_affiliation_logs_errors_instead_of_raising(self):
+        with patch(
+            "groups.tasks._update_affiliation_for_user",
+            side_effect=RuntimeError("boom"),
+        ):
+            update_affiliation(self.user.id)
+        self.assertFalse(
+            UserAffiliation.objects.filter(user=self.user).exists()
+        )
 
 
 class GroupTasksTestCase(TestCase):

--- a/backend/tribes/migrations/0037_remove_stale_celery_beat_tasks.py
+++ b/backend/tribes/migrations/0037_remove_stale_celery_beat_tasks.py
@@ -1,0 +1,25 @@
+# Beat still enqueues the deleted tribe group activity processor.
+
+from django.db import migrations
+
+STALE_TASKS = ("tribes.tasks.process_tribe_group_activities",)
+
+
+def remove_stale_periodic_tasks(apps, schema_editor):
+    PeriodicTask = apps.get_model("django_celery_beat", "PeriodicTask")
+    PeriodicTask.objects.filter(task__in=STALE_TASKS).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("tribes", "0036_external_guild_tribe_group"),
+        ("django_celery_beat", "0019_alter_periodictasks_options"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            remove_stale_periodic_tasks,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/frontend/app/src/components/blocks/DeliveryContractInvoice.astro
+++ b/frontend/app/src/components/blocks/DeliveryContractInvoice.astro
@@ -49,7 +49,6 @@ import PilotBadge from './PilotBadge.astro';
             })
         },
     }`}
-    x-init="update_tooltip()"
 >
     <ComponentBlock width='narrow'>
         <Flexblock class="[ w-full ]" gap='var(--space-m)'>

--- a/frontend/app/src/components/blocks/FleetDetails.astro
+++ b/frontend/app/src/components/blocks/FleetDetails.astro
@@ -83,7 +83,7 @@ const eve_time_text = eve_time.toLocaleDateString(lang, JSON.parse(import.meta.e
         tracking_started: false,
     }`}
     @tracking_started="tracking_started = true"
-    @is_fleet_time="document.getElementById('preping-button').remove()"
+    @is_fleet_time="document.getElementById('preping-button')?.remove()"
 >
     <FleetHero
         fleet={{

--- a/frontend/app/src/components/blocks/StartFleet.astro
+++ b/frontend/app/src/components/blocks/StartFleet.astro
@@ -25,6 +25,11 @@ const FLET_START_PARTIAL_URL = translatePath('/partials/fleet_start_component/')
 <form
     method="post"
     action={FLET_START_PARTIAL_URL}
+    hx-post={FLET_START_PARTIAL_URL}
+    hx-trigger="submit"
+    hx-target="#fleet-start"
+    hx-swap="innerHTML"
+    hx-indicator=".loader"
     class="block w-full"
     x-on:submit="$nextTick(() => {
         submitted = true

--- a/frontend/app/src/components/partials/FooterScripts.astro
+++ b/frontend/app/src/components/partials/FooterScripts.astro
@@ -88,6 +88,11 @@ const DISABLED_CCPWGL = is_disabled_ccpwgl()
         if (typeof Alpine !== 'undefined') Alpine.initTree(next)
     }
 
+    window.minmatar_after_inner_html_swap = function () {
+        if (typeof htmx !== 'undefined') htmx.process(this)
+        if (typeof Alpine !== 'undefined') Alpine.initTree(this)
+    }
+
     if (!window.__footer_scripts_bound) {
         window.__footer_scripts_bound = true
 

--- a/frontend/app/src/pages/alliance/propaganda/my_posts.astro
+++ b/frontend/app/src/pages/alliance/propaganda/my_posts.astro
@@ -2,6 +2,8 @@
 import { i18n } from '@helpers/i18n'
 const { t, translatePath } = i18n(Astro.url)
 
+import { HTTP_403_Forbidden } from '@helpers/http_responses'
+
 import type { User } from '@dtypes/jwt'
 import * as jose from 'jose'
 

--- a/frontend/app/src/pages/alliance/propaganda/trash.astro
+++ b/frontend/app/src/pages/alliance/propaganda/trash.astro
@@ -2,6 +2,8 @@
 import { i18n } from '@helpers/i18n'
 const { t, translatePath } = i18n(Astro.url)
 
+import { HTTP_403_Forbidden } from '@helpers/http_responses'
+
 import type { User } from '@dtypes/jwt'
 import * as jose from 'jose'
 

--- a/frontend/app/src/pages/fleets/start.astro
+++ b/frontend/app/src/pages/fleets/start.astro
@@ -52,7 +52,12 @@ import ErrorRefetch from '@components/blocks/ErrorRefetch.astro';
 const page_title = t('fleets.start.page_title')
 ---
 
-<Viewport title={page_title}>
+<Viewport
+    title={page_title}
+    components={{
+        alert_dialog: true,
+    }}
+>
     <PageDefault
         cover={{
             image: '/images/fleets-cover.jpg',
@@ -75,18 +80,23 @@ const page_title = t('fleets.start.page_title')
                 <p class="[ excerpt ]">{t('fleets.start.choose_character')}</p>
             </TextBox>
 
-            {fetch_error ?
-                <ErrorRefetch
-                    args={{
-                        partial: FLET_START_PARTIAL_URL,
-                        error: fetch_error,
-                        delay: 0,
-                    }}
-                /> :
-                pilots.length > 0 ?
-                    <StartFleet pilots={pilots} /> :
-                    <p>{t('no_pilots_to_show')}</p>
-            }
+            <div
+                id="fleet-start"
+                hx-on--after-swap="window.minmatar_after_inner_html_swap.call(this)"
+            >
+                {fetch_error ?
+                    <ErrorRefetch
+                        args={{
+                            partial: FLET_START_PARTIAL_URL,
+                            error: fetch_error,
+                            delay: 0,
+                        }}
+                    /> :
+                    pilots.length > 0 ?
+                        <StartFleet pilots={pilots} /> :
+                        <p>{t('no_pilots_to_show')}</p>
+                }
+            </div>
         </Flexblock>
     </PageDefault>
 </Viewport>

--- a/frontend/app/src/pages/partials/fleet_start_component.astro
+++ b/frontend/app/src/pages/partials/fleet_start_component.astro
@@ -36,7 +36,17 @@ if (Astro.request.method === 'POST') {
         const fleet = await start_fleet_now(auth_token as string, fc_character_id)
         send_active_fleet_notification(auth_token as string, fleet.id)
 
-        return Astro.redirect(translatePath(`/fleets/upcoming/${fleet.id}`))
+        const fleet_path = translatePath(`/fleets/upcoming/${fleet.id}`)
+        if (Astro.request.headers.get('HX-Request') === 'true') {
+            return new Response('', {
+                status: 200,
+                headers: {
+                    'Content-Type': 'text/html',
+                    'HX-Redirect': fleet_path,
+                },
+            })
+        }
+        return Astro.redirect(fleet_path)
     } catch (error) {
         alert = {
             title: t('starting_fleet'),

--- a/frontend/app/testing/components/blocks/DeliveryContractInvoice.test.ts
+++ b/frontend/app/testing/components/blocks/DeliveryContractInvoice.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+
+test("DeliveryContractInvoice does not call update_tooltip on init", () => {
+  const src = readFileSync(
+    join(
+      dirname(fileURLToPath(import.meta.url)),
+      "../../../src/components/blocks/DeliveryContractInvoice.astro",
+    ),
+    "utf8",
+  );
+
+  expect(src).not.toContain('x-init="update_tooltip()"');
+});

--- a/frontend/app/testing/components/blocks/FleetDetails.test.ts
+++ b/frontend/app/testing/components/blocks/FleetDetails.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+
+test("FleetDetails null-guards preping-button removal", () => {
+  const src = readFileSync(
+    join(
+      dirname(fileURLToPath(import.meta.url)),
+      "../../../src/components/blocks/FleetDetails.astro",
+    ),
+    "utf8",
+  );
+
+  expect(src).toContain(
+    "document.getElementById('preping-button')?.remove()",
+  );
+});

--- a/frontend/app/testing/components/blocks/StartFleet.test.ts
+++ b/frontend/app/testing/components/blocks/StartFleet.test.ts
@@ -1,0 +1,33 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { expect, test } from "vitest";
+import StartFleet from "@components/blocks/StartFleet.astro";
+import type { SummaryCharacter } from "@dtypes/api.minmatar.org";
+
+const pilots: SummaryCharacter[] = [
+  {
+    character_id: 1,
+    character_name: "Test Pilot",
+    is_primary: true,
+    corp_id: 1000009,
+    corp_name: "Test Corp",
+    alliance_id: 1,
+    alliance_name: "Test Alliance",
+    esi_token: "",
+    token_status: "ACTIVE",
+    flags: [],
+    requested_groups: [],
+    actual_groups: [],
+  },
+];
+
+test("StartFleet posts the start partial in-page via htmx", async () => {
+  const container = await AstroContainer.create();
+  const result = await container.renderToString(StartFleet, {
+    props: { pilots },
+  });
+
+  expect(result).toContain('hx-post="/partials/fleet_start_component/"');
+  expect(result).toContain('hx-target="#fleet-start"');
+  expect(result).toContain('hx-swap="innerHTML"');
+  expect(result).toContain('name="fc_character_id"');
+});


### PR DESCRIPTION
## Summary
- Keep fleet start in-page (`hx-post` + `HX-Redirect` + Viewport `alert_dialog`) so a failed start no longer ClientRouter-navigates to a partial and crashes on `show_alert_dialog`.
- Fix SSR/Alpine holes: missing `HTTP_403_Forbidden` import on propaganda my-posts/trash, leftover invoice `update_tooltip()` init, and null `#preping-button` remove.
- Make overlapping Celery writers safe: affiliation `get_or_create` after deleting other rows, explicit feed-event child-link deletes plus MySQL `ON DELETE CASCADE`, `QueueOnce` on `run_feed_rollups`, and drop the stale `tribes.tasks.process_tribe_group_activities` beat row.

## Test plan
- [ ] `pipenv run python manage.py test groups feed --settings=app.settings_test` from `backend/`
- [ ] `npm run check` and `npm run test` from `frontend/app/`
- [ ] Logged-in FC without a fleet: `/fleets/start` submit stays on that URL and shows the alert (no console `show_alert_dialog` error)
- [ ] Successful fleet start full-page navigates to `/fleets/upcoming/{id}` (does not dump fleet detail into the start slot)
- [ ] Industry invoice page loads with no console `update_tooltip` error
- [ ] Logged-out / no `posts.add_evepost` user hitting `/alliance/propaganda/my_posts` and `/trash` gets 403, not 500
- [ ] Sit on an upcoming fleet page until T-30 with no preping button; no `#preping-button` TypeError
- [ ] After deploy, confirm beat no longer enqueues `tribes.tasks.process_tribe_group_activities`


Made with [Cursor](https://cursor.com)